### PR TITLE
Restart from a GSD file or a snapshot

### DIFF
--- a/polymer-flow/init.py
+++ b/polymer-flow/init.py
@@ -27,8 +27,9 @@ def get_parameters():
                               "PolyEthylene"
                               ]
     parameters["n_mols"] = [[30]]
-    parameters["chain_lengths"] = [[10]]
-    parameters["density"] = [1.1]
+    parameters["chain_lengths"] = [[20]]
+    parameters["density"] = [0.6]
+    parameters["remove_charge"] = [True]
     parameters["system_type"] = [
         "pack",
     ]
@@ -48,23 +49,24 @@ def get_parameters():
     parameters["r_cut"] = [2.5]
     parameters["auto_scale"] = [True]
 
-    parameters["shrink_kT"] = [8.0]
+    parameters["shrink_kT"] = [16.0]
     parameters["shrink_steps"] = [2e5]
     parameters["shrink_period"] = [1000]
 
-    parameters["NVT_start_kT"] = [8.0]
-    parameters["NVT_final_kT"] = [2.0]
+    parameters["NVT_start_kT"] = [16.0]
+    parameters["NVT_final_kT"] = [13.0]
     parameters["NVT_steps"] = [5e5]
 
+    parameters["final_NVT_steps"] = [5e7]
     parameters["NPT_kT"] = [2.0]
     parameters["NPT_steps"] = [5e5]
     parameters["NPT_p"] = [0.001]
 
-    parameters["gsd_write_freq"] = [10000]
-    parameters["log_write_freq"] = [1000]
+    parameters["gsd_write_freq"] = [100000]
+    parameters["log_write_freq"] = [100000]
 
     # epsilon adjusting factor
-    parameters["e_factor"] = [0.1, 0.5]
+    parameters["e_factor"] = [1]
 
     return list(parameters.keys()), list(product(*parameters.values()))
 
@@ -81,6 +83,7 @@ def main():
         parent_job = project.open_job(parent_statepoint)
         parent_job.init()
         parent_job.doc.setdefault("done", False)
+        parent_job.doc.setdefault("run_longer", 0)
 
     if custom_job_doc:
         for key in custom_job_doc:

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -96,7 +96,12 @@ class Simulation:
                 pppm_kwargs=self.pppm_kwargs 
         )
         if self.restart:
-            self.sim.create_state_from_gsd(self.restart)
+            # Restarting from a GSD File
+            if isinstance(self.restart, str):
+                self.sim.create_state_from_gsd(self.restart)
+            # Restarting from a gsd.hoomd.Snapshot
+            elif isinstance(self.restart, gsd.hoomd.Snapshot):
+                self.sim.create_state_from_snapshot(self.restart)
         else:
             self.sim.create_state_from_snapshot(self.init_snap)
         # Add a gsd and thermo props logger to sim operations

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -317,7 +317,7 @@ class Simulation:
         gsd_writer = hoomd.write.GSD(
                 filename=self.gsd_file_name,
                 trigger=hoomd.trigger.Periodic(int(self.gsd_write_freq)),
-                mode="wb",
+                mode="ab",
                 dynamic=["momentum"]
         )
 


### PR DESCRIPTION
The simulation class has a restart parameter that is useful for restarting simulations from a previous state point.

Previously, restarting only worked when restarting from a GSD file, but this PR makes it so that we can restart from a GSD file or a snapshot. 