### PR TITLE
Add forcefield.py with library of FF options; include option to use united atom system

### DIFF
--- a/src/examples.ipynb
+++ b/src/examples.ipynb
@@ -2,23 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "ebd37904",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning: importing 'simtk.openmm' is deprecated.  Import 'openmm' instead.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from molecules import PPS, PolyEthylene\n",
     "from system import System\n",
     "from simulation import Simulation\n",
-    "import foyer\n",
+    "from forcefields import GAFF, OPLS_AA, OPLS_AA_PPS\n",
+    "\n",
+    "\n",
     "import warnings\n",
     "warnings.filterwarnings(\"ignore\")"
    ]
@@ -37,67 +31,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "c7a21879",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/3dmoljs_load.v0": "<div id=\"3dmolviewer_167478883061999\"  style=\"position: relative; width: 640px; height: 480px\">\n        <p id=\"3dmolwarning_167478883061999\" style=\"background-color:#ffcccc;color:black\">You appear to be running in JupyterLab (or JavaScript failed to load for some other reason).  You need to install the 3dmol extension: <br>\n        <tt>jupyter labextension install jupyterlab_3dmol</tt></p>\n        </div>\n<script>\n\nvar loadScriptAsync = function(uri){\n  return new Promise((resolve, reject) => {\n    //this is to ignore the existence of requirejs amd\n    var savedexports, savedmodule;\n    if (typeof exports !== 'undefined') savedexports = exports;\n    else exports = {}\n    if (typeof module !== 'undefined') savedmodule = module;\n    else module = {}\n\n    var tag = document.createElement('script');\n    tag.src = uri;\n    tag.async = true;\n    tag.onload = () => {\n        exports = savedexports;\n        module = savedmodule;\n        resolve();\n    };\n  var firstScriptTag = document.getElementsByTagName('script')[0];\n  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);\n});\n};\n\nif(typeof $3Dmolpromise === 'undefined') {\n$3Dmolpromise = null;\n  $3Dmolpromise = loadScriptAsync('https://cdn.jsdelivr.net/npm/3dmol@latest/build/3Dmol-min.min.js');\n}\n\nvar viewer_167478883061999 = null;\nvar warn = document.getElementById(\"3dmolwarning_167478883061999\");\nif(warn) {\n    warn.parentNode.removeChild(warn);\n}\n$3Dmolpromise.then(function() {\nviewer_167478883061999 = $3Dmol.createViewer(document.getElementById(\"3dmolviewer_167478883061999\"),{backgroundColor:\"white\"});\nviewer_167478883061999.zoomTo();\n\tviewer_167478883061999.addModel(\"@<TRIPOS>MOLECULE\\nRES\\n57 61 1 0 1\\nSMALL\\nNO_CHARGES\\n@<TRIPOS>CRYSIN\\n   37.1577     5.8905     9.3059    90.0000    90.0000    90.0000  1  1\\n@<TRIPOS>ATOM\\n       1 C            1.7051     0.0421     0.0000 C             1 RES     \\n       2 C            1.0063     0.0692    -1.2113 C             1 RES     \\n       3 C           -0.3915     0.1236    -1.2122 C             1 RES     \\n       4 C           -1.0924     0.1505     0.0000 C             1 RES     \\n       5 S           -2.8809     0.2202     0.0000 S             1 RES     \\n       6 C           -0.3915     0.1236     1.2122 C             1 RES     \\n       7 C            1.0063     0.0693     1.2113 C             1 RES     \\n       8 H            1.5475     0.0482    -2.1484 H             1 RES     \\n       9 H           -0.9269     0.1442    -2.1529 H             1 RES     \\n      10 H           -0.9269     0.1442     2.1529 H             1 RES     \\n      11 H            1.5475     0.0482     2.1484 H             1 RES     \\n      12 C           -4.6409     0.2202    -0.0000 C             1 RES     \\n      13 C           -5.3396     0.2473    -1.2113 C             1 RES     \\n      14 C           -6.7374     0.3017    -1.2122 C             1 RES     \\n      15 C           -7.4383     0.3286    -0.0000 C             1 RES     \\n      16 S           -9.2268     0.3982    -0.0000 S             1 RES     \\n      17 C           -6.7374     0.3017     1.2122 C             1 RES     \\n      18 C           -5.3396     0.2473     1.2113 C             1 RES     \\n      19 H           -4.7985     0.2263    -2.1484 H             1 RES     \\n      20 H           -7.2728     0.3223    -2.1529 H             1 RES     \\n      21 H           -7.2728     0.3223     2.1529 H             1 RES     \\n      22 H           -4.7985     0.2263     2.1484 H             1 RES     \\n      23 C          -10.9868     0.3982    -0.0000 C             1 RES     \\n      24 C          -11.6856     0.4254    -1.2113 C             1 RES     \\n      25 C          -13.0834     0.4798    -1.2122 C             1 RES     \\n      26 C          -13.7843     0.5067    -0.0000 C             1 RES     \\n      27 S          -15.5728     0.5763    -0.0000 S             1 RES     \\n      28 C          -13.0834     0.4798     1.2122 C             1 RES     \\n      29 C          -11.6856     0.4254     1.2113 C             1 RES     \\n      30 H          -11.1444     0.4044    -2.1484 H             1 RES     \\n      31 H          -13.6187     0.5004    -2.1529 H             1 RES     \\n      32 H          -13.6187     0.5004     2.1529 H             1 RES     \\n      33 H          -11.1444     0.4044     2.1484 H             1 RES     \\n      34 C          -17.3328     0.5763    -0.0000 C             1 RES     \\n      35 C          -18.0315     0.6035    -1.2113 C             1 RES     \\n      36 C          -19.4293     0.6579    -1.2122 C             1 RES     \\n      37 C          -20.1302     0.6848    -0.0000 C             1 RES     \\n      38 S          -21.9187     0.7544    -0.0000 S             1 RES     \\n      39 C          -19.4293     0.6579     1.2122 C             1 RES     \\n      40 C          -18.0315     0.6035     1.2113 C             1 RES     \\n      41 H          -17.4904     0.5825    -2.1484 H             1 RES     \\n      42 H          -19.9647     0.6784    -2.1529 H             1 RES     \\n      43 H          -19.9647     0.6785     2.1529 H             1 RES     \\n      44 H          -17.4904     0.5825     2.1484 H             1 RES     \\n      45 C          -23.6787     0.7544    -0.0000 C             1 RES     \\n      46 C          -24.3775     0.7816    -1.2113 C             1 RES     \\n      47 C          -25.7753     0.8360    -1.2122 C             1 RES     \\n      48 C          -26.4762     0.8629    -0.0000 C             1 RES     \\n      49 S          -28.2647     0.9325    -0.0000 S             1 RES     \\n      50 C          -25.7753     0.8360     1.2122 C             1 RES     \\n      51 C          -24.3775     0.7816     1.2113 C             1 RES     \\n      52 H          -23.8363     0.7606    -2.1484 H             1 RES     \\n      53 H          -26.3106     0.8565    -2.1529 H             1 RES     \\n      54 H          -26.3106     0.8565     2.1529 H             1 RES     \\n      55 H          -23.8363     0.7606     2.1484 H             1 RES     \\n      56 H            2.7991     0.0421     0.0000 H             1 RES     \\n      57 H          -29.3587     0.9325    -0.0000 H             1 RES     \\n@<TRIPOS>BOND\\n       1        2        1 1\\n       2        7        1 1\\n       3       56        1 1\\n       4        3        2 1\\n       5        8        2 1\\n       6        4        3 1\\n       7        9        3 1\\n       8        5        4 1\\n       9        6        4 1\\n      10       12        5 1\\n      11        7        6 1\\n      12       10        6 1\\n      13       11        7 1\\n      14       13       12 1\\n      15       18       12 1\\n      16       14       13 1\\n      17       19       13 1\\n      18       15       14 1\\n      19       20       14 1\\n      20       16       15 1\\n      21       17       15 1\\n      22       23       16 1\\n      23       18       17 1\\n      24       21       17 1\\n      25       22       18 1\\n      26       24       23 1\\n      27       29       23 1\\n      28       25       24 1\\n      29       30       24 1\\n      30       26       25 1\\n      31       31       25 1\\n      32       27       26 1\\n      33       28       26 1\\n      34       34       27 1\\n      35       29       28 1\\n      36       32       28 1\\n      37       33       29 1\\n      38       35       34 1\\n      39       40       34 1\\n      40       36       35 1\\n      41       41       35 1\\n      42       37       36 1\\n      43       42       36 1\\n      44       38       37 1\\n      45       39       37 1\\n      46       45       38 1\\n      47       40       39 1\\n      48       43       39 1\\n      49       44       40 1\\n      50       46       45 1\\n      51       51       45 1\\n      52       47       46 1\\n      53       52       46 1\\n      54       48       47 1\\n      55       53       47 1\\n      56       49       48 1\\n      57       50       48 1\\n      58       57       49 1\\n      59       51       50 1\\n      60       54       50 1\\n      61       55       51 1\\n@<TRIPOS>SUBSTRUCTURE\\n       1 RES             1 RESIDUE    0 **** ROOT      0\\n\",\"mol2\");\n\tviewer_167478883061999.setStyle({\"stick\": {\"radius\": 0.2, \"color\": \"grey\"}, \"sphere\": {\"scale\": 0.3, \"colorscheme\": {}}});\n\tviewer_167478883061999.zoomTo();\nviewer_167478883061999.render();\n});\n</script>",
-      "text/html": [
-       "<div id=\"3dmolviewer_167478883061999\"  style=\"position: relative; width: 640px; height: 480px\">\n",
-       "        <p id=\"3dmolwarning_167478883061999\" style=\"background-color:#ffcccc;color:black\">You appear to be running in JupyterLab (or JavaScript failed to load for some other reason).  You need to install the 3dmol extension: <br>\n",
-       "        <tt>jupyter labextension install jupyterlab_3dmol</tt></p>\n",
-       "        </div>\n",
-       "<script>\n",
-       "\n",
-       "var loadScriptAsync = function(uri){\n",
-       "  return new Promise((resolve, reject) => {\n",
-       "    //this is to ignore the existence of requirejs amd\n",
-       "    var savedexports, savedmodule;\n",
-       "    if (typeof exports !== 'undefined') savedexports = exports;\n",
-       "    else exports = {}\n",
-       "    if (typeof module !== 'undefined') savedmodule = module;\n",
-       "    else module = {}\n",
-       "\n",
-       "    var tag = document.createElement('script');\n",
-       "    tag.src = uri;\n",
-       "    tag.async = true;\n",
-       "    tag.onload = () => {\n",
-       "        exports = savedexports;\n",
-       "        module = savedmodule;\n",
-       "        resolve();\n",
-       "    };\n",
-       "  var firstScriptTag = document.getElementsByTagName('script')[0];\n",
-       "  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);\n",
-       "});\n",
-       "};\n",
-       "\n",
-       "if(typeof $3Dmolpromise === 'undefined') {\n",
-       "$3Dmolpromise = null;\n",
-       "  $3Dmolpromise = loadScriptAsync('https://cdn.jsdelivr.net/npm/3dmol@latest/build/3Dmol-min.min.js');\n",
-       "}\n",
-       "\n",
-       "var viewer_167478883061999 = null;\n",
-       "var warn = document.getElementById(\"3dmolwarning_167478883061999\");\n",
-       "if(warn) {\n",
-       "    warn.parentNode.removeChild(warn);\n",
-       "}\n",
-       "$3Dmolpromise.then(function() {\n",
-       "viewer_167478883061999 = $3Dmol.createViewer(document.getElementById(\"3dmolviewer_167478883061999\"),{backgroundColor:\"white\"});\n",
-       "viewer_167478883061999.zoomTo();\n",
-       "\tviewer_167478883061999.addModel(\"@<TRIPOS>MOLECULE\\nRES\\n57 61 1 0 1\\nSMALL\\nNO_CHARGES\\n@<TRIPOS>CRYSIN\\n   37.1577     5.8905     9.3059    90.0000    90.0000    90.0000  1  1\\n@<TRIPOS>ATOM\\n       1 C            1.7051     0.0421     0.0000 C             1 RES     \\n       2 C            1.0063     0.0692    -1.2113 C             1 RES     \\n       3 C           -0.3915     0.1236    -1.2122 C             1 RES     \\n       4 C           -1.0924     0.1505     0.0000 C             1 RES     \\n       5 S           -2.8809     0.2202     0.0000 S             1 RES     \\n       6 C           -0.3915     0.1236     1.2122 C             1 RES     \\n       7 C            1.0063     0.0693     1.2113 C             1 RES     \\n       8 H            1.5475     0.0482    -2.1484 H             1 RES     \\n       9 H           -0.9269     0.1442    -2.1529 H             1 RES     \\n      10 H           -0.9269     0.1442     2.1529 H             1 RES     \\n      11 H            1.5475     0.0482     2.1484 H             1 RES     \\n      12 C           -4.6409     0.2202    -0.0000 C             1 RES     \\n      13 C           -5.3396     0.2473    -1.2113 C             1 RES     \\n      14 C           -6.7374     0.3017    -1.2122 C             1 RES     \\n      15 C           -7.4383     0.3286    -0.0000 C             1 RES     \\n      16 S           -9.2268     0.3982    -0.0000 S             1 RES     \\n      17 C           -6.7374     0.3017     1.2122 C             1 RES     \\n      18 C           -5.3396     0.2473     1.2113 C             1 RES     \\n      19 H           -4.7985     0.2263    -2.1484 H             1 RES     \\n      20 H           -7.2728     0.3223    -2.1529 H             1 RES     \\n      21 H           -7.2728     0.3223     2.1529 H             1 RES     \\n      22 H           -4.7985     0.2263     2.1484 H             1 RES     \\n      23 C          -10.9868     0.3982    -0.0000 C             1 RES     \\n      24 C          -11.6856     0.4254    -1.2113 C             1 RES     \\n      25 C          -13.0834     0.4798    -1.2122 C             1 RES     \\n      26 C          -13.7843     0.5067    -0.0000 C             1 RES     \\n      27 S          -15.5728     0.5763    -0.0000 S             1 RES     \\n      28 C          -13.0834     0.4798     1.2122 C             1 RES     \\n      29 C          -11.6856     0.4254     1.2113 C             1 RES     \\n      30 H          -11.1444     0.4044    -2.1484 H             1 RES     \\n      31 H          -13.6187     0.5004    -2.1529 H             1 RES     \\n      32 H          -13.6187     0.5004     2.1529 H             1 RES     \\n      33 H          -11.1444     0.4044     2.1484 H             1 RES     \\n      34 C          -17.3328     0.5763    -0.0000 C             1 RES     \\n      35 C          -18.0315     0.6035    -1.2113 C             1 RES     \\n      36 C          -19.4293     0.6579    -1.2122 C             1 RES     \\n      37 C          -20.1302     0.6848    -0.0000 C             1 RES     \\n      38 S          -21.9187     0.7544    -0.0000 S             1 RES     \\n      39 C          -19.4293     0.6579     1.2122 C             1 RES     \\n      40 C          -18.0315     0.6035     1.2113 C             1 RES     \\n      41 H          -17.4904     0.5825    -2.1484 H             1 RES     \\n      42 H          -19.9647     0.6784    -2.1529 H             1 RES     \\n      43 H          -19.9647     0.6785     2.1529 H             1 RES     \\n      44 H          -17.4904     0.5825     2.1484 H             1 RES     \\n      45 C          -23.6787     0.7544    -0.0000 C             1 RES     \\n      46 C          -24.3775     0.7816    -1.2113 C             1 RES     \\n      47 C          -25.7753     0.8360    -1.2122 C             1 RES     \\n      48 C          -26.4762     0.8629    -0.0000 C             1 RES     \\n      49 S          -28.2647     0.9325    -0.0000 S             1 RES     \\n      50 C          -25.7753     0.8360     1.2122 C             1 RES     \\n      51 C          -24.3775     0.7816     1.2113 C             1 RES     \\n      52 H          -23.8363     0.7606    -2.1484 H             1 RES     \\n      53 H          -26.3106     0.8565    -2.1529 H             1 RES     \\n      54 H          -26.3106     0.8565     2.1529 H             1 RES     \\n      55 H          -23.8363     0.7606     2.1484 H             1 RES     \\n      56 H            2.7991     0.0421     0.0000 H             1 RES     \\n      57 H          -29.3587     0.9325    -0.0000 H             1 RES     \\n@<TRIPOS>BOND\\n       1        2        1 1\\n       2        7        1 1\\n       3       56        1 1\\n       4        3        2 1\\n       5        8        2 1\\n       6        4        3 1\\n       7        9        3 1\\n       8        5        4 1\\n       9        6        4 1\\n      10       12        5 1\\n      11        7        6 1\\n      12       10        6 1\\n      13       11        7 1\\n      14       13       12 1\\n      15       18       12 1\\n      16       14       13 1\\n      17       19       13 1\\n      18       15       14 1\\n      19       20       14 1\\n      20       16       15 1\\n      21       17       15 1\\n      22       23       16 1\\n      23       18       17 1\\n      24       21       17 1\\n      25       22       18 1\\n      26       24       23 1\\n      27       29       23 1\\n      28       25       24 1\\n      29       30       24 1\\n      30       26       25 1\\n      31       31       25 1\\n      32       27       26 1\\n      33       28       26 1\\n      34       34       27 1\\n      35       29       28 1\\n      36       32       28 1\\n      37       33       29 1\\n      38       35       34 1\\n      39       40       34 1\\n      40       36       35 1\\n      41       41       35 1\\n      42       37       36 1\\n      43       42       36 1\\n      44       38       37 1\\n      45       39       37 1\\n      46       45       38 1\\n      47       40       39 1\\n      48       43       39 1\\n      49       44       40 1\\n      50       46       45 1\\n      51       51       45 1\\n      52       47       46 1\\n      53       52       46 1\\n      54       48       47 1\\n      55       53       47 1\\n      56       49       48 1\\n      57       50       48 1\\n      58       57       49 1\\n      59       51       50 1\\n      60       54       50 1\\n      61       55       51 1\\n@<TRIPOS>SUBSTRUCTURE\\n       1 RES             1 RESIDUE    0 **** ROOT      0\\n\",\"mol2\");\n",
-       "\tviewer_167478883061999.setStyle({\"stick\": {\"radius\": 0.2, \"color\": \"grey\"}, \"sphere\": {\"scale\": 0.3, \"colorscheme\": {}}});\n",
-       "\tviewer_167478883061999.zoomTo();\n",
-       "viewer_167478883061999.render();\n",
-       "});\n",
-       "</script>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Use the PPS template to create a 5mer PPS molecule\n",
     "pps_chain = PPS(length=5)\n",
@@ -106,77 +43,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "357df16a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/3dmoljs_load.v0": "<div id=\"3dmolviewer_1674788587747354\"  style=\"position: relative; width: 640px; height: 480px\">\n        <p id=\"3dmolwarning_1674788587747354\" style=\"background-color:#ffcccc;color:black\">You appear to be running in JupyterLab (or JavaScript failed to load for some other reason).  You need to install the 3dmol extension: <br>\n        <tt>jupyter labextension install jupyterlab_3dmol</tt></p>\n        </div>\n<script>\n\nvar loadScriptAsync = function(uri){\n  return new Promise((resolve, reject) => {\n    //this is to ignore the existence of requirejs amd\n    var savedexports, savedmodule;\n    if (typeof exports !== 'undefined') savedexports = exports;\n    else exports = {}\n    if (typeof module !== 'undefined') savedmodule = module;\n    else module = {}\n\n    var tag = document.createElement('script');\n    tag.src = uri;\n    tag.async = true;\n    tag.onload = () => {\n        exports = savedexports;\n        module = savedmodule;\n        resolve();\n    };\n  var firstScriptTag = document.getElementsByTagName('script')[0];\n  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);\n});\n};\n\nif(typeof $3Dmolpromise === 'undefined') {\n$3Dmolpromise = null;\n  $3Dmolpromise = loadScriptAsync('https://cdn.jsdelivr.net/npm/3dmol@latest/build/3Dmol-min.min.js');\n}\n\nvar viewer_1674788587747354 = null;\nvar warn = document.getElementById(\"3dmolwarning_1674788587747354\");\nif(warn) {\n    warn.parentNode.removeChild(warn);\n}\n$3Dmolpromise.then(function() {\nviewer_1674788587747354 = $3Dmol.createViewer(document.getElementById(\"3dmolviewer_1674788587747354\"),{backgroundColor:\"white\"});\nviewer_1674788587747354.zoomTo();\n\tviewer_1674788587747354.addModel(\"@<TRIPOS>MOLECULE\\nRES\\n50 49 1 0 1\\nSMALL\\nNO_CHARGES\\n@<TRIPOS>CRYSIN\\n   21.4470    14.6208    12.5476    90.0000    90.0000    90.0000  1  1\\n@<TRIPOS>ATOM\\n       1 C           -0.7591     0.0183     0.0212 C             1 RES     \\n       2 C            0.7591    -0.0183    -0.0212 C             1 RES     \\n       3 H           -1.0995     0.9536     0.5134 H             1 RES     \\n       4 H           -1.1654    -0.0180    -1.0116 H             1 RES     \\n       5 H            1.0995    -0.9536    -0.5134 H             1 RES     \\n       6 H            1.1654     0.0180     1.0116 H             1 RES     \\n       7 C            1.2575     1.1202    -0.7681 C             1 RES     \\n       8 C            2.7757     1.0836    -0.8104 C             1 RES     \\n       9 H            0.9171     2.0555    -0.2758 H             1 RES     \\n      10 H            0.8512     1.0840    -1.8008 H             1 RES     \\n      11 H            3.1161     0.1484    -1.3027 H             1 RES     \\n      12 H            3.1820     1.1199     0.2223 H             1 RES     \\n      13 C            3.2741     2.2222    -1.5573 C             1 RES     \\n      14 C            4.7923     2.1856    -1.5996 C             1 RES     \\n      15 H            2.9337     3.1575    -1.0650 H             1 RES     \\n      16 H            2.8678     2.1859    -2.5900 H             1 RES     \\n      17 H            5.1327     1.2503    -2.0919 H             1 RES     \\n      18 H            5.1986     2.2218    -0.5669 H             1 RES     \\n      19 C            5.2907     3.3241    -2.3465 C             1 RES     \\n      20 C            6.8089     3.2875    -2.3888 C             1 RES     \\n      21 H            4.9503     4.2594    -1.8542 H             1 RES     \\n      22 H            4.8844     3.2879    -3.3792 H             1 RES     \\n      23 H            7.1493     2.3522    -2.8811 H             1 RES     \\n      24 H            7.2152     3.3238    -1.3561 H             1 RES     \\n      25 C            7.3073     4.4261    -3.1357 C             1 RES     \\n      26 C            8.8255     4.3895    -3.1781 C             1 RES     \\n      27 H            6.9669     5.3613    -2.6434 H             1 RES     \\n      28 H            6.9010     4.3898    -4.1684 H             1 RES     \\n      29 H            9.1659     3.4542    -3.6703 H             1 RES     \\n      30 H            9.2318     4.4257    -2.1453 H             1 RES     \\n      31 C            9.3239     5.5280    -3.9249 C             1 RES     \\n      32 C           10.8421     5.4914    -3.9672 C             1 RES     \\n      33 H            8.9835     6.4633    -3.4326 H             1 RES     \\n      34 H            8.9176     5.4918    -4.9576 H             1 RES     \\n      35 H           11.1825     4.5561    -4.4595 H             1 RES     \\n      36 H           11.2484     5.5277    -2.9345 H             1 RES     \\n      37 C           11.3405     6.6300    -4.7141 C             1 RES     \\n      38 C           12.8587     6.5934    -4.7564 C             1 RES     \\n      39 H           11.0001     7.5652    -4.2218 H             1 RES     \\n      40 H           10.9342     6.5937    -5.7468 H             1 RES     \\n      41 H           13.1991     5.6581    -5.2487 H             1 RES     \\n      42 H           13.2650     6.6296    -3.7237 H             1 RES     \\n      43 C           13.3571     7.7319    -5.5033 C             1 RES     \\n      44 C           14.8753     7.6954    -5.5456 C             1 RES     \\n      45 H           13.0168     8.6672    -5.0110 H             1 RES     \\n      46 H           12.9508     7.6957    -6.5360 H             1 RES     \\n      47 H           15.2157     6.7601    -6.0379 H             1 RES     \\n      48 H           15.2816     7.7316    -4.5129 H             1 RES     \\n      49 H           -1.1351    -0.8407     0.5847 H             1 RES     \\n      50 H           15.2514     8.5544    -6.1091 H             1 RES     \\n@<TRIPOS>BOND\\n       1        2        1 1\\n       2        3        1 1\\n       3        4        1 1\\n       4       49        1 1\\n       5        5        2 1\\n       6        6        2 1\\n       7        7        2 1\\n       8        8        7 1\\n       9        9        7 1\\n      10       10        7 1\\n      11       11        8 1\\n      12       12        8 1\\n      13       13        8 1\\n      14       14       13 1\\n      15       15       13 1\\n      16       16       13 1\\n      17       17       14 1\\n      18       18       14 1\\n      19       19       14 1\\n      20       20       19 1\\n      21       21       19 1\\n      22       22       19 1\\n      23       23       20 1\\n      24       24       20 1\\n      25       25       20 1\\n      26       26       25 1\\n      27       27       25 1\\n      28       28       25 1\\n      29       29       26 1\\n      30       30       26 1\\n      31       31       26 1\\n      32       32       31 1\\n      33       33       31 1\\n      34       34       31 1\\n      35       35       32 1\\n      36       36       32 1\\n      37       37       32 1\\n      38       38       37 1\\n      39       39       37 1\\n      40       40       37 1\\n      41       41       38 1\\n      42       42       38 1\\n      43       43       38 1\\n      44       44       43 1\\n      45       45       43 1\\n      46       46       43 1\\n      47       47       44 1\\n      48       48       44 1\\n      49       50       44 1\\n@<TRIPOS>SUBSTRUCTURE\\n       1 RES             1 RESIDUE    0 **** ROOT      0\\n\",\"mol2\");\n\tviewer_1674788587747354.setStyle({\"stick\": {\"radius\": 0.2, \"color\": \"grey\"}, \"sphere\": {\"scale\": 0.3, \"colorscheme\": {}}});\n\tviewer_1674788587747354.zoomTo();\nviewer_1674788587747354.render();\n});\n</script>",
-      "text/html": [
-       "<div id=\"3dmolviewer_1674788587747354\"  style=\"position: relative; width: 640px; height: 480px\">\n",
-       "        <p id=\"3dmolwarning_1674788587747354\" style=\"background-color:#ffcccc;color:black\">You appear to be running in JupyterLab (or JavaScript failed to load for some other reason).  You need to install the 3dmol extension: <br>\n",
-       "        <tt>jupyter labextension install jupyterlab_3dmol</tt></p>\n",
-       "        </div>\n",
-       "<script>\n",
-       "\n",
-       "var loadScriptAsync = function(uri){\n",
-       "  return new Promise((resolve, reject) => {\n",
-       "    //this is to ignore the existence of requirejs amd\n",
-       "    var savedexports, savedmodule;\n",
-       "    if (typeof exports !== 'undefined') savedexports = exports;\n",
-       "    else exports = {}\n",
-       "    if (typeof module !== 'undefined') savedmodule = module;\n",
-       "    else module = {}\n",
-       "\n",
-       "    var tag = document.createElement('script');\n",
-       "    tag.src = uri;\n",
-       "    tag.async = true;\n",
-       "    tag.onload = () => {\n",
-       "        exports = savedexports;\n",
-       "        module = savedmodule;\n",
-       "        resolve();\n",
-       "    };\n",
-       "  var firstScriptTag = document.getElementsByTagName('script')[0];\n",
-       "  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);\n",
-       "});\n",
-       "};\n",
-       "\n",
-       "if(typeof $3Dmolpromise === 'undefined') {\n",
-       "$3Dmolpromise = null;\n",
-       "  $3Dmolpromise = loadScriptAsync('https://cdn.jsdelivr.net/npm/3dmol@latest/build/3Dmol-min.min.js');\n",
-       "}\n",
-       "\n",
-       "var viewer_1674788587747354 = null;\n",
-       "var warn = document.getElementById(\"3dmolwarning_1674788587747354\");\n",
-       "if(warn) {\n",
-       "    warn.parentNode.removeChild(warn);\n",
-       "}\n",
-       "$3Dmolpromise.then(function() {\n",
-       "viewer_1674788587747354 = $3Dmol.createViewer(document.getElementById(\"3dmolviewer_1674788587747354\"),{backgroundColor:\"white\"});\n",
-       "viewer_1674788587747354.zoomTo();\n",
-       "\tviewer_1674788587747354.addModel(\"@<TRIPOS>MOLECULE\\nRES\\n50 49 1 0 1\\nSMALL\\nNO_CHARGES\\n@<TRIPOS>CRYSIN\\n   21.4470    14.6208    12.5476    90.0000    90.0000    90.0000  1  1\\n@<TRIPOS>ATOM\\n       1 C           -0.7591     0.0183     0.0212 C             1 RES     \\n       2 C            0.7591    -0.0183    -0.0212 C             1 RES     \\n       3 H           -1.0995     0.9536     0.5134 H             1 RES     \\n       4 H           -1.1654    -0.0180    -1.0116 H             1 RES     \\n       5 H            1.0995    -0.9536    -0.5134 H             1 RES     \\n       6 H            1.1654     0.0180     1.0116 H             1 RES     \\n       7 C            1.2575     1.1202    -0.7681 C             1 RES     \\n       8 C            2.7757     1.0836    -0.8104 C             1 RES     \\n       9 H            0.9171     2.0555    -0.2758 H             1 RES     \\n      10 H            0.8512     1.0840    -1.8008 H             1 RES     \\n      11 H            3.1161     0.1484    -1.3027 H             1 RES     \\n      12 H            3.1820     1.1199     0.2223 H             1 RES     \\n      13 C            3.2741     2.2222    -1.5573 C             1 RES     \\n      14 C            4.7923     2.1856    -1.5996 C             1 RES     \\n      15 H            2.9337     3.1575    -1.0650 H             1 RES     \\n      16 H            2.8678     2.1859    -2.5900 H             1 RES     \\n      17 H            5.1327     1.2503    -2.0919 H             1 RES     \\n      18 H            5.1986     2.2218    -0.5669 H             1 RES     \\n      19 C            5.2907     3.3241    -2.3465 C             1 RES     \\n      20 C            6.8089     3.2875    -2.3888 C             1 RES     \\n      21 H            4.9503     4.2594    -1.8542 H             1 RES     \\n      22 H            4.8844     3.2879    -3.3792 H             1 RES     \\n      23 H            7.1493     2.3522    -2.8811 H             1 RES     \\n      24 H            7.2152     3.3238    -1.3561 H             1 RES     \\n      25 C            7.3073     4.4261    -3.1357 C             1 RES     \\n      26 C            8.8255     4.3895    -3.1781 C             1 RES     \\n      27 H            6.9669     5.3613    -2.6434 H             1 RES     \\n      28 H            6.9010     4.3898    -4.1684 H             1 RES     \\n      29 H            9.1659     3.4542    -3.6703 H             1 RES     \\n      30 H            9.2318     4.4257    -2.1453 H             1 RES     \\n      31 C            9.3239     5.5280    -3.9249 C             1 RES     \\n      32 C           10.8421     5.4914    -3.9672 C             1 RES     \\n      33 H            8.9835     6.4633    -3.4326 H             1 RES     \\n      34 H            8.9176     5.4918    -4.9576 H             1 RES     \\n      35 H           11.1825     4.5561    -4.4595 H             1 RES     \\n      36 H           11.2484     5.5277    -2.9345 H             1 RES     \\n      37 C           11.3405     6.6300    -4.7141 C             1 RES     \\n      38 C           12.8587     6.5934    -4.7564 C             1 RES     \\n      39 H           11.0001     7.5652    -4.2218 H             1 RES     \\n      40 H           10.9342     6.5937    -5.7468 H             1 RES     \\n      41 H           13.1991     5.6581    -5.2487 H             1 RES     \\n      42 H           13.2650     6.6296    -3.7237 H             1 RES     \\n      43 C           13.3571     7.7319    -5.5033 C             1 RES     \\n      44 C           14.8753     7.6954    -5.5456 C             1 RES     \\n      45 H           13.0168     8.6672    -5.0110 H             1 RES     \\n      46 H           12.9508     7.6957    -6.5360 H             1 RES     \\n      47 H           15.2157     6.7601    -6.0379 H             1 RES     \\n      48 H           15.2816     7.7316    -4.5129 H             1 RES     \\n      49 H           -1.1351    -0.8407     0.5847 H             1 RES     \\n      50 H           15.2514     8.5544    -6.1091 H             1 RES     \\n@<TRIPOS>BOND\\n       1        2        1 1\\n       2        3        1 1\\n       3        4        1 1\\n       4       49        1 1\\n       5        5        2 1\\n       6        6        2 1\\n       7        7        2 1\\n       8        8        7 1\\n       9        9        7 1\\n      10       10        7 1\\n      11       11        8 1\\n      12       12        8 1\\n      13       13        8 1\\n      14       14       13 1\\n      15       15       13 1\\n      16       16       13 1\\n      17       17       14 1\\n      18       18       14 1\\n      19       19       14 1\\n      20       20       19 1\\n      21       21       19 1\\n      22       22       19 1\\n      23       23       20 1\\n      24       24       20 1\\n      25       25       20 1\\n      26       26       25 1\\n      27       27       25 1\\n      28       28       25 1\\n      29       29       26 1\\n      30       30       26 1\\n      31       31       26 1\\n      32       32       31 1\\n      33       33       31 1\\n      34       34       31 1\\n      35       35       32 1\\n      36       36       32 1\\n      37       37       32 1\\n      38       38       37 1\\n      39       39       37 1\\n      40       40       37 1\\n      41       41       38 1\\n      42       42       38 1\\n      43       43       38 1\\n      44       44       43 1\\n      45       45       43 1\\n      46       46       43 1\\n      47       47       44 1\\n      48       48       44 1\\n      49       50       44 1\\n@<TRIPOS>SUBSTRUCTURE\\n       1 RES             1 RESIDUE    0 **** ROOT      0\\n\",\"mol2\");\n",
-       "\tviewer_1674788587747354.setStyle({\"stick\": {\"radius\": 0.2, \"color\": \"grey\"}, \"sphere\": {\"scale\": 0.3, \"colorscheme\": {}}});\n",
-       "\tviewer_1674788587747354.zoomTo();\n",
-       "viewer_1674788587747354.render();\n",
-       "});\n",
-       "</script>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<py3Dmol.view at 0x17f259dc0>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We can do the same with a Poly-ethylene chain\n",
     "pe_chain = PolyEthylene(length=8)\n",
@@ -194,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "cd931723",
    "metadata": {},
    "outputs": [],
@@ -204,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "0be4f4d8",
    "metadata": {},
    "outputs": [],
@@ -215,32 +85,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "5152e820",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Apply a foyer forcefield\n",
-    "opls = foyer.Forcefield(name=\"oplsaa\")\n",
-    "sys.apply_forcefield(forcefield=opls)"
+    "sys.apply_forcefield(forcefield=GAFF())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "f69c32a3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<Compound 620 particles, 610 bonds, System box: Box: Lx=76.696126, Ly=76.696126, Lz=76.696126, xy=0.000000, xz=0.000000, yz=0.000000, , id: 6452434976>\n",
-      "\n",
-      "<Structure 620 atoms; 1 residues; 610 bonds; PBC (orthogonal); parametrized>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We now have 2 different versions of our system. An mBuild Compound and a Parmed Structure\n",
     "print(sys.system)\n",
@@ -268,44 +127,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "61ff6332",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Processing LJ and QQ\n",
-      "Processing 1-4 interactions, adjusting neighborlist exclusions\n",
-      "Processing harmonic bonds\n",
-      "Processing harmonic angles\n",
-      "Processing RB torsions\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sim = Simulation(system=sys.typed_system)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "f4ee3145",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<hoomd.md.nlist.Cell object at 0x180f03fa0>\n",
-      "\n",
-      "[<hoomd.md.pair.pair.LJ object at 0x180ef5640>, <hoomd.md.pair.pair.Ewald object at 0x180ef5760>, <hoomd.md.long_range.pppm.Coulomb object at 0x180f1f1c0>, <hoomd.md.special_pair.LJ object at 0x180ef5550>, <hoomd.md.special_pair.Coulomb object at 0x180f1fa60>, <hoomd.md.bond.Harmonic object at 0x180f1fe20>, <hoomd.md.angle.Harmonic object at 0x180f244f0>, <hoomd.md.dihedral.OPLS object at 0x1044edc70>]\n",
-      "\n",
-      "0.0003\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(sim.nlist)\n",
     "print()\n",
@@ -316,18 +151,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "491908b0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "notice(2): charge.pppm: RMS error: 0.0982533\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The integrator and integrator method are not set up until a run function is called for the first time:\n",
     "sim.run_NVT(n_steps=0, kT=1, tau_kt=0.1)"
@@ -335,55 +162,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "a1a23a8c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<hoomd.md.integrate.Integrator object at 0x180f31970>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(sim.integrator)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "7c7230b2",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<hoomd.md.methods.methods.NVT object at 0x180f1f280>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(sim.method)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "45b2f544",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0003\n",
-      "0.0001\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Change simulation parameters like dt\n",
     "print(sim.integrator.dt)\n",
@@ -393,19 +195,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "d5c42ead",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<hoomd.md.methods.methods.NVT object at 0x180f1f280>\n",
-      "<hoomd.md.methods.methods.NPT object at 0x180f1f280>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Calling a run function again will update the method if needed\n",
     "print(sim.method)\n",
@@ -426,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "c1d6f260",
    "metadata": {},
    "outputs": [],
@@ -434,27 +227,15 @@
     "# Build up a polyethylene system of 10 10mers, apply an OPLS forcefield\n",
     "sys = System(molecule=PolyEthylene, n_mols=[10], chain_lengths=[10], density=1.3)\n",
     "sys.pack()\n",
-    "opls = foyer.Forcefield(name=\"oplsaa\")\n",
-    "sys.apply_forcefield(forcefield=opls)"
+    "sys.apply_forcefield(forcefield=GAFF())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "6b1c6f88",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([1.53392282, 1.53392282, 1.53392282])"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We can use the target_box attribute to help with the shrink run\n",
     "# Remember we'll have to convert from nm to angstroms\n",
@@ -464,43 +245,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "e31ca141",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Processing LJ and QQ\n",
-      "Processing 1-4 interactions, adjusting neighborlist exclusions\n",
-      "Processing harmonic bonds\n",
-      "Processing harmonic angles\n",
-      "Processing RB torsions\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sim = Simulation(system=sys.typed_system, auto_scale=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "e8da6af2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.5"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This is in angstroms:\n",
     "sim.ref_distance"
@@ -508,45 +266,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "98a50495",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "notice(2): charge.pppm: RMS error: 0.0982533\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "**ERROR**: Particle with unique tag 588 is no longer in the simulation box.\n",
-      "\n",
-      "Cartesian coordinates: \n",
-      "x: -0.901592 y: -40.148 z: 2.05055\n",
-      "Fractional coordinates: \n",
-      "f.x: 0.361934 f.y: -5.64811 f.z: 0.814013\n",
-      "Local box lo: (-3.26506, -3.26506, -3.26506)\n",
-      "          hi: (3.26506, 3.26506, 3.26506)\n"
-     ]
-    },
-    {
-     "ename": "RuntimeError",
-     "evalue": "Error computing cell list",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[29], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43msim\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun_shrink\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[43m    \u001b[49m\u001b[43mkT\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m5.0\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m      3\u001b[0m \u001b[43m    \u001b[49m\u001b[43mfinal_box_lengths\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msys\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtarget_box\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m10\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m/\u001b[39;49m\u001b[43m \u001b[49m\u001b[43msim\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mref_distance\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[43m    \u001b[49m\u001b[43mn_steps\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1e4\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m      5\u001b[0m \u001b[43m    \u001b[49m\u001b[43mtau_kt\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.01\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m      6\u001b[0m \u001b[43m    \u001b[49m\u001b[43mperiod\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m100\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m      7\u001b[0m \u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/cme/projects/advanced-sampling/advanced-sampling-polymers/src/simulation.py:227\u001b[0m, in \u001b[0;36mrun_shrink\u001b[0;34m(self, n_steps, period, kT, tau_kt, final_box_lengths, thermalize_particles)\u001b[0m\n\u001b[1;32m    225\u001b[0m self.set_integrator_method(\n\u001b[1;32m    226\u001b[0m         integrator_method=hoomd.md.methods.NVT,\n\u001b[0;32m--> 227\u001b[0m         method_kwargs={\"tau\": tau_kt, \"filter\": self.all, \"kT\": kT},\n\u001b[1;32m    228\u001b[0m )\n\u001b[1;32m    229\u001b[0m if thermalize_particles:\n",
-      "File \u001b[0;32m~/miniconda3/envs/polymers/lib/python3.9/site-packages/hoomd/simulation.py:462\u001b[0m, in \u001b[0;36mSimulation.run\u001b[0;34m(self, steps, write_at_start)\u001b[0m\n\u001b[1;32m    458\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m steps_int \u001b[38;5;241m<\u001b[39m \u001b[38;5;241m0\u001b[39m \u001b[38;5;129;01mor\u001b[39;00m steps_int \u001b[38;5;241m>\u001b[39m TIMESTEP_MAX \u001b[38;5;241m-\u001b[39m \u001b[38;5;241m1\u001b[39m:\n\u001b[1;32m    459\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msteps must be in the range [0, \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    460\u001b[0m                      \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mTIMESTEP_MAX\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m]\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 462\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_cpp_sys\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43msteps_int\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mwrite_at_start\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[0;31mRuntimeError\u001b[0m: Error computing cell list"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sim.run_shrink(\n",
     "    kT=5.0,\n",
@@ -582,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/src/examples.ipynb
+++ b/src/examples.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "ebd37904",
    "metadata": {},
    "outputs": [],
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sys = System(molecule=PolyEthylene, n_mols=[10], chain_lengths=[10], density=1.3)"
+    "sys = System(molecule=PolyEthylene, n_mols=[10], chain_lengths=[10], density=1.3, united_atom=True)"
    ]
   },
   {

--- a/src/forcefields.py
+++ b/src/forcefields.py
@@ -1,0 +1,20 @@
+import foyer
+
+class OPLS_AA(foyer.Forcefield):
+    def __init__(self, name="oplsaa"):
+        super(OPLSAA, self).__init__(name=name)
+        self.description = (
+                "Standard opls-aa forcefield found in the Foyer library"
+        )
+
+
+class OPLS_AA_PPS(foyer.Forcefield):
+    def __init__(self, forcefield_files="library/forcefields/pps_opls.xml"):
+        super(OPLS_AA_PPS, self).__init__(forcefield_files=forcefield_files)
+        self.description = (
+                "Based on OPLS_AA, trimmed down to include only PPS parameters."
+                "One missing parameter was added manually:"
+                "<Angle class1=CA class2=S class3=CA angle=1.805 k=627.6/>"
+                "The equilibrium angle was determined from experimental PPS papers."
+                "The spring constant was used for the equivalent angle in GAFF."
+		)

--- a/src/forcefields.py
+++ b/src/forcefields.py
@@ -1,8 +1,8 @@
 import foyer
-from pkg_resources import resource_filename
+from library import FF_DIR
 
 class GAFF(foyer.Forcefield):
-    def __init__(self, forcefield_files="library/forcefields/gaff.xml"):
+    def __init__(self, forcefield_files=f"{FF_DIR}/gaff.xml"):
         super(GAFF, self).__init__(forcefield_files=forcefield_files)
         self.description = (
                 "The General Amber Forcefield written in foyer XML format. "

--- a/src/forcefields.py
+++ b/src/forcefields.py
@@ -1,6 +1,7 @@
 import foyer
 from library import FF_DIR
 
+
 class GAFF(foyer.Forcefield):
     def __init__(self, forcefield_files=f"{FF_DIR}/gaff.xml"):
         super(GAFF, self).__init__(forcefield_files=forcefield_files)

--- a/src/forcefields.py
+++ b/src/forcefields.py
@@ -1,10 +1,20 @@
 import foyer
+from pkg_resources import resource_filename
+
+class GAFF(foyer.Forcefield):
+    def __init__(self, forcefield_files="library/forcefields/gaff.xml"):
+        super(GAFF, self).__init__(forcefield_files=forcefield_files)
+        self.description = (
+                "The General Amber Forcefield written in foyer XML format. "
+                "The XML file was obtained from the antefoyer package: "
+                "https://github.com/rsdefever/antefoyer/tree/master/antefoyer"
+        )
 
 class OPLS_AA(foyer.Forcefield):
     def __init__(self, name="oplsaa"):
-        super(OPLSAA, self).__init__(name=name)
+        super(OPLS_AA, self).__init__(name=name)
         self.description = (
-                "Standard opls-aa forcefield found in the Foyer library"
+                "opls-aa forcefield found in the Foyer package"
         )
 
 

--- a/src/library/__init__.py
+++ b/src/library/__init__.py
@@ -1,0 +1,1 @@
+from library.forcefields import FF_DIR

--- a/src/library/forcefields/__init__.py
+++ b/src/library/forcefields/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+
+FF_DIR = os.path.abspath(os.path.dirname(__file__))

--- a/src/library/forcefields/gaff.xml
+++ b/src/library/forcefields/gaff.xml
@@ -1,0 +1,7128 @@
+<ForceField>
+  <AtomTypes>
+    <Type name="c" class="c" element="C" mass="12.01" def="[C;X3][O&amp;X1,S&amp;X1]" overrides="c2,cc_r5,cc_r6,ce,cv,ca" desc="Sp2 C carbonyl group" doi="10.1002/jcc/20035"/>
+    <Type name="c1" class="c1" element="C" mass="12.01" def="[C;X2]" desc="Sp C" doi="10.1002/jcc/20035"/>
+    <Type name="c2" class="c2" element="C" mass="12.01" def="[C;X3]" desc="Sp2 C" doi="10.1002/jcc/20035"/>
+    <Type name="c3" class="c3" element="C" mass="12.01" def="[C;X4]" desc="Sp3 C" doi="10.1002/jcc/20035"/>
+    <Type name="ca" class="ca" element="C" mass="12.01" def="[C;X3;r6]1[C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2]1" overrides="ce,cc_r5,cc_r6,c2,cz" desc="Sp2 C in pure aromatic systems" doi="10.1002/jcc/20035"/>
+    <Type name="cp" class="cp" element="C" mass="12.01" def="[C;X3;r6;R1]([C;X3;r6]1[C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2]1)([C&amp;X3,N&amp;X2,P&amp;X2;r6;!r5][C&amp;X3,N&amp;X2,P&amp;X2;r6;!r5])[C&amp;X3,N&amp;X2,P&amp;X2;r6;!r5][C&amp;X3,N&amp;X2,P&amp;X2;r6;!r5]" overrides="ca,cc_r5,cc_r6" desc="Head Sp2 C that connect two rings in biphenyl sys." doi="10.1002/jcc/20035"/>
+    <Type name="cq" class="cq" element="C" mass="12.01" desc="Head Sp2 C that connect two rings in biphenyl sys. identical to cp" doi="10.1002/jcc/20035"/>
+    <Type name="cc" class="cc" element="C" mass="12.01" def="" desc="Sp2 carbons in non-pure aromatic systems" doi="10.1002/jcc/20035"/>
+    <Type name="cc_r5" class="cc" element="C" mass="12.01" def="[C;X3;r5]1[C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2]1" overrides="ce,c2,cz" desc="Sp2 carbons in non-pure aromatic systems" doi="10.1002/jcc/20035"/>
+    <Type name="cc_r6" class="cc" element="C" mass="12.01" def="[C;X3;r6]1[C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2]1" overrides="ce,c2,cz,cc_r5" desc="Sp2 carbons in non-pure aromatic systems" doi="10.1002/jcc/20035"/>
+    <Type name="cd" class="cd" element="C" mass="12.01" desc="Sp2 carbons in non-pure aromatic systems, identical to cc" doi="10.1002/jcc/20035"/>
+    <Type name="ce" class="ce" element="C" mass="12.01" def="[C;X3]([C&amp;X3,C&amp;X2,N&amp;X2])[C&amp;X3,C&amp;X2,N&amp;X2,%pe,%px,%py,%sx,%sy]" overrides="c2" desc="Inner Sp2 carbons in conjugated systems" doi="10.1002/jcc/20035"/>
+    <Type name="cf" class="cf" element="C" mass="12.01" desc="Inner Sp2 carbons in conjugated systems, identical to ce" doi="10.1002/jcc/20035"/>
+    <Type name="cg" class="cg" element="C" mass="12.01" def="[C;X2]([C&amp;X2,N&amp;X1])[C&amp;X3,C&amp;X2,N&amp;X2,N&amp;X1,%pe,%px,%py,%sx,%sy]" overrides="c1" desc="Inner Sp carbons in conjugated systems" doi="10.1002/jcc/20035"/>
+    <Type name="ch" class="ch" element="C" mass="12.01" desc="Inner Sp carbons in conjugated systems, identical to cg" doi="10.1002/jcc/20035"/>
+    <Type name="cx" class="cx" element="C" mass="12.01" def="[C;X4;r3]" overrides="c3" desc="Sp3 carbons in triangle systems" doi="10.1002/jcc/20035"/>
+    <Type name="cy" class="cy" element="C" mass="12.01" def="[C;X4;r4]" overrides="c3" desc="Sp3 carbons in square systems" doi="10.1002/jcc/20035"/>
+    <Type name="cu" class="cu" element="C" mass="12.01" def="[C;X3;r3]" overrides="c2" desc="Sp2 carbons in triangle systems" doi="10.1002/jcc/20035"/>
+    <Type name="cv" class="cv" element="C" mass="12.01" def="[C;X3;r4]" overrides="c2" desc="Sp2 carbons in square systems" doi="10.1002/jcc/20035"/>
+    <Type name="cz" class="cz" element="C" mass="12.01" def="[C;X3](N)(N)N" overrides="c2" desc="Sp2 carbon in guanidine group" doi="10.1002/jcc/20035"/>
+    <Type name="ha" class="ha" element="H" mass="1.008" def="H[C;!X4]" desc="H bonded to aromatic carbon" doi="10.1002/jcc/20035"/>
+    <Type name="hc" class="hc" element="H" mass="1.008" def="H[C;X4]" desc="H bonded to aliphatic carbon without d. group" doi="10.1002/jcc/20035"/>
+    <Type name="h1" class="h1" element="H" mass="1.008" def="H[C;X4]([N,O,F,Cl,Br,I,S])" overrides="hc" desc="H bonded to aliphatic carbon with 1 d. group" doi="10.1002/jcc/20035"/>
+    <Type name="h2" class="h2" element="H" mass="1.008" def="H[C;X4]([N,O,F,Cl,Br,I,S])[N,O,F,Cl,Br,I,S]" overrides="h1" desc="H bonded to aliphatic carbon with 2 d. group" doi="10.1002/jcc/20035"/>
+    <Type name="h3" class="h3" element="H" mass="1.008" def="H[C;X4]([N,O,F,Cl,Br,I,S])([N,O,F,Cl,Br,I,S])[N,O,F,Cl,Br,I,S]" overrides="h2" desc="H bonded to aliphatic carbon with 3 d. group" doi="10.1002/jcc/20035"/>
+    <Type name="h4" class="h4" element="H" mass="1.008" def="H[C;!X4]([N,O,F,Cl,Br,I,S])" overrides="ha" desc="H bonded to non-sp3 carbon with 1 d. group" doi="10.1002/jcc/20035"/>
+    <Type name="h5" class="h5" element="H" mass="1.008" def="H[C;!X4]([N,O,F,Cl,Br,I,S])([N,O,F,Cl,Br,I,S])" overrides="h4" desc="H bonded to non-sp3 carbon with 2 d. group" doi="10.1002/jcc/20035"/>
+    <Type name="hn" class="hn" element="H" mass="1.008" def="HN" desc="H bonded to nitrogen atoms" doi="10.1002/jcc/20035"/>
+    <Type name="ho" class="ho" element="H" mass="1.008" def="HO" desc="Hydroxyl group" doi="10.1002/jcc/20035"/>
+    <Type name="hp" class="hp" element="H" mass="1.008" def="HP" desc="H bonded to phosphate" doi="10.1002/jcc/20035"/>
+    <Type name="hs" class="hs" element="H" mass="1.008" def="HS" desc="Hydrogen bonded to sulphur" doi="10.1002/jcc/20035"/>
+    <Type name="hw" class="hw" element="H" mass="1.008" def="H[%ow]" overrides="ho" desc="Hydrogen in water" doi="10.1002/jcc/20035"/>
+    <Type name="hx" class="hx" element="H" mass="1.008" def="H[C][N;%n4]" overrides="h1,h2,h3" desc="H bonded to C next to positively charged group" doi="10.1002/jcc/20035"/>
+    <Type name="f" class="f" element="F" mass="19.00" def="F" desc="Fluorine" doi="10.1002/jcc/20035"/>
+    <Type name="cl" class="cl" element="Cl" mass="35.45" def="Cl" desc="Chlorine" doi="10.1002/jcc/20035"/>
+    <Type name="br" class="br" element="Br" mass="79.90" def="Br" desc="Bromine" doi="10.1002/jcc/20035"/>
+    <Type name="i" class="i" element="I" mass="126.9" def="I" desc="Iodine" doi="10.1002/jcc/20035"/>
+    <Type name="n" class="n" element="N" mass="14.01" def="[N;X3][C;X3][O&amp;X1,S&amp;X1]" overrides="n3,nh,na,na_r5,na_r6" desc="Sp2 nitrogen in amide groups" doi="10.1002/jcc/20035"/>
+    <Type name="n1" class="n1" element="N" mass="14.01" def="[N;X1]" desc="Sp N" doi="10.1002/jcc/20035"/>
+    <Type name="n2" class="n2" element="N" mass="14.01" def="[N;X2]" desc="aliphatic Sp2 N with two connected atoms" doi="10.1002/jcc/20035"/>
+    <Type name="n3" class="n3" element="N" mass="14.01" def="[N;X3]" desc="Sp3 N with three connected atoms" doi="10.1002/jcc/20035"/>
+    <Type name="n4" class="n4" element="N" mass="14.01" def="[N;X4]" desc="Sp3 N with four connected atoms" doi="10.1002/jcc/20035"/>
+    <Type name="na" class="na" element="N" mass="14.01" def="[N;X3]([C&amp;X3,N&amp;X2])[C&amp;X3,N&amp;X2]" overrides="n3" desc="Sp2 N with three connected atoms" doi="10.1002/jcc/20035"/>
+    <Type name="na_r5" class="na" element="N" mass="14.01" def="[N;X3;r5]1[C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2]1" overrides="na,n3,nh" desc="Sp2 N with three connected atoms" doi="10.1002/jcc/20035"/>
+    <Type name="na_r6" class="na" element="N" mass="14.01" def="[N;X3;r6]1[C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2]1" overrides="na,na_r5,n3,nh" desc="Sp2 N with three connected atoms" doi="10.1002/jcc/20035"/>
+    <Type name="nb" class="nb" element="N" mass="14.01" def="[N;X2;r6]1[C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2]1" overrides="nc_r6" desc="Sp2 N in pure aromatic systems" doi="10.1002/jcc/20035"/>
+    <Type name="nc" class="nc" element="N" mass="14.01" def="" desc="Sp2 N in non-pure aromatic systems" doi="10.1002/jcc/20035"/>
+    <Type name="nc_r5" class="nc" element="N" mass="14.01" def="[N;X2;r5]1[C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2]1" overrides="ne,n2" desc="Sp2 N in non-pure aromatic systems" doi="10.1002/jcc/20035"/>
+    <Type name="nc_r6" class="nc" element="N" mass="14.01" def="[N;X2;r6]1[C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2]1" overrides="ne,n2,nc_r5" desc="Sp2 N in non-pure aromatic systems" doi="10.1002/jcc/20035"/>
+    <Type name="nd" class="nd" element="N" mass="14.01" desc="Sp2 N in non-pure aromatic systems, identical to nc" doi="10.1002/jcc/20035"/>
+    <Type name="ne" class="ne" element="N" mass="14.01" def="[N;X2]([C&amp;X3,C&amp;X2,N&amp;X2,%pe,%px,%py,%sx,%sy])[C&amp;X2,C&amp;X3,N&amp;X2,%pe,%px,%py,%sx,%sy]" overrides="n2" desc="Inner Sp2 N in conjugated systems" doi="10.1002/jcc/20035"/>
+    <Type name="nf" class="nf" element="N" mass="14.01" desc="Inner Sp2 N in conjugated systems, identical to ne" doi="10.1002/jcc/20035"/>
+    <Type name="nh" class="nh" element="N" mass="14.01" def="[N;X3][C&amp;X3,N&amp;X2]" overrides="n3,na" desc="Amine N connected one or more aromatic rings" doi="10.1002/jcc/20035"/>
+    <Type name="no" class="no" element="N" mass="14.01" def="[N;X3]([O&amp;X1])[O&amp;X1]" overrides="na,na_r5,na_r6,n3,nh" desc="Nitro N" doi="10.1002/jcc/20035"/>
+    <Type name="ni" class="ni" element="N" mass="14.01" def="[N;X3;r3][C][O&amp;X1,S&amp;X1]" overrides="n,np,nm" desc="like n in RG3" doi="10.1002/jcc/20035"/>
+    <Type name="nj" class="nj" element="N" mass="14.01" def="[N;X3;r4][C][O&amp;X1,S&amp;X1]" overrides="n,nq,nn" desc="like n in RG4" doi="10.1002/jcc/20035"/>
+    <Type name="nk" class="nk" element="N" mass="14.01" def="[N;X4;r3]" overrides="n4" desc="like n4/nx/ny in RG3" doi="10.1002/jcc/20035"/>
+    <Type name="nl" class="nl" element="N" mass="14.01" def="[N;X4;r4]" overrides="n4" desc="like n4/nx/ny in RG4" doi="10.1002/jcc/20035"/>
+    <Type name="nm" class="nm" element="N" mass="14.01" def="[N;X3;r3][C&amp;X3,N&amp;X2]" overrides="nh" desc="like nh in RG3" doi="10.1002/jcc/20035"/>
+    <Type name="nn" class="nn" element="N" mass="14.01" def="[N;X3;r4][C&amp;X3,N&amp;X2]" overrides="nh" desc="like nh in RG4" doi="10.1002/jcc/20035"/>
+    <Type name="np" class="np" element="N" mass="14.01" def="[N;X3;r3]" overrides="n3" desc="like n3 in RG3" doi="10.1002/jcc/20035"/>
+    <Type name="nq" class="nq" element="N" mass="14.01" def="[N;X3;r4]" overrides="n3" desc="like n3 in RG4" doi="10.1002/jcc/20035"/>
+    <Type name="o" class="o" element="O" mass="16.00" def="[O;X1]" desc="Oxygen with one connected atom" doi="10.1002/jcc/20035"/>
+    <Type name="oh" class="oh" element="O" mass="16.00" def="[O;X2]H" desc="Oxygen in hydroxyl group" doi="10.1002/jcc/20035"/>
+    <Type name="op" class="op" element="O" mass="16.00" desc="" doi=""/>
+    <Type name="oq" class="oq" element="O" mass="16.00" desc="" doi=""/>
+    <Type name="os" class="os" element="O" mass="16.00" def="[O;X2]([!H])[!H]" desc="Ether and ester oxygen" doi="10.1002/jcc/20035"/>
+    <Type name="ow" class="ow" element="O" mass="16.00" def="[O;X2]([H;%hw])[H;%hw]" overrides="os" desc="Oxygen in water" doi="10.1002/jcc/20035"/>
+    <Type name="p2" class="p2" element="P" mass="30.97" def="[P;X2]" desc="Phosphate with two connected atoms" doi="10.1002/jcc/20035"/>
+    <Type name="p3" class="p3" element="P" mass="30.97" def="[P;X3]" desc="Phosphate with three connected atoms, such as PH3" doi="10.1002/jcc/20035"/>
+    <Type name="p4" class="p4" element="P" mass="30.97" def="[P;X3][O&amp;X1,S&amp;X1,%n2]" overrides="p3" desc="Phosphate with three connected atoms, such as O=P(CH3)2" doi="10.1002/jcc/20035"/>
+    <Type name="p5" class="p5" element="P" mass="30.97" def="[P;X4]" desc="Phosphate with four connected atoms, such as O=P(OH)3" doi="10.1002/jcc/20035"/>
+    <Type name="pb" class="pb" element="P" mass="30.97" def="[P;X2;r6]1[C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2][C&amp;X3,N&amp;X2,P&amp;X2]1" overrides="pe,pc_r6" desc="Sp2 P in pure aromatic systems" doi="10.1002/jcc/20035"/>
+    <Type name="pc" class="pc" element="P" mass="30.97" def="" desc="Sp2 P in non-pure aromatic system" doi="10.1002/jcc/20035"/>
+    <Type name="pc_r5" class="pc" element="P" mass="30.97" def="[P;X2;r5]1[C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2]1" overrides="pe" desc="Sp2 P in non-pure aromatic system" doi="10.1002/jcc/20035"/>
+    <Type name="pc_r6" class="pc" element="P" mass="30.97" def="[P;X2;r6]1[C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2][C&amp;X3,N&amp;X3,N&amp;X2,O&amp;X2,S&amp;X2,P&amp;X2]1" overrides="pe,pc_r5" desc="Sp2 P in non-pure aromatic system" doi="10.1002/jcc/20035"/>
+    <Type name="pd" class="pd" element="P" mass="30.97" desc="Sp2 P in non-pure aromatic systems, identical to pc" doi="10.1002/jcc/20035"/>
+    <Type name="pe" class="pe" element="P" mass="30.97" def="[P;X2]([C&amp;X3,C&amp;X2,N&amp;X2])[C&amp;X3,C&amp;X2,N&amp;X2,%pe,%px,%py,%sx,%sy]" overrides="p2" desc="Inner Sp2 P in conjugated systems" doi="10.1002/jcc/20035"/>
+    <Type name="pf" class="pf" element="P" mass="30.97" desc="Inner Sp2 P in conjugated systems, identical to pe" doi="10.1002/jcc/20035"/>
+    <Type name="px" class="px" element="P" mass="30.97" def="[P;X3]([O;X1])[C&amp;X3,N&amp;X2]" overrides="p4" desc="Special p4 in conjugated systems (phosphite)" doi="10.1002/jcc/20035"/>
+    <Type name="py" class="py" element="P" mass="30.97" def="[P;X4]([O;X1])([O;X2])([O;X2])[C&amp;X3,N&amp;X2,P&amp;X4]" overrides="p5" desc="Special p5 in conjugated systems (phosphate)" doi="10.1002/jcc/20035"/>
+    <Type name="s" class="s" element="S" mass="32.06" def="[S;X1]" desc="S with one connected atom" doi="10.1002/jcc/20035"/>
+    <Type name="s2" class="s2" element="S" mass="32.06" def="[S;X2][!H]" desc="S with two connected atom, involved at least one double bond" doi="10.1002/jcc/20035"/>
+    <Type name="s4" class="s4" element="S" mass="32.06" def="[S;X3]" desc="S with three connected atoms" doi="10.1002/jcc/20035"/>
+    <Type name="s6" class="s6" element="S" mass="32.06" def="[S;X4]" desc="S with four connected atoms" doi="10.1002/jcc/20035"/>
+    <Type name="sh" class="sh" element="S" mass="32.06" def="[S]H" overrides="s2" desc="Sp3 S connected with hydrogen" doi="10.1002/jcc/20035"/>
+    <Type name="sp" class="sp" element="S" mass="32.06" desc="" doi=""/>
+    <Type name="sq" class="sq" element="S" mass="32.06" desc="" doi=""/>
+    <Type name="ss" class="ss" element="S" mass="32.06" def="[S;X2]([C,S,O])[C,S,O]" overrides="s2" desc="Sp3 S in thio-ester and thio-ether" doi="10.1002/jcc/20035"/>
+    <Type name="sx" class="sx" element="S" mass="32.06" def="[S;X3]([O;X1])[C&amp;X3,N&amp;X2]" overrides="s4" desc="Special s4 in conjugated systems (sulfoxide)" doi="10.1002/jcc/20035"/>
+    <Type name="sy" class="sy" element="S" mass="32.06" def="[S;X4]([O;X1])([O;X1])[C&amp;X3,N&amp;X2]" overrides="s6" desc="Special s6 in conjugated systems (sulfone)" doi="10.1002/jcc/20035"/>
+  </AtomTypes>
+  <NonbondedForce coulomb14scale="0.833333333" lj14scale="0.5">
+    <Atom type="c" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="c1" charge="0.0" sigma="0.33996695084235345" epsilon="0.87864"/>
+    <Atom type="c2" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="c3" charge="0.0" sigma="0.33996695084235345" epsilon="0.4577296"/>
+    <Atom type="ca" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cp" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cq" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cc" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cc_r5" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cc_r6" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cd" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="ce" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cf" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cg" charge="0.0" sigma="0.33996695084235345" epsilon="0.87864"/>
+    <Atom type="ch" charge="0.0" sigma="0.33996695084235345" epsilon="0.87864"/>
+    <Atom type="cx" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cy" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cu" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cv" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="cz" charge="0.0" sigma="0.33996695084235345" epsilon="0.359824"/>
+    <Atom type="ha" charge="0.0" sigma="0.259964245953351" epsilon="0.06276"/>
+    <Atom type="hc" charge="0.0" sigma="0.26495327877493696" epsilon="0.06568879999999999"/>
+    <Atom type="h1" charge="0.0" sigma="0.24713530441213014" epsilon="0.06568879999999999"/>
+    <Atom type="h2" charge="0.0" sigma="0.22931733004932334" epsilon="0.06568879999999999"/>
+    <Atom type="h3" charge="0.0" sigma="0.21149935568651657" epsilon="0.06568879999999999"/>
+    <Atom type="h4" charge="0.0" sigma="0.2510552587719476" epsilon="0.06276"/>
+    <Atom type="h5" charge="0.0" sigma="0.2421462715905442" epsilon="0.06276"/>
+    <Atom type="hn" charge="0.0" sigma="0.10690784617684071" epsilon="0.06568879999999999"/>
+    <Atom type="ho" charge="0.0" sigma="0.0" epsilon="0.0"/>
+    <Atom type="hp" charge="0.0" sigma="0.10690784617684071" epsilon="0.06568879999999999"/>
+    <Atom type="hs" charge="0.0" sigma="0.10690784617684071" epsilon="0.06568879999999999"/>
+    <Atom type="hw" charge="0.0" sigma="0.0" epsilon="0.0"/>
+    <Atom type="hx" charge="0.0" sigma="0.19599771799087468" epsilon="0.06568879999999999"/>
+    <Atom type="f" charge="0.0" sigma="0.3118145513491188" epsilon="0.255224"/>
+    <Atom type="cl" charge="0.0" sigma="0.3470941405874762" epsilon="1.1087600000000002"/>
+    <Atom type="br" charge="0.0" sigma="0.3599230821286971" epsilon="1.75728"/>
+    <Atom type="i" charge="0.0" sigma="0.38308644880034587" epsilon="2.092"/>
+    <Atom type="n" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="n1" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="n2" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="n3" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="n4" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="na" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="na_r5" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="na_r6" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nb" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nc" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nc_r5" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nc_r6" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nd" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="ne" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nf" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nh" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="no" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="ni" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nj" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nk" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nl" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nm" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nn" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="np" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="nq" charge="0.0" sigma="0.32499985237759577" epsilon="0.7112800000000001"/>
+    <Atom type="o" charge="0.0" sigma="0.2959921901149464" epsilon="0.87864"/>
+    <Atom type="oh" charge="0.0" sigma="0.3066473387839048" epsilon="0.8803136"/>
+    <Atom type="op" charge="0.0" sigma="0.3000012343465779" epsilon="0.7112800000000001"/>
+    <Atom type="oq" charge="0.0" sigma="0.3000012343465779" epsilon="0.7112800000000001"/>
+    <Atom type="os" charge="0.0" sigma="0.3000012343465779" epsilon="0.7112800000000001"/>
+    <Atom type="ow" charge="0.0" sigma="0.3150752406575124" epsilon="0.635968"/>
+    <Atom type="p2" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="p3" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="p4" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="p5" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="pb" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="pc" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="pc_r5" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="pc_r6" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="pd" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="pe" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="pf" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="px" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="py" charge="0.0" sigma="0.37417746161894255" epsilon="0.8368000000000001"/>
+    <Atom type="s" charge="0.0" sigma="0.35635948725613575" epsilon="1.046"/>
+    <Atom type="s2" charge="0.0" sigma="0.35635948725613575" epsilon="1.046"/>
+    <Atom type="s4" charge="0.0" sigma="0.35635948725613575" epsilon="1.046"/>
+    <Atom type="s6" charge="0.0" sigma="0.35635948725613575" epsilon="1.046"/>
+    <Atom type="sh" charge="0.0" sigma="0.35635948725613575" epsilon="1.046"/>
+    <Atom type="sp" charge="0.0" sigma="0.35635948725613575" epsilon="1.046"/>
+    <Atom type="sq" charge="0.0" sigma="0.35635948725613575" epsilon="1.046"/>
+    <Atom type="ss" charge="0.0" sigma="0.35635948725613575" epsilon="1.046"/>
+    <Atom type="sx" charge="0.0" sigma="0.35635948725613575" epsilon="1.046"/>
+    <Atom type="sy" charge="0.0" sigma="0.35635948725613575" epsilon="1.046"/>
+  </NonbondedForce>
+  <HarmonicBondForce>
+    <Bond class1="ow" class2="hw" length="0.09572000000000001" k="462750.3999999999"/>
+    <Bond class1="hw" class2="hw" length="0.15136000000000002" k="462750.3999999999"/>
+    <Bond class1="br" class2="br" length="0.2542" k="103093.75999999998"/>
+    <Bond class1="br" class2="c1" length="0.1787" k="295139.3599999999"/>
+    <Bond class1="br" class2="c2" length="0.18928" k="227860.63999999996"/>
+    <Bond class1="br" class2="c" length="0.1946" k="201083.03999999998"/>
+    <Bond class1="br" class2="c3" length="0.19779000000000002" k="186941.11999999997"/>
+    <Bond class1="br" class2="ca" length="0.19079000000000002" k="219827.35999999996"/>
+    <Bond class1="br" class2="cc" length="0.1885" k="232128.31999999995"/>
+    <Bond class1="br" class2="cx" length="0.1937" k="205350.71999999997"/>
+    <Bond class1="br" class2="i" length="0.2671" k="0.0"/>
+    <Bond class1="br" class2="n1" length="0.18600000000000003" k="276478.7199999999"/>
+    <Bond class1="br" class2="n2" length="0.20379999999999998" k="183259.19999999998"/>
+    <Bond class1="br" class2="n" length="0.18730000000000002" k="267943.3599999999"/>
+    <Bond class1="br" class2="n3" length="0.1952" k="222505.11999999994"/>
+    <Bond class1="br" class2="n4" length="0.1926" k="236312.31999999995"/>
+    <Bond class1="br" class2="na" length="0.2002" k="198572.63999999998"/>
+    <Bond class1="br" class2="nh" length="0.19440000000000002" k="226689.11999999997"/>
+    <Bond class1="br" class2="no" length="0.2101" k="159828.79999999996"/>
+    <Bond class1="br" class2="o" length="0.18000000000000002" k="233383.51999999996"/>
+    <Bond class1="br" class2="oh" length="0.18660000000000002" k="198488.95999999996"/>
+    <Bond class1="br" class2="os" length="0.1887" k="188782.07999999996"/>
+    <Bond class1="br" class2="p2" length="0.221" k="145854.23999999996"/>
+    <Bond class1="br" class2="p3" length="0.2231" k="139745.59999999998"/>
+    <Bond class1="br" class2="p4" length="0.2171" k="157987.83999999997"/>
+    <Bond class1="br" class2="p5" length="0.21960000000000002" k="150038.24"/>
+    <Bond class1="br" class2="s" length="0.22200000000000003" k="142758.07999999996"/>
+    <Bond class1="br" class2="s4" length="0.23410000000000003" k="112382.24"/>
+    <Bond class1="br" class2="s6" length="0.2214" k="144515.35999999996"/>
+    <Bond class1="br" class2="sh" length="0.2209" k="145937.91999999998"/>
+    <Bond class1="br" class2="ss" length="0.2203" k="147778.87999999998"/>
+    <Bond class1="c1" class2="c1" length="0.11982999999999999" k="772952.1599999999"/>
+    <Bond class1="c1" class2="c2" length="0.1307" k="522999.9999999999"/>
+    <Bond class1="c1" class2="c3" length="0.14671" k="310954.88"/>
+    <Bond class1="c1" class2="ca" length="0.144" k="338150.88"/>
+    <Bond class1="c1" class2="ce" length="0.13153" k="508272.31999999995"/>
+    <Bond class1="c1" class2="cg" length="0.12159" k="723915.6799999999"/>
+    <Bond class1="c1" class2="ch" length="0.12194" k="714627.1999999998"/>
+    <Bond class1="c1" class2="cl" length="0.16310000000000002" k="351204.9599999999"/>
+    <Bond class1="c1" class2="cx" length="0.14450000000000002" k="333046.3999999999"/>
+    <Bond class1="c1" class2="f" length="0.127" k="392793.9199999999"/>
+    <Bond class1="c1" class2="ha" length="0.10668" k="313548.9599999999"/>
+    <Bond class1="c1" class2="hc" length="0.10600000000000001" k="322670.08"/>
+    <Bond class1="c1" class2="i" length="0.19890000000000002" k="266771.83999999997"/>
+    <Bond class1="c1" class2="n1" length="0.11535000000000001" k="798809.2799999999"/>
+    <Bond class1="c1" class2="n2" length="0.11971000000000001" k="675967.0399999999"/>
+    <Bond class1="c1" class2="n3" length="0.13475" k="396894.23999999993"/>
+    <Bond class1="c1" class2="n4" length="0.14170000000000002" k="316477.75999999995"/>
+    <Bond class1="c1" class2="n" length="0.133" k="420910.39999999997"/>
+    <Bond class1="c1" class2="na" length="0.13620000000000002" k="378233.6"/>
+    <Bond class1="c1" class2="ne" length="0.12023" k="662912.9599999998"/>
+    <Bond class1="c1" class2="nf" length="0.12023" k="662912.9599999998"/>
+    <Bond class1="c1" class2="nh" length="0.13423000000000002" k="403839.68"/>
+    <Bond class1="c1" class2="no" length="0.1405" k="328862.39999999997"/>
+    <Bond class1="c1" class2="o" length="0.11724000000000001" k="634378.08"/>
+    <Bond class1="c1" class2="oh" length="0.13260000000000002" k="364510.07999999996"/>
+    <Bond class1="c1" class2="os" length="0.13181" k="374467.99999999994"/>
+    <Bond class1="c1" class2="p2" length="0.17700000000000002" k="242086.23999999996"/>
+    <Bond class1="c1" class2="p3" length="0.17900000000000002" k="230203.68"/>
+    <Bond class1="c1" class2="p4" length="0.17900000000000002" k="230203.68"/>
+    <Bond class1="c1" class2="p5" length="0.1753" k="252880.95999999996"/>
+    <Bond class1="c1" class2="s2" length="0.1595" k="343087.99999999994"/>
+    <Bond class1="c1" class2="s" length="0.16032000000000002" k="335222.07999999996"/>
+    <Bond class1="c1" class2="s4" length="0.1746" k="228362.71999999994"/>
+    <Bond class1="c1" class2="s6" length="0.17220000000000002" k="243006.71999999994"/>
+    <Bond class1="c1" class2="sh" length="0.168" k="271541.6"/>
+    <Bond class1="c1" class2="ss" length="0.16898000000000002" k="264596.16"/>
+    <Bond class1="c2" class2="c2" length="0.13343000000000002" k="476473.9199999999"/>
+    <Bond class1="c2" class2="c3" length="0.15095000000000003" k="273466.24"/>
+    <Bond class1="c2" class2="ca" length="0.13846" k="403421.27999999997"/>
+    <Bond class1="c2" class2="cc" length="0.13593" k="438315.83999999985"/>
+    <Bond class1="c2" class2="cd" length="0.13593" k="438315.83999999985"/>
+    <Bond class1="c2" class2="ce" length="0.13461" k="457980.63999999984"/>
+    <Bond class1="c2" class2="cf" length="0.13461" k="457980.63999999984"/>
+    <Bond class1="c2" class2="cl" length="0.17308" k="268863.83999999997"/>
+    <Bond class1="c2" class2="cu" length="0.13240000000000002" k="493711.9999999999"/>
+    <Bond class1="c2" class2="cx" length="0.14850000000000002" k="294553.6"/>
+    <Bond class1="c2" class2="cy" length="0.1511" k="272462.07999999996"/>
+    <Bond class1="c2" class2="f" length="0.13385" k="310118.07999999996"/>
+    <Bond class1="c2" class2="h4" length="0.10868" k="288361.27999999997"/>
+    <Bond class1="c2" class2="h5" length="0.10912" k="283173.11999999994"/>
+    <Bond class1="c2" class2="ha" length="0.10879000000000001" k="287106.07999999996"/>
+    <Bond class1="c2" class2="hc" length="0.1087" k="288110.24"/>
+    <Bond class1="c2" class2="hx" length="0.10830000000000001" k="292963.68"/>
+    <Bond class1="c2" class2="i" length="0.21701000000000004" k="180246.71999999997"/>
+    <Bond class1="c2" class2="n1" length="0.13060000000000002" k="456892.7999999999"/>
+    <Bond class1="c2" class2="n2" length="0.12817" k="497142.87999999995"/>
+    <Bond class1="c2" class2="n3" length="0.134" k="406935.8399999999"/>
+    <Bond class1="c2" class2="n" length="0.13994" k="334803.68"/>
+    <Bond class1="c2" class2="n4" length="0.15125" k="235977.59999999998"/>
+    <Bond class1="c2" class2="na" length="0.14015" k="332544.31999999995"/>
+    <Bond class1="c2" class2="nc" length="0.1313" k="446014.39999999997"/>
+    <Bond class1="c2" class2="nd" length="0.1313" k="446014.39999999997"/>
+    <Bond class1="c2" class2="ne" length="0.12915000000000001" k="480406.8799999999"/>
+    <Bond class1="c2" class2="nf" length="0.12915000000000001" k="480406.8799999999"/>
+    <Bond class1="c2" class2="nh" length="0.13872" k="348276.1599999999"/>
+    <Bond class1="c2" class2="no" length="0.14481" k="287022.39999999997"/>
+    <Bond class1="c2" class2="o" length="0.12247" k="521242.7199999999"/>
+    <Bond class1="c2" class2="oh" length="0.13385" k="349447.68"/>
+    <Bond class1="c2" class2="os" length="0.13596" k="325682.55999999994"/>
+    <Bond class1="c2" class2="p2" length="0.16686" k="315724.63999999996"/>
+    <Bond class1="c2" class2="p3" length="0.1834" k="206354.87999999998"/>
+    <Bond class1="c2" class2="p4" length="0.18220000000000003" k="212547.19999999998"/>
+    <Bond class1="c2" class2="p5" length="0.18626" k="192463.99999999997"/>
+    <Bond class1="c2" class2="pe" length="0.16886" k="299239.68"/>
+    <Bond class1="c2" class2="pf" length="0.16886" k="299239.68"/>
+    <Bond class1="c2" class2="s2" length="0.16100000000000003" k="328946.07999999996"/>
+    <Bond class1="c2" class2="s" length="0.1734" k="235559.19999999995"/>
+    <Bond class1="c2" class2="s4" length="0.17600000000000002" k="220245.75999999998"/>
+    <Bond class1="c2" class2="s6" length="0.17600000000000002" k="220245.75999999998"/>
+    <Bond class1="c2" class2="sh" length="0.17820000000000003" k="208279.51999999996"/>
+    <Bond class1="c2" class2="ss" length="0.1736" k="234303.99999999994"/>
+    <Bond class1="c3" class2="c3" length="0.15375000000000003" k="251793.11999999994"/>
+    <Bond class1="c3" class2="ca" length="0.15156000000000003" k="268612.8"/>
+    <Bond class1="c3" class2="cc" length="0.15015" k="280160.63999999996"/>
+    <Bond class1="c3" class2="cd" length="0.15015" k="280160.63999999996"/>
+    <Bond class1="c3" class2="ce" length="0.15159" k="268361.75999999995"/>
+    <Bond class1="c3" class2="cf" length="0.15157" k="268529.11999999994"/>
+    <Bond class1="c3" class2="cl" length="0.18045" k="222839.83999999997"/>
+    <Bond class1="c3" class2="cu" length="0.1484" k="295474.08"/>
+    <Bond class1="c3" class2="cv" length="0.1501" k="280662.7199999999"/>
+    <Bond class1="c3" class2="cx" length="0.1522" k="263675.67999999993"/>
+    <Bond class1="c3" class2="cy" length="0.1534" k="254554.55999999994"/>
+    <Bond class1="c3" class2="f" length="0.13497" k="298653.9199999999"/>
+    <Bond class1="c3" class2="h1" length="0.10969000000000001" k="276646.07999999996"/>
+    <Bond class1="c3" class2="h2" length="0.10961000000000001" k="277566.55999999994"/>
+    <Bond class1="c3" class2="h3" length="0.10949" k="278905.43999999994"/>
+    <Bond class1="c3" class2="hc" length="0.10969000000000001" k="276646.07999999996"/>
+    <Bond class1="c3" class2="hx" length="0.1091" k="283424.1599999999"/>
+    <Bond class1="c3" class2="i" length="0.22117" k="165519.03999999998"/>
+    <Bond class1="c3" class2="n1" length="0.1433" k="300913.27999999997"/>
+    <Bond class1="c3" class2="n2" length="0.14661" k="271541.6"/>
+    <Bond class1="c3" class2="n" length="0.14619000000000001" k="275056.16"/>
+    <Bond class1="c3" class2="n3" length="0.14647" k="272713.11999999994"/>
+    <Bond class1="c3" class2="n4" length="0.1511" k="237065.44"/>
+    <Bond class1="c3" class2="na" length="0.14629" k="274219.3599999999"/>
+    <Bond class1="c3" class2="nc" length="0.1456" k="280076.95999999996"/>
+    <Bond class1="c3" class2="nd" length="0.1456" k="280076.95999999996"/>
+    <Bond class1="c3" class2="nh" length="0.1464" k="273298.87999999995"/>
+    <Bond class1="c3" class2="no" length="0.15334000000000003" k="221835.68"/>
+    <Bond class1="c3" class2="o" length="0.13165000000000002" k="376476.3199999999"/>
+    <Bond class1="c3" class2="oh" length="0.14233" k="265014.55999999994"/>
+    <Bond class1="c3" class2="os" length="0.14316" k="258236.47999999998"/>
+    <Bond class1="c3" class2="p2" length="0.1855" k="196062.24"/>
+    <Bond class1="c3" class2="p3" length="0.18582" k="194555.99999999997"/>
+    <Bond class1="c3" class2="p4" length="0.18387" k="204011.83999999997"/>
+    <Bond class1="c3" class2="p5" length="0.18395" k="203593.43999999997"/>
+    <Bond class1="c3" class2="px" length="0.18286000000000002" k="209116.31999999995"/>
+    <Bond class1="c3" class2="py" length="0.18397" k="203509.75999999998"/>
+    <Bond class1="c3" class2="s" length="0.1845" k="178154.71999999997"/>
+    <Bond class1="c3" class2="s4" length="0.18305000000000002" k="184598.07999999996"/>
+    <Bond class1="c3" class2="s6" length="0.18075000000000002" k="195392.79999999996"/>
+    <Bond class1="c3" class2="sh" length="0.18435" k="178824.15999999997"/>
+    <Bond class1="c3" class2="ss" length="0.18392" k="180665.11999999997"/>
+    <Bond class1="c3" class2="sx" length="0.18418" k="179577.27999999997"/>
+    <Bond class1="c3" class2="sy" length="0.18087" k="194807.03999999998"/>
+    <Bond class1="ca" class2="ca" length="0.13984000000000002" k="385848.4799999999"/>
+    <Bond class1="ca" class2="cc" length="0.14555" k="322251.68"/>
+    <Bond class1="ca" class2="cd" length="0.14555" k="322251.68"/>
+    <Bond class1="ca" class2="ce" length="0.14763" k="302335.83999999997"/>
+    <Bond class1="ca" class2="cf" length="0.14763" k="302335.83999999997"/>
+    <Bond class1="ca" class2="cg" length="0.14328000000000002" k="345849.43999999994"/>
+    <Bond class1="ca" class2="ch" length="0.14328000000000002" k="345849.43999999994"/>
+    <Bond class1="ca" class2="cl" length="0.17502" k="255726.08"/>
+    <Bond class1="ca" class2="cp" length="0.14058" k="376727.3599999999"/>
+    <Bond class1="ca" class2="cq" length="0.14058" k="376727.3599999999"/>
+    <Bond class1="ca" class2="cx" length="0.1496" k="284930.39999999997"/>
+    <Bond class1="ca" class2="cy" length="0.1516" k="268445.43999999994"/>
+    <Bond class1="ca" class2="f" length="0.1349" k="299407.0399999999"/>
+    <Bond class1="ca" class2="h4" length="0.1089" k="285767.19999999995"/>
+    <Bond class1="ca" class2="h5" length="0.10878000000000002" k="287189.75999999995"/>
+    <Bond class1="ca" class2="ha" length="0.10860000000000002" k="289365.44"/>
+    <Bond class1="ca" class2="i" length="0.21288" k="196564.31999999998"/>
+    <Bond class1="ca" class2="n1" length="0.1335" k="413881.27999999997"/>
+    <Bond class1="ca" class2="n2" length="0.1303" k="461578.87999999995"/>
+    <Bond class1="ca" class2="n" length="0.14121" k="321498.55999999994"/>
+    <Bond class1="ca" class2="n4" length="0.14842" k="256897.59999999995"/>
+    <Bond class1="ca" class2="na" length="0.1384" k="351874.39999999997"/>
+    <Bond class1="ca" class2="nb" length="0.1339" k="408358.39999999997"/>
+    <Bond class1="ca" class2="nc" length="0.13516999999999998" k="391371.3599999999"/>
+    <Bond class1="ca" class2="nd" length="0.13516999999999998" k="391371.3599999999"/>
+    <Bond class1="ca" class2="ne" length="0.14079" k="325766.23999999993"/>
+    <Bond class1="ca" class2="nf" length="0.14079" k="325766.23999999993"/>
+    <Bond class1="ca" class2="nh" length="0.13859" k="349698.7199999999"/>
+    <Bond class1="ca" class2="no" length="0.14689000000000002" k="269198.55999999994"/>
+    <Bond class1="ca" class2="o" length="0.12358000000000001" k="500490.07999999996"/>
+    <Bond class1="ca" class2="oh" length="0.13637" k="321331.19999999995"/>
+    <Bond class1="ca" class2="os" length="0.13696" k="315138.87999999995"/>
+    <Bond class1="ca" class2="p2" length="0.18400000000000002" k="203342.39999999997"/>
+    <Bond class1="ca" class2="p3" length="0.18257" k="210622.55999999997"/>
+    <Bond class1="ca" class2="p4" length="0.1806" k="221166.23999999996"/>
+    <Bond class1="ca" class2="p5" length="0.17952" k="227191.19999999998"/>
+    <Bond class1="ca" class2="pe" length="0.1829" k="208865.27999999994"/>
+    <Bond class1="ca" class2="pf" length="0.1829" k="208865.27999999994"/>
+    <Bond class1="ca" class2="px" length="0.1825" k="210957.27999999994"/>
+    <Bond class1="ca" class2="py" length="0.18162" k="215643.35999999993"/>
+    <Bond class1="ca" class2="s" length="0.17390000000000003" k="232546.71999999997"/>
+    <Bond class1="ca" class2="s4" length="0.17880000000000001" k="205183.35999999996"/>
+    <Bond class1="ca" class2="s6" length="0.17669" k="216480.15999999995"/>
+    <Bond class1="ca" class2="sh" length="0.17809" k="208865.27999999994"/>
+    <Bond class1="ca" class2="ss" length="0.17806" k="209032.63999999998"/>
+    <Bond class1="ca" class2="sx" length="0.18251" k="187108.47999999998"/>
+    <Bond class1="ca" class2="sy" length="0.17909" k="203677.11999999997"/>
+    <Bond class1="c" class2="c1" length="0.146" k="317816.63999999996"/>
+    <Bond class1="c" class2="c2" length="0.1406" k="376476.3199999999"/>
+    <Bond class1="c" class2="c" length="0.15482" k="244094.55999999994"/>
+    <Bond class1="c" class2="c3" length="0.15241000000000002" k="261918.39999999997"/>
+    <Bond class1="c" class2="ca" length="0.14906" k="289449.11999999994"/>
+    <Bond class1="c" class2="cc" length="0.14676" k="310452.8"/>
+    <Bond class1="cc" class2="cc" length="0.14278" k="351288.63999999996"/>
+    <Bond class1="cc" class2="cd" length="0.13729" k="419153.11999999994"/>
+    <Bond class1="cc" class2="ce" length="0.1454" k="323757.9199999999"/>
+    <Bond class1="cc" class2="cf" length="0.13656" k="429278.39999999997"/>
+    <Bond class1="cc" class2="cg" length="0.14257" k="353631.68"/>
+    <Bond class1="cc" class2="ch" length="0.14270000000000002" k="352209.11999999994"/>
+    <Bond class1="cc" class2="cl" length="0.17354000000000003" k="265683.99999999994"/>
+    <Bond class1="cc" class2="cx" length="0.1469" k="309281.27999999997"/>
+    <Bond class1="c" class2="cd" length="0.14676" k="310452.8"/>
+    <Bond class1="c" class2="ce" length="0.14825" k="296645.6"/>
+    <Bond class1="c" class2="cf" length="0.14825" k="296645.6"/>
+    <Bond class1="cc" class2="f" length="0.13407" k="307775.04"/>
+    <Bond class1="c" class2="cg" length="0.14512" k="326519.3599999999"/>
+    <Bond class1="c" class2="ch" length="0.14512" k="326519.3599999999"/>
+    <Bond class1="cc" class2="h4" length="0.10817000000000002" k="294553.6"/>
+    <Bond class1="cc" class2="h5" length="0.10819000000000001" k="294302.55999999994"/>
+    <Bond class1="cc" class2="ha" length="0.10837000000000002" k="292126.87999999995"/>
+    <Bond class1="c" class2="cl" length="0.18029" k="223760.31999999995"/>
+    <Bond class1="cc" class2="n2" length="0.12905" k="482080.48"/>
+    <Bond class1="cc" class2="n" length="0.13807" k="355723.67999999993"/>
+    <Bond class1="cc" class2="n4" length="0.14930000000000002" k="250203.19999999995"/>
+    <Bond class1="cc" class2="na" length="0.13802" k="356309.43999999994"/>
+    <Bond class1="cc" class2="nc" length="0.13694" k="369112.48"/>
+    <Bond class1="cc" class2="nd" length="0.13172" k="439654.7199999999"/>
+    <Bond class1="cc" class2="ne" length="0.13786" k="358150.39999999997"/>
+    <Bond class1="cc" class2="nf" length="0.12985" k="468859.0399999999"/>
+    <Bond class1="cc" class2="nh" length="0.13735" k="364175.3599999999"/>
+    <Bond class1="cc" class2="no" length="0.14289000000000002" k="304762.55999999994"/>
+    <Bond class1="cc" class2="oh" length="0.13470000000000001" k="339657.11999999994"/>
+    <Bond class1="cc" class2="os" length="0.13620000000000002" k="323088.48"/>
+    <Bond class1="cc" class2="pd" length="0.1733" k="266269.75999999995"/>
+    <Bond class1="cc" class2="sh" length="0.17693000000000003" k="215141.27999999997"/>
+    <Bond class1="cc" class2="ss" length="0.17562" k="222421.43999999997"/>
+    <Bond class1="cc" class2="sx" length="0.18107" k="193886.55999999997"/>
+    <Bond class1="cc" class2="sy" length="0.17839000000000002" k="207275.35999999996"/>
+    <Bond class1="c" class2="cu" length="0.1412" k="369363.51999999996"/>
+    <Bond class1="c" class2="cx" length="0.1503" k="278989.11999999994"/>
+    <Bond class1="c" class2="cy" length="0.1552" k="241500.47999999998"/>
+    <Bond class1="cd" class2="cd" length="0.14278" k="351288.63999999996"/>
+    <Bond class1="cd" class2="ce" length="0.13656" k="429278.39999999997"/>
+    <Bond class1="cd" class2="cf" length="0.1454" k="323757.9199999999"/>
+    <Bond class1="cd" class2="cg" length="0.14270000000000002" k="352209.11999999994"/>
+    <Bond class1="cd" class2="ch" length="0.14257" k="353631.68"/>
+    <Bond class1="cd" class2="cl" length="0.17354000000000003" k="265683.99999999994"/>
+    <Bond class1="cd" class2="cx" length="0.148" k="299072.31999999995"/>
+    <Bond class1="cd" class2="cy" length="0.1505" k="277315.5199999999"/>
+    <Bond class1="cd" class2="h4" length="0.10817000000000002" k="294553.6"/>
+    <Bond class1="cd" class2="h5" length="0.10818000000000001" k="294386.24"/>
+    <Bond class1="cd" class2="ha" length="0.10837000000000002" k="292126.87999999995"/>
+    <Bond class1="cd" class2="n2" length="0.12905" k="482080.48"/>
+    <Bond class1="cd" class2="n" length="0.13807" k="355723.67999999993"/>
+    <Bond class1="cd" class2="na" length="0.13802" k="356309.43999999994"/>
+    <Bond class1="cd" class2="nc" length="0.13172" k="439654.7199999999"/>
+    <Bond class1="cd" class2="nd" length="0.13694" k="369112.48"/>
+    <Bond class1="cd" class2="ne" length="0.12985" k="468859.0399999999"/>
+    <Bond class1="cd" class2="nh" length="0.13735" k="364175.3599999999"/>
+    <Bond class1="cd" class2="oh" length="0.13470000000000001" k="339657.11999999994"/>
+    <Bond class1="cd" class2="os" length="0.13620000000000002" k="323088.48"/>
+    <Bond class1="cd" class2="pc" length="0.1733" k="266269.75999999995"/>
+    <Bond class1="cd" class2="ss" length="0.17562" k="222421.43999999997"/>
+    <Bond class1="cd" class2="sy" length="0.17839000000000002" k="207275.35999999996"/>
+    <Bond class1="ce" class2="ce" length="0.14574" k="320327.04"/>
+    <Bond class1="ce" class2="cf" length="0.13509000000000002" k="450700.48"/>
+    <Bond class1="ce" class2="cg" length="0.14270000000000002" k="352209.11999999994"/>
+    <Bond class1="ce" class2="ch" length="0.1431" k="347774.07999999996"/>
+    <Bond class1="ce" class2="cl" length="0.17641" k="246772.31999999995"/>
+    <Bond class1="ce" class2="cx" length="0.1503" k="278989.11999999994"/>
+    <Bond class1="ce" class2="cy" length="0.1517" k="267608.63999999996"/>
+    <Bond class1="ce" class2="h4" length="0.10916" k="282671.04"/>
+    <Bond class1="ce" class2="ha" length="0.10883000000000001" k="286603.99999999994"/>
+    <Bond class1="ce" class2="n1" length="0.13111" k="448943.1999999999"/>
+    <Bond class1="ce" class2="n2" length="0.12874000000000002" k="487352.3199999999"/>
+    <Bond class1="ce" class2="n" length="0.14242" k="309364.95999999996"/>
+    <Bond class1="ce" class2="na" length="0.14209000000000002" k="312628.48"/>
+    <Bond class1="ce" class2="ne" length="0.13942000000000002" k="340493.9199999999"/>
+    <Bond class1="ce" class2="nf" length="0.12964" k="472289.91999999987"/>
+    <Bond class1="ce" class2="nh" length="0.13901" k="345012.63999999996"/>
+    <Bond class1="ce" class2="oh" length="0.13502" k="336058.88"/>
+    <Bond class1="ce" class2="os" length="0.1371" k="313716.31999999995"/>
+    <Bond class1="ce" class2="p2" length="0.1814" k="216814.88"/>
+    <Bond class1="ce" class2="pe" length="0.18180000000000002" k="214639.19999999998"/>
+    <Bond class1="ce" class2="px" length="0.1821" k="213049.27999999997"/>
+    <Bond class1="ce" class2="py" length="0.18056000000000003" k="221333.59999999998"/>
+    <Bond class1="ce" class2="s" length="0.168" k="271541.6"/>
+    <Bond class1="ce" class2="ss" length="0.17814000000000002" k="208614.24"/>
+    <Bond class1="ce" class2="sx" length="0.18185" k="190120.95999999996"/>
+    <Bond class1="ce" class2="sy" length="0.17881000000000002" k="205099.67999999996"/>
+    <Bond class1="c" class2="f" length="0.1325" k="324594.72"/>
+    <Bond class1="cf" class2="cf" length="0.14574" k="320327.04"/>
+    <Bond class1="cf" class2="cg" length="0.1431" k="347774.07999999996"/>
+    <Bond class1="cf" class2="ch" length="0.14270000000000002" k="352209.11999999994"/>
+    <Bond class1="cf" class2="h4" length="0.10916" k="282671.04"/>
+    <Bond class1="cf" class2="ha" length="0.10883000000000001" k="286603.99999999994"/>
+    <Bond class1="cf" class2="n1" length="0.13111" k="448943.1999999999"/>
+    <Bond class1="cf" class2="n2" length="0.12874000000000002" k="487352.3199999999"/>
+    <Bond class1="cf" class2="n" length="0.14242" k="309364.95999999996"/>
+    <Bond class1="cf" class2="ne" length="0.12964" k="472289.91999999987"/>
+    <Bond class1="cf" class2="nf" length="0.13942000000000002" k="340493.9199999999"/>
+    <Bond class1="cf" class2="nh" length="0.13901" k="345012.63999999996"/>
+    <Bond class1="cf" class2="oh" length="0.13502" k="336058.88"/>
+    <Bond class1="cf" class2="os" length="0.1371" k="313716.31999999995"/>
+    <Bond class1="cf" class2="p2" length="0.1814" k="216814.88"/>
+    <Bond class1="cf" class2="pf" length="0.18180000000000002" k="214639.19999999998"/>
+    <Bond class1="cf" class2="px" length="0.1821" k="213049.27999999997"/>
+    <Bond class1="cf" class2="py" length="0.18056000000000003" k="221333.59999999998"/>
+    <Bond class1="cf" class2="s" length="0.168" k="271541.6"/>
+    <Bond class1="cf" class2="sx" length="0.18185" k="190120.95999999996"/>
+    <Bond class1="cf" class2="sy" length="0.17881000000000002" k="205099.67999999996"/>
+    <Bond class1="cg" class2="cg" length="0.13693" k="424090.23999999993"/>
+    <Bond class1="cg" class2="ch" length="0.12056" k="752115.8399999999"/>
+    <Bond class1="cg" class2="n1" length="0.11566000000000001" k="789186.0799999998"/>
+    <Bond class1="cg" class2="ne" length="0.13261" k="426516.95999999996"/>
+    <Bond class1="cg" class2="pe" length="0.16210000000000002" k="359656.63999999996"/>
+    <Bond class1="c" class2="h4" length="0.11121000000000002" k="259993.75999999998"/>
+    <Bond class1="c" class2="h5" length="0.11051" k="267524.95999999996"/>
+    <Bond class1="c" class2="ha" length="0.1101" k="272043.68"/>
+    <Bond class1="ch" class2="ch" length="0.13693" k="424090.23999999993"/>
+    <Bond class1="ch" class2="n1" length="0.11566000000000001" k="789186.0799999998"/>
+    <Bond class1="ch" class2="nf" length="0.13261" k="426516.95999999996"/>
+    <Bond class1="ch" class2="pf" length="0.16210000000000002" k="359656.63999999996"/>
+    <Bond class1="c" class2="i" length="0.2209" k="166439.52"/>
+    <Bond class1="cl" class2="cl" length="0.2267" k="119913.43999999999"/>
+    <Bond class1="cl" class2="cx" length="0.17880000000000001" k="232295.68"/>
+    <Bond class1="cl" class2="cy" length="0.1794" k="228781.11999999997"/>
+    <Bond class1="cl" class2="f" length="0.1648" k="83.67999999999999"/>
+    <Bond class1="cl" class2="i" length="0.255" k="0.0"/>
+    <Bond class1="cl" class2="n1" length="0.163" k="361162.87999999995"/>
+    <Bond class1="cl" class2="n2" length="0.1819" k="220413.11999999994"/>
+    <Bond class1="cl" class2="n3" length="0.17772" k="244763.99999999994"/>
+    <Bond class1="cl" class2="n" length="0.17161" k="286436.63999999996"/>
+    <Bond class1="cl" class2="n4" length="0.1753" k="260328.47999999998"/>
+    <Bond class1="cl" class2="na" length="0.1835" k="211877.75999999995"/>
+    <Bond class1="cl" class2="nh" length="0.1763" k="253717.75999999995"/>
+    <Bond class1="cl" class2="no" length="0.18400000000000002" k="209283.67999999996"/>
+    <Bond class1="cl" class2="o" length="0.14830000000000002" k="466599.68"/>
+    <Bond class1="cl" class2="oh" length="0.169" k="259156.95999999993"/>
+    <Bond class1="cl" class2="os" length="0.17300000000000001" k="233299.84"/>
+    <Bond class1="cl" class2="p2" length="0.207" k="182003.99999999997"/>
+    <Bond class1="cl" class2="p3" length="0.2008" k="208697.91999999998"/>
+    <Bond class1="cl" class2="p4" length="0.2008" k="208697.91999999998"/>
+    <Bond class1="cl" class2="p5" length="0.2008" k="208697.91999999998"/>
+    <Bond class1="cl" class2="pb" length="0.19970000000000002" k="213886.07999999996"/>
+    <Bond class1="cl" class2="s" length="0.20720000000000002" k="174640.15999999995"/>
+    <Bond class1="cl" class2="s2" length="0.21610000000000001" k="144515.35999999996"/>
+    <Bond class1="cl" class2="s4" length="0.20720000000000002" k="174640.15999999995"/>
+    <Bond class1="cl" class2="s6" length="0.20720000000000002" k="174640.15999999995"/>
+    <Bond class1="cl" class2="sh" length="0.20720000000000002" k="174640.15999999995"/>
+    <Bond class1="cl" class2="ss" length="0.20720000000000002" k="174640.15999999995"/>
+    <Bond class1="cl" class2="sx" length="0.20720000000000002" k="174640.15999999995"/>
+    <Bond class1="cl" class2="sy" length="0.20720000000000002" k="174640.15999999995"/>
+    <Bond class1="c" class2="n2" length="0.142" k="313465.27999999997"/>
+    <Bond class1="c" class2="n4" length="0.15460000000000002" k="213802.39999999994"/>
+    <Bond class1="c" class2="n" length="0.13789" k="357815.67999999993"/>
+    <Bond class1="c" class2="nc" length="0.13867000000000002" k="348861.9199999999"/>
+    <Bond class1="c" class2="nd" length="0.13867000000000002" k="348861.9199999999"/>
+    <Bond class1="c" class2="ne" length="0.13909000000000002" k="344092.16"/>
+    <Bond class1="c" class2="nf" length="0.13909000000000002" k="344092.16"/>
+    <Bond class1="c" class2="no" length="0.15400000000000003" k="217651.68"/>
+    <Bond class1="c" class2="o" length="0.12183" k="533627.36"/>
+    <Bond class1="c" class2="oh" length="0.13513" k="334803.68"/>
+    <Bond class1="c" class2="os" length="0.13584000000000002" k="327021.43999999994"/>
+    <Bond class1="c" class2="p2" length="0.19" k="175979.03999999998"/>
+    <Bond class1="c" class2="p3" length="0.18830000000000002" k="183259.19999999998"/>
+    <Bond class1="c" class2="p4" length="0.188" k="184598.07999999996"/>
+    <Bond class1="c" class2="p5" length="0.18818000000000001" k="183761.27999999997"/>
+    <Bond class1="cp" class2="cp" length="0.14854" k="294051.5199999999"/>
+    <Bond class1="cp" class2="cq" length="0.14542" k="323506.88"/>
+    <Bond class1="c" class2="pe" length="0.19110000000000002" k="171460.31999999998"/>
+    <Bond class1="c" class2="pf" length="0.19110000000000002" k="171460.31999999998"/>
+    <Bond class1="cp" class2="na" length="0.1384" k="351874.39999999997"/>
+    <Bond class1="cp" class2="nb" length="0.13387000000000002" k="408776.79999999993"/>
+    <Bond class1="c" class2="px" length="0.1904" k="174305.43999999997"/>
+    <Bond class1="c" class2="py" length="0.1867" k="190455.67999999996"/>
+    <Bond class1="cq" class2="cq" length="0.14854" k="294051.5199999999"/>
+    <Bond class1="c" class2="s" length="0.16723" k="277231.83999999997"/>
+    <Bond class1="c" class2="s4" length="0.18700000000000003" k="167694.71999999997"/>
+    <Bond class1="c" class2="s6" length="0.18700000000000003" k="167694.71999999997"/>
+    <Bond class1="c" class2="sh" length="0.17971" k="200580.95999999996"/>
+    <Bond class1="c" class2="ss" length="0.18000000000000002" k="199074.71999999997"/>
+    <Bond class1="c" class2="sx" length="0.1885" k="161753.44"/>
+    <Bond class1="c" class2="sy" length="0.1865" k="169703.03999999998"/>
+    <Bond class1="cu" class2="cu" length="0.13" k="536054.08"/>
+    <Bond class1="cu" class2="cx" length="0.147" k="308360.79999999993"/>
+    <Bond class1="cu" class2="ha" length="0.1079" k="297900.8"/>
+    <Bond class1="cv" class2="cv" length="0.1341" k="466097.6"/>
+    <Bond class1="cv" class2="cy" length="0.1521" k="264428.79999999993"/>
+    <Bond class1="cv" class2="ha" length="0.10880000000000001" k="286938.72"/>
+    <Bond class1="cv" class2="cx" length="0.1505" k="277315.5199999999"/>
+    <Bond class1="cx" class2="cx" length="0.15080000000000002" k="274888.79999999993"/>
+    <Bond class1="cx" class2="cy" length="0.15280000000000002" k="259073.27999999997"/>
+    <Bond class1="cx" class2="f" length="0.1361" k="287691.83999999997"/>
+    <Bond class1="cx" class2="h1" length="0.1089" k="285767.19999999995"/>
+    <Bond class1="cx" class2="h2" length="0.1087" k="288110.24"/>
+    <Bond class1="cx" class2="hc" length="0.1087" k="288110.24"/>
+    <Bond class1="cx" class2="hx" length="0.1085" k="290536.95999999996"/>
+    <Bond class1="cx" class2="n2" length="0.1452" k="283591.51999999996"/>
+    <Bond class1="cx" class2="n3" length="0.1443" k="291624.79999999993"/>
+    <Bond class1="cx" class2="n" length="0.1434" k="299992.8"/>
+    <Bond class1="cx" class2="na" length="0.1461" k="275809.27999999997"/>
+    <Bond class1="cx" class2="nh" length="0.1434" k="299992.8"/>
+    <Bond class1="cx" class2="oh" length="0.13970000000000002" k="288110.24"/>
+    <Bond class1="cx" class2="os" length="0.1405" k="280830.08"/>
+    <Bond class1="cx" class2="p3" length="0.191" k="171878.72"/>
+    <Bond class1="cx" class2="s4" length="0.1882" k="162924.95999999996"/>
+    <Bond class1="cx" class2="s6" length="0.1849" k="176397.43999999997"/>
+    <Bond class1="cx" class2="ss" length="0.1836" k="182087.67999999996"/>
+    <Bond class1="cy" class2="cy" length="0.15580000000000002" k="237316.48"/>
+    <Bond class1="cy" class2="f" length="0.13570000000000002" k="291541.11999999994"/>
+    <Bond class1="cy" class2="h1" length="0.1095" k="278738.07999999996"/>
+    <Bond class1="cy" class2="h2" length="0.10930000000000001" k="281081.11999999994"/>
+    <Bond class1="cy" class2="hc" length="0.1095" k="278738.07999999996"/>
+    <Bond class1="cy" class2="n" length="0.1433" k="300913.27999999997"/>
+    <Bond class1="cy" class2="n3" length="0.14570000000000002" k="279240.16"/>
+    <Bond class1="cy" class2="oh" length="0.1412" k="274554.07999999996"/>
+    <Bond class1="cy" class2="os" length="0.1422" k="266018.7199999999"/>
+    <Bond class1="cy" class2="s6" length="0.18510000000000001" k="175560.63999999998"/>
+    <Bond class1="cy" class2="ss" length="0.18500000000000003" k="175979.03999999998"/>
+    <Bond class1="cz" class2="nh" length="0.1339" k="408358.39999999997"/>
+    <Bond class1="f" class2="n1" length="0.141" k="314385.7599999999"/>
+    <Bond class1="f" class2="n2" length="0.1444" k="282420.0"/>
+    <Bond class1="f" class2="n3" length="0.1406" k="318486.07999999996"/>
+    <Bond class1="f" class2="n" length="0.13970000000000002" k="327774.55999999994"/>
+    <Bond class1="f" class2="n4" length="0.1308" k="440826.2399999999"/>
+    <Bond class1="f" class2="na" length="0.1411" k="313381.6"/>
+    <Bond class1="f" class2="nh" length="0.1426" k="298821.27999999997"/>
+    <Bond class1="f" class2="no" length="0.14670000000000002" k="263089.9199999999"/>
+    <Bond class1="f" class2="o" length="0.133" k="370032.9599999999"/>
+    <Bond class1="f" class2="oh" length="0.1444" k="255558.71999999994"/>
+    <Bond class1="f" class2="os" length="0.1423" k="272964.1599999999"/>
+    <Bond class1="f" class2="p2" length="0.15360000000000001" k="240412.63999999996"/>
+    <Bond class1="f" class2="p3" length="0.15780000000000002" k="212965.59999999995"/>
+    <Bond class1="f" class2="p4" length="0.15900000000000003" k="205852.8"/>
+    <Bond class1="f" class2="p5" length="0.15862" k="208028.47999999995"/>
+    <Bond class1="f" class2="s2" length="0.1643" k="204513.91999999995"/>
+    <Bond class1="f" class2="s" length="0.166" k="195225.44"/>
+    <Bond class1="f" class2="s4" length="0.15910000000000002" k="236312.31999999995"/>
+    <Bond class1="f" class2="s6" length="0.1612" k="222756.15999999995"/>
+    <Bond class1="f" class2="sh" length="0.16490000000000002" k="201166.71999999997"/>
+    <Bond class1="f" class2="ss" length="0.1634" k="209618.39999999997"/>
+    <Bond class1="hn" class2="n1" length="0.09860000000000001" k="380827.68"/>
+    <Bond class1="hn" class2="n2" length="0.1023" k="322670.08"/>
+    <Bond class1="hn" class2="n3" length="0.10189999999999999" k="328360.31999999995"/>
+    <Bond class1="hn" class2="n" length="0.10128999999999999" k="337397.75999999995"/>
+    <Bond class1="hn" class2="n4" length="0.10304" k="312293.75999999995"/>
+    <Bond class1="hn" class2="na" length="0.101" k="341749.11999999994"/>
+    <Bond class1="hn" class2="nh" length="0.10121000000000001" k="338569.27999999997"/>
+    <Bond class1="hn" class2="no" length="0.1023" k="322670.08"/>
+    <Bond class1="ho" class2="o" length="0.0981" k="299490.72"/>
+    <Bond class1="ho" class2="oh" length="0.0973" k="310787.51999999996"/>
+    <Bond class1="hp" class2="p2" length="0.13360000000000002" k="322251.68"/>
+    <Bond class1="hp" class2="p3" length="0.1412" k="251207.35999999996"/>
+    <Bond class1="hp" class2="p4" length="0.1349" k="308528.1599999999"/>
+    <Bond class1="hp" class2="p5" length="0.14178" k="246604.95999999993"/>
+    <Bond class1="hs" class2="s" length="0.1353" k="239659.51999999993"/>
+    <Bond class1="hs" class2="s4" length="0.1375" k="222923.51999999996"/>
+    <Bond class1="hs" class2="s6" length="0.1359" k="234973.43999999997"/>
+    <Bond class1="hs" class2="sh" length="0.13473" k="244261.91999999995"/>
+    <Bond class1="i" class2="i" length="0.2917" k="91378.55999999998"/>
+    <Bond class1="i" class2="n1" length="0.20600000000000002" k="252797.28"/>
+    <Bond class1="i" class2="n2" length="0.2304" k="152799.68"/>
+    <Bond class1="i" class2="n" length="0.2098" k="232881.43999999997"/>
+    <Bond class1="i" class2="n3" length="0.21850000000000003" k="193970.23999999996"/>
+    <Bond class1="i" class2="n4" length="0.2155" k="206354.87999999998"/>
+    <Bond class1="i" class2="na" length="0.2129" k="217986.39999999997"/>
+    <Bond class1="i" class2="nh" length="0.215" k="208530.55999999997"/>
+    <Bond class1="i" class2="no" length="0.2231" k="176564.8"/>
+    <Bond class1="i" class2="o" length="0.198" k="270955.83999999997"/>
+    <Bond class1="i" class2="oh" length="0.2101" k="207442.71999999997"/>
+    <Bond class1="i" class2="os" length="0.2129" k="195476.47999999995"/>
+    <Bond class1="i" class2="p2" length="0.2643" k="90541.76"/>
+    <Bond class1="i" class2="p3" length="0.2566" k="103428.47999999997"/>
+    <Bond class1="i" class2="p4" length="0.2352" k="153134.39999999997"/>
+    <Bond class1="i" class2="p5" length="0.2596" k="98156.63999999998"/>
+    <Bond class1="i" class2="s" length="0.24300000000000002" k="146523.67999999996"/>
+    <Bond class1="i" class2="s4" length="0.28700000000000003" k="69287.04"/>
+    <Bond class1="i" class2="s6" length="0.28700000000000003" k="69287.04"/>
+    <Bond class1="i" class2="sh" length="0.256" k="115896.79999999999"/>
+    <Bond class1="i" class2="ss" length="0.25710000000000005" k="113721.12"/>
+    <Bond class1="n1" class2="n1" length="0.11345000000000001" k="980394.8799999998"/>
+    <Bond class1="n1" class2="n2" length="0.12304" k="680485.7599999999"/>
+    <Bond class1="n1" class2="n3" length="0.135" k="448273.75999999995"/>
+    <Bond class1="n1" class2="n4" length="0.136" k="433629.76"/>
+    <Bond class1="n1" class2="na" length="0.135" k="448273.75999999995"/>
+    <Bond class1="n1" class2="nc" length="0.1216" k="717472.32"/>
+    <Bond class1="n1" class2="nd" length="0.1216" k="717472.32"/>
+    <Bond class1="n1" class2="ne" length="0.1252" k="629189.9199999998"/>
+    <Bond class1="n1" class2="nf" length="0.1252" k="629189.9199999998"/>
+    <Bond class1="n1" class2="nh" length="0.134" k="463503.51999999996"/>
+    <Bond class1="n1" class2="no" length="0.13999999999999999" k="380576.63999999996"/>
+    <Bond class1="n1" class2="o" length="0.1277" k="516723.9999999999"/>
+    <Bond class1="n1" class2="oh" length="0.13" k="476808.6399999999"/>
+    <Bond class1="n1" class2="os" length="0.131" k="460658.3999999999"/>
+    <Bond class1="n1" class2="p2" length="0.1678" k="300243.83999999997"/>
+    <Bond class1="n1" class2="p3" length="0.166" k="315222.55999999994"/>
+    <Bond class1="n1" class2="p4" length="0.168" k="298653.9199999999"/>
+    <Bond class1="n1" class2="p5" length="0.15710000000000002" k="403923.3599999999"/>
+    <Bond class1="n1" class2="s2" length="0.1449" k="505678.23999999993"/>
+    <Bond class1="n1" class2="s" length="0.16590000000000002" k="275056.16"/>
+    <Bond class1="n1" class2="s4" length="0.165" k="281834.23999999993"/>
+    <Bond class1="n1" class2="s6" length="0.1416" k="560907.0399999998"/>
+    <Bond class1="n1" class2="sh" length="0.16100000000000003" k="314720.48"/>
+    <Bond class1="n1" class2="ss" length="0.16100000000000003" k="314720.48"/>
+    <Bond class1="n2" class2="n2" length="0.12668" k="596805.76"/>
+    <Bond class1="n2" class2="n3" length="0.1329" k="480992.63999999984"/>
+    <Bond class1="n2" class2="n4" length="0.16790000000000002" k="168029.44"/>
+    <Bond class1="n2" class2="na" length="0.13676" k="422835.0399999999"/>
+    <Bond class1="n2" class2="nc" length="0.1255" k="622495.5199999999"/>
+    <Bond class1="n2" class2="nd" length="0.1255" k="622495.5199999999"/>
+    <Bond class1="n2" class2="ne" length="0.12714" k="587182.5599999999"/>
+    <Bond class1="n2" class2="nf" length="0.12714" k="587182.5599999999"/>
+    <Bond class1="n2" class2="nh" length="0.13524" k="444675.5199999999"/>
+    <Bond class1="n2" class2="no" length="0.14346" k="340995.99999999994"/>
+    <Bond class1="n2" class2="o" length="0.12172000000000001" k="641239.8399999999"/>
+    <Bond class1="n2" class2="oh" length="0.13912" k="351455.99999999994"/>
+    <Bond class1="n2" class2="os" length="0.14015" k="339991.8399999999"/>
+    <Bond class1="n2" class2="p2" length="0.1605" k="366769.43999999994"/>
+    <Bond class1="n2" class2="p3" length="0.1764" k="239743.19999999998"/>
+    <Bond class1="n2" class2="p4" length="0.1724" k="265851.36"/>
+    <Bond class1="n2" class2="p5" length="0.15990000000000001" k="373045.43999999994"/>
+    <Bond class1="n2" class2="pe" length="0.15400000000000003" k="441746.7199999999"/>
+    <Bond class1="n2" class2="pf" length="0.15400000000000003" k="441746.7199999999"/>
+    <Bond class1="n2" class2="s2" length="0.15441000000000002" k="379907.19999999995"/>
+    <Bond class1="n2" class2="s4" length="0.16100000000000003" k="314720.48"/>
+    <Bond class1="n2" class2="s" length="0.15410000000000001" k="383338.07999999996"/>
+    <Bond class1="n2" class2="s6" length="0.15538000000000002" k="369279.83999999997"/>
+    <Bond class1="n2" class2="sh" length="0.1738" k="223090.87999999998"/>
+    <Bond class1="n2" class2="ss" length="0.1656" k="277315.5199999999"/>
+    <Bond class1="n3" class2="n3" length="0.14415" k="333715.83999999997"/>
+    <Bond class1="n3" class2="n4" length="0.143" k="345933.11999999994"/>
+    <Bond class1="n3" class2="na" length="0.142" k="357062.55999999994"/>
+    <Bond class1="n3" class2="nh" length="0.14156" k="362083.3599999999"/>
+    <Bond class1="n3" class2="no" length="0.13978" k="383254.39999999997"/>
+    <Bond class1="n3" class2="o" length="0.1303" k="471955.19999999995"/>
+    <Bond class1="n3" class2="oh" length="0.14149" k="325766.23999999993"/>
+    <Bond class1="n3" class2="os" length="0.14406000000000002" k="300411.19999999995"/>
+    <Bond class1="n3" class2="p2" length="0.167" k="306770.87999999995"/>
+    <Bond class1="n3" class2="p3" length="0.17300000000000001" k="261751.03999999995"/>
+    <Bond class1="n3" class2="p4" length="0.16970000000000002" k="285432.48"/>
+    <Bond class1="n3" class2="p5" length="0.16696" k="307105.5999999999"/>
+    <Bond class1="n3" class2="py" length="0.16939" k="287775.51999999996"/>
+    <Bond class1="n3" class2="s" length="0.17920000000000003" k="194388.63999999998"/>
+    <Bond class1="n3" class2="s4" length="0.17544" k="213886.07999999996"/>
+    <Bond class1="n3" class2="s6" length="0.16723" k="265349.27999999997"/>
+    <Bond class1="n3" class2="sh" length="0.17390000000000003" k="222505.11999999994"/>
+    <Bond class1="n3" class2="ss" length="0.17236" k="231626.23999999996"/>
+    <Bond class1="n3" class2="sy" length="0.16962" k="248864.31999999995"/>
+    <Bond class1="n4" class2="n4" length="0.1484" k="292796.31999999995"/>
+    <Bond class1="n4" class2="na" length="0.14350000000000002" k="340577.6"/>
+    <Bond class1="n4" class2="nh" length="0.1466" k="309364.95999999996"/>
+    <Bond class1="n4" class2="no" length="0.148" k="296394.55999999994"/>
+    <Bond class1="n4" class2="o" length="0.1361" k="387940.4799999999"/>
+    <Bond class1="n4" class2="oh" length="0.13999999999999999" k="341581.7599999999"/>
+    <Bond class1="n4" class2="os" length="0.1421" k="319490.24"/>
+    <Bond class1="n4" class2="p2" length="0.1942" k="155561.11999999997"/>
+    <Bond class1="n4" class2="p3" length="0.188" k="179995.67999999996"/>
+    <Bond class1="n4" class2="p4" length="0.1938" k="156983.67999999996"/>
+    <Bond class1="n4" class2="p5" length="0.18300000000000002" k="203258.71999999997"/>
+    <Bond class1="n4" class2="py" length="0.1902" k="170874.55999999997"/>
+    <Bond class1="n4" class2="s" length="0.18320000000000003" k="175979.03999999998"/>
+    <Bond class1="n4" class2="s4" length="0.19720000000000001" k="126356.79999999997"/>
+    <Bond class1="n4" class2="s6" length="0.19140000000000001" k="144515.35999999996"/>
+    <Bond class1="n4" class2="sh" length="0.1811" k="185351.19999999998"/>
+    <Bond class1="n4" class2="ss" length="0.18120000000000003" k="184932.79999999996"/>
+    <Bond class1="na" class2="na" length="0.1401" k="379321.43999999994"/>
+    <Bond class1="na" class2="nb" length="0.13472" k="452457.75999999995"/>
+    <Bond class1="na" class2="nc" length="0.13558" k="439654.7199999999"/>
+    <Bond class1="na" class2="nd" length="0.13541" k="442165.11999999994"/>
+    <Bond class1="na" class2="nh" length="0.13999999999999999" k="380576.63999999996"/>
+    <Bond class1="na" class2="no" length="0.14346" k="340995.99999999994"/>
+    <Bond class1="na" class2="o" length="0.12394000000000001" k="591115.5199999999"/>
+    <Bond class1="na" class2="oh" length="0.13925" k="349949.75999999995"/>
+    <Bond class1="na" class2="os" length="0.1444" k="297231.3599999999"/>
+    <Bond class1="na" class2="p2" length="0.17490000000000003" k="249199.03999999998"/>
+    <Bond class1="na" class2="p3" length="0.17620000000000002" k="240998.39999999994"/>
+    <Bond class1="na" class2="p4" length="0.1564" k="412040.3199999999"/>
+    <Bond class1="na" class2="p5" length="0.1715" k="272211.0399999999"/>
+    <Bond class1="na" class2="pc" length="0.17320000000000002" k="260328.47999999998"/>
+    <Bond class1="na" class2="pd" length="0.17320000000000002" k="260328.47999999998"/>
+    <Bond class1="na" class2="py" length="0.17120000000000002" k="274303.04"/>
+    <Bond class1="na" class2="s" length="0.1765" k="208112.15999999995"/>
+    <Bond class1="na" class2="s4" length="0.17930000000000001" k="193886.55999999997"/>
+    <Bond class1="na" class2="s6" length="0.17227" k="232128.31999999995"/>
+    <Bond class1="na" class2="sh" length="0.17210000000000003" k="233132.47999999998"/>
+    <Bond class1="na" class2="ss" length="0.17325000000000002" k="226270.71999999994"/>
+    <Bond class1="na" class2="sy" length="0.17270000000000002" k="229534.23999999996"/>
+    <Bond class1="nb" class2="nb" length="0.13335" k="473796.16"/>
+    <Bond class1="nb" class2="pb" length="0.1587" k="385848.4799999999"/>
+    <Bond class1="nc" class2="nc" length="0.13646" k="427102.71999999986"/>
+    <Bond class1="nc" class2="nd" length="0.12988" k="533459.9999999999"/>
+    <Bond class1="nc" class2="os" length="0.14013" k="340159.19999999995"/>
+    <Bond class1="nc" class2="ss" length="0.1626" k="301080.63999999996"/>
+    <Bond class1="nc" class2="sy" length="0.1555" k="368024.63999999996"/>
+    <Bond class1="nd" class2="nd" length="0.13646" k="427102.71999999986"/>
+    <Bond class1="nd" class2="os" length="0.14013" k="340159.19999999995"/>
+    <Bond class1="nd" class2="ss" length="0.1626" k="301080.63999999996"/>
+    <Bond class1="nd" class2="sy" length="0.1555" k="368024.63999999996"/>
+    <Bond class1="ne" class2="ne" length="0.14221999999999999" k="354552.1599999999"/>
+    <Bond class1="ne" class2="nf" length="0.12632000000000002" k="604504.3199999998"/>
+    <Bond class1="ne" class2="o" length="0.12307" k="610110.88"/>
+    <Bond class1="ne" class2="p2" length="0.1563" k="413295.51999999996"/>
+    <Bond class1="ne" class2="pe" length="0.17120000000000002" k="274303.04"/>
+    <Bond class1="ne" class2="px" length="0.17020000000000002" k="281666.88"/>
+    <Bond class1="ne" class2="py" length="0.16049000000000002" k="366853.11999999994"/>
+    <Bond class1="ne" class2="s" length="0.1537" k="387856.79999999993"/>
+    <Bond class1="ne" class2="sx" length="0.18380000000000002" k="173468.63999999998"/>
+    <Bond class1="ne" class2="sy" length="0.16723" k="265349.27999999997"/>
+    <Bond class1="nf" class2="nf" length="0.14221999999999999" k="354552.1599999999"/>
+    <Bond class1="nf" class2="o" length="0.12307" k="610110.88"/>
+    <Bond class1="nf" class2="p2" length="0.1563" k="413295.51999999996"/>
+    <Bond class1="nf" class2="pf" length="0.17120000000000002" k="274303.04"/>
+    <Bond class1="nf" class2="px" length="0.17020000000000002" k="281666.88"/>
+    <Bond class1="nf" class2="py" length="0.16049000000000002" k="366853.11999999994"/>
+    <Bond class1="nf" class2="s" length="0.1537" k="387856.79999999993"/>
+    <Bond class1="nf" class2="sx" length="0.18380000000000002" k="173468.63999999998"/>
+    <Bond class1="nf" class2="sy" length="0.16723" k="265349.27999999997"/>
+    <Bond class1="nh" class2="nh" length="0.14021999999999998" k="377898.88"/>
+    <Bond class1="nh" class2="no" length="0.13864" k="397647.3599999999"/>
+    <Bond class1="nh" class2="o" length="0.12628" k="543417.9199999998"/>
+    <Bond class1="nh" class2="oh" length="0.14162" k="324343.68"/>
+    <Bond class1="nh" class2="os" length="0.14153000000000002" k="325347.83999999997"/>
+    <Bond class1="nh" class2="p2" length="0.16790000000000002" k="299407.0399999999"/>
+    <Bond class1="nh" class2="p3" length="0.17300000000000001" k="261751.03999999995"/>
+    <Bond class1="nh" class2="p4" length="0.1706" k="278738.07999999996"/>
+    <Bond class1="nh" class2="p5" length="0.16710000000000003" k="305934.07999999996"/>
+    <Bond class1="nh" class2="s" length="0.1784" k="198321.59999999998"/>
+    <Bond class1="nh" class2="s4" length="0.17490000000000003" k="216814.88"/>
+    <Bond class1="nh" class2="s6" length="0.16975" k="248027.51999999996"/>
+    <Bond class1="nh" class2="sh" length="0.1708" k="241249.43999999994"/>
+    <Bond class1="nh" class2="ss" length="0.17091" k="240579.99999999997"/>
+    <Bond class1="nh" class2="sy" length="0.17141" k="237400.15999999995"/>
+    <Bond class1="n" class2="n1" length="0.134" k="463503.51999999996"/>
+    <Bond class1="n" class2="n2" length="0.13604000000000002" k="433043.99999999994"/>
+    <Bond class1="n" class2="n3" length="0.14042" k="375472.1599999999"/>
+    <Bond class1="n" class2="n4" length="0.1432" k="343757.44"/>
+    <Bond class1="n" class2="n" length="0.14043000000000003" k="375388.48"/>
+    <Bond class1="n" class2="na" length="0.14071" k="372041.27999999997"/>
+    <Bond class1="n" class2="nc" length="0.13599000000000003" k="433713.4399999999"/>
+    <Bond class1="n" class2="nd" length="0.13599000000000003" k="433713.4399999999"/>
+    <Bond class1="n" class2="nh" length="0.14016" k="378651.99999999994"/>
+    <Bond class1="n" class2="no" length="0.1456" k="318988.16"/>
+    <Bond class1="n" class2="o" length="0.12430000000000002" k="583416.9599999998"/>
+    <Bond class1="n" class2="oh" length="0.14062" k="334887.3599999999"/>
+    <Bond class1="no" class2="no" length="0.1824" k="115729.44"/>
+    <Bond class1="no" class2="o" length="0.1226" k="620738.2399999999"/>
+    <Bond class1="no" class2="oh" length="0.1406" k="335138.39999999997"/>
+    <Bond class1="no" class2="os" length="0.14211000000000001" k="319406.55999999994"/>
+    <Bond class1="no" class2="p2" length="0.1738" k="256311.83999999997"/>
+    <Bond class1="no" class2="p3" length="0.1844" k="196396.95999999996"/>
+    <Bond class1="no" class2="p4" length="0.18700000000000003" k="184430.71999999997"/>
+    <Bond class1="no" class2="p5" length="0.1834" k="201250.39999999997"/>
+    <Bond class1="no" class2="s" length="0.17420000000000002" k="220747.83999999997"/>
+    <Bond class1="n" class2="os" length="0.14089000000000002" k="332042.24"/>
+    <Bond class1="no" class2="s4" length="0.1996" k="119662.39999999998"/>
+    <Bond class1="no" class2="s6" length="0.1976" k="125185.27999999997"/>
+    <Bond class1="no" class2="sh" length="0.1804" k="188614.71999999997"/>
+    <Bond class1="no" class2="ss" length="0.18280000000000002" k="177736.31999999998"/>
+    <Bond class1="n" class2="p2" length="0.1733" k="259659.03999999995"/>
+    <Bond class1="n" class2="p3" length="0.17700000000000002" k="236144.95999999993"/>
+    <Bond class1="n" class2="p4" length="0.1734" k="258989.59999999998"/>
+    <Bond class1="n" class2="p5" length="0.17171000000000003" k="270704.8"/>
+    <Bond class1="n" class2="pc" length="0.17400000000000002" k="255056.63999999996"/>
+    <Bond class1="n" class2="pd" length="0.17400000000000002" k="255056.63999999996"/>
+    <Bond class1="n" class2="s" length="0.1767" k="207107.99999999994"/>
+    <Bond class1="n" class2="s4" length="0.17681000000000002" k="206522.23999999996"/>
+    <Bond class1="n" class2="s6" length="0.17186" k="234638.71999999997"/>
+    <Bond class1="n" class2="sh" length="0.1728" k="228948.47999999998"/>
+    <Bond class1="n" class2="ss" length="0.17259000000000002" k="230203.68"/>
+    <Bond class1="n" class2="sy" length="0.17163" k="236061.28"/>
+    <Bond class1="oh" class2="oh" length="0.1469" k="284930.39999999997"/>
+    <Bond class1="oh" class2="os" length="0.14555" k="296980.31999999995"/>
+    <Bond class1="oh" class2="p2" length="0.163" k="265098.24"/>
+    <Bond class1="oh" class2="p3" length="0.16770000000000002" k="233299.84"/>
+    <Bond class1="oh" class2="p4" length="0.16410000000000002" k="257232.31999999992"/>
+    <Bond class1="oh" class2="p5" length="0.16149000000000002" k="276478.7199999999"/>
+    <Bond class1="oh" class2="py" length="0.16162" k="275474.55999999994"/>
+    <Bond class1="oh" class2="s" length="0.18120000000000003" k="158991.99999999997"/>
+    <Bond class1="oh" class2="s4" length="0.16958" k="214220.79999999996"/>
+    <Bond class1="oh" class2="s6" length="0.16346000000000002" k="252797.28"/>
+    <Bond class1="oh" class2="sh" length="0.16920000000000002" k="216396.47999999998"/>
+    <Bond class1="oh" class2="ss" length="0.1688" k="218739.51999999996"/>
+    <Bond class1="oh" class2="sy" length="0.16497" k="242504.63999999998"/>
+    <Bond class1="o" class2="o" length="0.143" k="321582.23999999993"/>
+    <Bond class1="o" class2="oh" length="0.1517" k="246521.27999999997"/>
+    <Bond class1="o" class2="os" length="0.1504" k="256311.83999999997"/>
+    <Bond class1="o" class2="p2" length="0.15080000000000002" k="376308.95999999996"/>
+    <Bond class1="o" class2="p3" length="0.1515" k="368526.7199999999"/>
+    <Bond class1="o" class2="p4" length="0.15039000000000002" k="380911.3599999999"/>
+    <Bond class1="o" class2="p5" length="0.14866" k="401245.5999999999"/>
+    <Bond class1="o" class2="pe" length="0.1521" k="361999.68"/>
+    <Bond class1="o" class2="pf" length="0.1521" k="361999.68"/>
+    <Bond class1="o" class2="px" length="0.15035" k="381329.7599999999"/>
+    <Bond class1="o" class2="py" length="0.14875000000000002" k="400157.75999999995"/>
+    <Bond class1="o" class2="s" length="0.18020000000000003" k="163008.63999999998"/>
+    <Bond class1="o" class2="s2" length="0.15990000000000001" k="279156.48"/>
+    <Bond class1="o" class2="s4" length="0.15042" k="367438.87999999995"/>
+    <Bond class1="o" class2="s6" length="0.14533000000000001" k="429027.36"/>
+    <Bond class1="o" class2="sh" length="0.1605" k="274470.39999999997"/>
+    <Bond class1="os" class2="os" length="0.14653000000000002" k="288193.9199999999"/>
+    <Bond class1="os" class2="p2" length="0.1573" k="311205.9199999999"/>
+    <Bond class1="os" class2="p3" length="0.16744000000000003" k="234889.75999999992"/>
+    <Bond class1="os" class2="p4" length="0.1636" k="260746.87999999995"/>
+    <Bond class1="os" class2="p5" length="0.16147" k="276646.07999999996"/>
+    <Bond class1="os" class2="py" length="0.16185000000000002" k="273717.27999999997"/>
+    <Bond class1="os" class2="s" length="0.18000000000000002" k="163845.43999999997"/>
+    <Bond class1="o" class2="ss" length="0.15068" k="364593.75999999995"/>
+    <Bond class1="os" class2="s4" length="0.16922" k="216312.79999999996"/>
+    <Bond class1="os" class2="s6" length="0.16225" k="261416.31999999995"/>
+    <Bond class1="os" class2="sh" length="0.16710000000000003" k="228948.47999999998"/>
+    <Bond class1="os" class2="ss" length="0.1704" k="209618.39999999997"/>
+    <Bond class1="os" class2="sy" length="0.16990000000000002" k="212463.52"/>
+    <Bond class1="o" class2="sx" length="0.15129" k="358066.7199999999"/>
+    <Bond class1="o" class2="sy" length="0.1466" k="412542.3999999999"/>
+    <Bond class1="p2" class2="p2" length="0.1786" k="410283.0399999999"/>
+    <Bond class1="p2" class2="p3" length="0.21520000000000003" k="177317.91999999998"/>
+    <Bond class1="p2" class2="p4" length="0.21789999999999998" k="167694.71999999997"/>
+    <Bond class1="p2" class2="p5" length="0.21800000000000003" k="167276.31999999998"/>
+    <Bond class1="p2" class2="pe" length="0.1867" k="336058.88"/>
+    <Bond class1="p2" class2="pf" length="0.1867" k="336058.88"/>
+    <Bond class1="p2" class2="s" length="0.17720000000000002" k="302586.87999999995"/>
+    <Bond class1="p2" class2="s4" length="0.219" k="116649.92"/>
+    <Bond class1="p2" class2="s6" length="0.21800000000000003" k="119076.64"/>
+    <Bond class1="p2" class2="sh" length="0.19710000000000003" k="187443.19999999995"/>
+    <Bond class1="p2" class2="ss" length="0.1966" k="189618.87999999998"/>
+    <Bond class1="p3" class2="p3" length="0.2214" k="156063.19999999998"/>
+    <Bond class1="p3" class2="p4" length="0.22160000000000002" k="155393.75999999998"/>
+    <Bond class1="p3" class2="p5" length="0.22130000000000002" k="156397.91999999998"/>
+    <Bond class1="p3" class2="s" length="0.207" k="150372.95999999996"/>
+    <Bond class1="p3" class2="s4" length="0.20870000000000002" k="144933.75999999998"/>
+    <Bond class1="p3" class2="s6" length="0.2077" k="148029.91999999998"/>
+    <Bond class1="p3" class2="sh" length="0.21320000000000003" k="131628.63999999998"/>
+    <Bond class1="p3" class2="ss" length="0.2121" k="134724.8"/>
+    <Bond class1="p4" class2="p4" length="0.2034" k="228530.08"/>
+    <Bond class1="p4" class2="p5" length="0.2237" k="148950.4"/>
+    <Bond class1="p4" class2="s" length="0.2146" k="127779.35999999997"/>
+    <Bond class1="p4" class2="s4" length="0.2251" k="103093.75999999998"/>
+    <Bond class1="p4" class2="s6" length="0.22690000000000002" k="99495.51999999999"/>
+    <Bond class1="p4" class2="sh" length="0.21150000000000002" k="136482.07999999996"/>
+    <Bond class1="p4" class2="ss" length="0.21040000000000003" k="139745.59999999998"/>
+    <Bond class1="p5" class2="p5" length="0.2054" k="218739.51999999996"/>
+    <Bond class1="p5" class2="s" length="0.19341" k="204095.51999999996"/>
+    <Bond class1="p5" class2="s4" length="0.20400000000000001" k="160581.91999999998"/>
+    <Bond class1="p5" class2="s6" length="0.20400000000000001" k="160581.91999999998"/>
+    <Bond class1="p5" class2="sh" length="0.2082" k="146439.99999999997"/>
+    <Bond class1="p5" class2="ss" length="0.21176" k="135728.96"/>
+    <Bond class1="pe" class2="pe" length="0.20920000000000002" k="201417.75999999995"/>
+    <Bond class1="pe" class2="pf" length="0.20550000000000002" k="218237.43999999997"/>
+    <Bond class1="pe" class2="px" length="0.2005" k="243843.51999999993"/>
+    <Bond class1="pe" class2="py" length="0.2025" k="233132.47999999998"/>
+    <Bond class1="pe" class2="s" length="0.1758" k="313548.9599999999"/>
+    <Bond class1="pe" class2="sx" length="0.21680000000000002" k="122089.11999999998"/>
+    <Bond class1="pe" class2="sy" length="0.22130000000000002" k="111294.39999999998"/>
+    <Bond class1="pf" class2="pf" length="0.20920000000000002" k="201417.75999999995"/>
+    <Bond class1="pf" class2="px" length="0.2005" k="243843.51999999993"/>
+    <Bond class1="pf" class2="py" length="0.2025" k="233132.47999999998"/>
+    <Bond class1="pf" class2="s" length="0.1758" k="313548.9599999999"/>
+    <Bond class1="pf" class2="sx" length="0.21680000000000002" k="122089.11999999998"/>
+    <Bond class1="pf" class2="sy" length="0.22130000000000002" k="111294.39999999998"/>
+    <Bond class1="px" class2="py" length="0.21989999999999998" k="160916.63999999998"/>
+    <Bond class1="px" class2="sx" length="0.2242" k="104934.72"/>
+    <Bond class1="px" class2="sy" length="0.22490000000000002" k="103512.16"/>
+    <Bond class1="py" class2="py" length="0.21860000000000002" k="165267.99999999997"/>
+    <Bond class1="py" class2="sx" length="0.2259" k="101420.15999999999"/>
+    <Bond class1="py" class2="sy" length="0.2182" k="118574.55999999997"/>
+    <Bond class1="s4" class2="s4" length="0.20800000000000002" k="126775.19999999997"/>
+    <Bond class1="s4" class2="s6" length="0.20800000000000002" k="126775.19999999997"/>
+    <Bond class1="s4" class2="sh" length="0.21680000000000002" k="105185.75999999998"/>
+    <Bond class1="s4" class2="ss" length="0.21660000000000001" k="105604.15999999997"/>
+    <Bond class1="s6" class2="s6" length="0.20800000000000002" k="126775.19999999997"/>
+    <Bond class1="s6" class2="sh" length="0.21080000000000002" k="119327.68"/>
+    <Bond class1="s6" class2="ss" length="0.2118" k="116817.27999999998"/>
+    <Bond class1="sh" class2="sh" length="0.20579999999999998" k="132967.52"/>
+    <Bond class1="sh" class2="ss" length="0.20670000000000002" k="130373.43999999997"/>
+    <Bond class1="s" class2="s" length="0.20299999999999999" k="141419.19999999998"/>
+    <Bond class1="s" class2="s2" length="0.1897" k="191794.55999999997"/>
+    <Bond class1="s" class2="s4" length="0.2076" k="127863.04"/>
+    <Bond class1="s" class2="s6" length="0.20379999999999998" k="138908.79999999996"/>
+    <Bond class1="s" class2="sh" length="0.211" k="118825.59999999999"/>
+    <Bond class1="s" class2="ss" length="0.2089" k="124264.79999999999"/>
+    <Bond class1="ss" class2="ss" length="0.20728000000000002" k="128699.84"/>
+    <Bond class1="sx" class2="sx" length="0.2391" k="67697.12"/>
+    <Bond class1="sx" class2="sy" length="0.2255" k="88115.03999999998"/>
+    <Bond class1="sy" class2="sy" length="0.225" k="89035.51999999999"/>
+    <Bond class1="br" class2="cd" length="0.1885" k="232128.31999999995"/>
+    <Bond class1="c1" class2="cf" length="0.13153" k="508272.31999999995"/>
+    <Bond class1="cd" class2="f" length="0.13407" k="307775.04"/>
+    <Bond class1="cd" class2="n4" length="0.14930000000000002" k="250203.19999999995"/>
+    <Bond class1="cd" class2="nf" length="0.13786" k="358150.39999999997"/>
+    <Bond class1="cd" class2="no" length="0.14289000000000002" k="304762.55999999994"/>
+    <Bond class1="cd" class2="sh" length="0.17693000000000003" k="215141.27999999997"/>
+    <Bond class1="cd" class2="sx" length="0.18107" k="193886.55999999997"/>
+    <Bond class1="cc" class2="cy" length="0.1494" k="286687.68"/>
+    <Bond class1="cf" class2="cl" length="0.17641" k="246772.31999999995"/>
+    <Bond class1="cf" class2="cx" length="0.15000000000000002" k="281499.5199999999"/>
+    <Bond class1="cf" class2="cy" length="0.15159" k="268361.75999999995"/>
+    <Bond class1="cf" class2="na" length="0.14209000000000002" k="312628.48"/>
+    <Bond class1="cf" class2="ss" length="0.17814000000000002" k="208614.24"/>
+    <Bond class1="cq" class2="na" length="0.1384" k="351874.39999999997"/>
+    <Bond class1="cq" class2="nb" length="0.13387000000000002" k="408776.79999999993"/>
+    <Bond class1="cl" class2="py" length="0.20450000000000002" k="192212.95999999996"/>
+    <Bond class1="f" class2="py" length="0.1577" k="213551.35999999993"/>
+    <Bond class1="py" class2="s" length="0.19730000000000003" k="186606.39999999997"/>
+    <Bond class1="cy" class2="nh" length="0.1446" k="288947.04"/>
+    <Bond class1="cy" class2="hx" length="0.1091" k="283424.1599999999"/>
+    <Bond class1="br" class2="ce" length="0.1905" k="221333.59999999998"/>
+    <Bond class1="cc" class2="i" length="0.21200000000000002" k="200246.23999999996"/>
+    <Bond class1="cy" class2="n4" length="0.1516" k="233550.87999999998"/>
+    <Bond class1="cy" class2="p3" length="0.1908" k="172715.52"/>
+    <Bond class1="cy" class2="na" length="0.1446" k="288947.04"/>
+    <Bond class1="cx" class2="n4" length="0.1505" k="241333.11999999997"/>
+    <Bond class1="ne" class2="s4" length="0.166" k="274303.04"/>
+    <Bond class1="cv" class2="ss" length="0.1724" k="241751.51999999993"/>
+    <Bond class1="cy" class2="no" length="0.1519" k="231458.88"/>
+    <Bond class1="ce" class2="cv" length="0.136" k="437562.7199999999"/>
+    <Bond class1="cd" class2="i" length="0.21150000000000002" k="202338.24"/>
+    <Bond class1="cy" class2="s4" length="0.19130000000000003" k="151377.12"/>
+    <Bond class1="n2" class2="sy" length="0.1544" k="379990.87999999995"/>
+    <Bond class1="cc" class2="s6" length="0.1814" k="192296.63999999998"/>
+    <Bond class1="i" class2="s2" length="0.2883" k="67864.48"/>
+    <Bond class1="br" class2="cy" length="0.19510000000000002" k="198823.67999999996"/>
+    <Bond class1="br" class2="cf" length="0.1905" k="221333.59999999998"/>
+    <Bond class1="nf" class2="s4" length="0.166" k="274303.04"/>
+    <Bond class1="cf" class2="cv" length="0.136" k="437311.68"/>
+    <Bond class1="cd" class2="s6" length="0.1814" k="192296.63999999998"/>
+    <Bond class1="cx" class2="op" length="0.14370000000000002" k="253717.75999999995"/>
+    <Bond class1="c" class2="nj" length="0.1401" k="333130.07999999996"/>
+    <Bond class1="cy" class2="nj" length="0.14750000000000002" k="264261.44"/>
+    <Bond class1="ce" class2="nj" length="0.14250000000000002" k="308611.83999999997"/>
+    <Bond class1="cx" class2="np" length="0.147" k="268278.08"/>
+    <Bond class1="cx" class2="nm" length="0.14550000000000002" k="280997.43999999994"/>
+    <Bond class1="c3" class2="nj" length="0.1452" k="283591.51999999996"/>
+    <Bond class1="np" class2="p5" length="0.17020000000000002" k="281666.88"/>
+    <Bond class1="cy" class2="nq" length="0.1482" k="258654.88"/>
+    <Bond class1="cy" class2="oq" length="0.146" k="236228.63999999998"/>
+    <Bond class1="cc" class2="nm" length="0.14150000000000001" k="318569.75999999995"/>
+    <Bond class1="c3" class2="np" length="0.1462" k="274972.48"/>
+    <Bond class1="c3" class2="nq" length="0.14550000000000002" k="280997.43999999994"/>
+    <Bond class1="ca" class2="nm" length="0.1382" k="354217.43999999994"/>
+    <Bond class1="cy" class2="sq" length="0.1849" k="176397.43999999997"/>
+    <Bond class1="c" class2="oq" length="0.1373" k="311456.9599999999"/>
+    <Bond class1="p5" class2="sq" length="0.217" k="121587.04000000001"/>
+    <Bond class1="cf" class2="nj" length="0.1418" k="315557.27999999997"/>
+    <Bond class1="cy" class2="nn" length="0.14780000000000001" k="261834.7199999999"/>
+    <Bond class1="nj" class2="s6" length="0.17250000000000001" k="230789.43999999997"/>
+    <Bond class1="cd" class2="nm" length="0.13720000000000002" k="366016.31999999995"/>
+    <Bond class1="hn" class2="np" length="0.1021" k="325515.19999999995"/>
+    <Bond class1="hn" class2="nq" length="0.1018" k="329782.87999999995"/>
+    <Bond class1="cx" class2="nk" length="0.1496" k="247943.83999999994"/>
+    <Bond class1="c3" class2="nk" length="0.1506" k="240663.67999999996"/>
+    <Bond class1="cy" class2="nl" length="0.1524" k="228111.68"/>
+    <Bond class1="ca" class2="nn" length="0.1375" k="362418.07999999996"/>
+    <Bond class1="cx" class2="ni" length="0.14870000000000003" k="254805.59999999995"/>
+    <Bond class1="cv" class2="sq" length="0.1761" k="219743.68"/>
+    <Bond class1="np" class2="py" length="0.17" k="283173.11999999994"/>
+    <Bond class1="cx" class2="nj" length="0.1448" k="287106.07999999996"/>
+    <Bond class1="nq" class2="p5" length="0.1734" k="258989.59999999998"/>
+    <Bond class1="hn" class2="nj" length="0.1013" k="337230.39999999997"/>
+    <Bond class1="c2" class2="nm" length="0.1403" k="330954.39999999997"/>
+    <Bond class1="ca" class2="nj" length="0.1406" k="327858.23999999993"/>
+    <Bond class1="c" class2="ni" length="0.1433" k="300913.27999999997"/>
+    <Bond class1="cy" class2="n2" length="0.1424" k="309615.99999999994"/>
+    <Bond class1="op" class2="p5" length="0.16180000000000003" k="274135.68"/>
+    <Bond class1="cx" class2="sp" length="0.1824" k="187610.55999999994"/>
+    <Bond class1="hn" class2="nl" length="0.1048" k="289449.11999999994"/>
+    <Bond class1="nn" class2="p5" length="0.1665" k="310954.88"/>
+    <Bond class1="nj" class2="p5" length="0.1763" k="240412.63999999996"/>
+    <Bond class1="cc" class2="sq" length="0.1777" k="210957.27999999994"/>
+    <Bond class1="c2" class2="cv" length="0.1333" k="478816.9599999999"/>
+    <Bond class1="c1" class2="cy" length="0.1464" k="314051.04"/>
+    <Bond class1="cy" class2="i" length="0.2191" k="172631.83999999997"/>
+    <Bond class1="oq" class2="p5" length="0.1694" k="222923.51999999996"/>
+    <Bond class1="cy" class2="py" length="0.1937" k="161335.04"/>
+    <Bond class1="nj" class2="os" length="0.1398" k="343841.11999999994"/>
+    <Bond class1="op" class2="op" length="0.1597" k="195643.84"/>
+    <Bond class1="cy" class2="p5" length="0.18910000000000002" k="179828.31999999998"/>
+    <Bond class1="cy" class2="sx" length="0.18620000000000003" k="170958.24"/>
+    <Bond class1="cx" class2="i" length="0.2187" k="174054.39999999997"/>
+    <Bond class1="cx" class2="no" length="0.1499" k="245768.15999999995"/>
+    <Bond class1="ce" class2="cu" length="0.1307" k="523251.0399999999"/>
+    <Bond class1="np" class2="sy" length="0.1734" k="225433.91999999995"/>
+    <Bond class1="cl" class2="nj" length="0.17250000000000001" k="279825.9199999999"/>
+    <Bond class1="np" class2="s6" length="0.1795" k="192966.08"/>
+    <Bond class1="np" class2="op" length="0.1481" k="265265.5999999999"/>
+    <Bond class1="cl" class2="np" length="0.1794" k="234555.03999999995"/>
+    <Bond class1="cx" class2="p5" length="0.1837" k="204848.63999999998"/>
+    <Bond class1="cl" class2="cv" length="0.1738" k="263926.7199999999"/>
+    <Bond class1="cv" class2="nh" length="0.1369" k="369614.55999999994"/>
+    <Bond class1="nq" class2="s4" length="0.1734" k="225433.91999999995"/>
+    <Bond class1="c3" class2="nl" length="0.15080000000000002" k="239241.11999999997"/>
+    <Bond class1="np" class2="p3" length="0.1757" k="244094.55999999994"/>
+    <Bond class1="cu" class2="f" length="0.13140000000000002" k="336979.3599999999"/>
+    <Bond class1="c" class2="sq" length="0.1825" k="187108.47999999998"/>
+    <Bond class1="cu" class2="os" length="0.13340000000000002" k="354635.83999999997"/>
+    <Bond class1="cy" class2="sh" length="0.1837" k="181669.27999999997"/>
+    <Bond class1="cv" class2="oq" length="0.1446" k="246688.63999999998"/>
+    <Bond class1="cu" class2="cv" length="0.131" k="517895.51999999996"/>
+    <Bond class1="c1" class2="nj" length="0.13460000000000003" k="398902.55999999994"/>
+    <Bond class1="cu" class2="ne" length="0.127" k="518146.55999999994"/>
+    <Bond class1="cu" class2="op" length="0.1321" k="370618.7199999999"/>
+    <Bond class1="s6" class2="sp" length="0.20779999999999998" k="127277.27999999997"/>
+    <Bond class1="sp" class2="sp" length="0.21240000000000003" k="115311.03999999998"/>
+    <Bond class1="cv" class2="ne" length="0.1255" k="546597.7599999999"/>
+    <Bond class1="op" class2="s6" length="0.16200000000000003" k="263173.5999999999"/>
+    <Bond class1="op" class2="sp" length="0.18620000000000003" k="140666.08"/>
+    <Bond class1="c1" class2="cv" length="0.13060000000000002" k="525008.32"/>
+    <Bond class1="n2" class2="nj" length="0.1379" k="407354.23999999993"/>
+    <Bond class1="nq" class2="nq" length="0.1494" k="284093.6"/>
+    <Bond class1="cv" class2="p3" length="0.18080000000000002" k="220078.39999999997"/>
+    <Bond class1="cv" class2="p5" length="0.16810000000000003" k="305348.31999999995"/>
+    <Bond class1="np" class2="os" length="0.14350000000000002" k="305683.04"/>
+    <Bond class1="nj" class2="nq" length="0.1459" k="316059.3599999999"/>
+    <Bond class1="no" class2="nq" length="0.1353" k="443838.7199999999"/>
+    <Bond class1="cy" class2="sy" length="0.18500000000000003" k="175979.03999999998"/>
+    <Bond class1="ce" class2="nm" length="0.1399" k="335222.07999999996"/>
+    <Bond class1="cv" class2="os" length="0.1368" k="316645.11999999994"/>
+    <Bond class1="cy" class2="n1" length="0.14270000000000002" k="306687.19999999995"/>
+    <Bond class1="c" class2="op" length="0.1325" k="365597.9199999999"/>
+    <Bond class1="cv" class2="n2" length="0.1272" k="514464.63999999984"/>
+    <Bond class1="cx" class2="oq" length="0.1436" k="254554.55999999994"/>
+    <Bond class1="cx" class2="n1" length="0.1392" k="342920.63999999996"/>
+  </HarmonicBondForce>
+  <HarmonicAngleForce>
+    <Angle class1="hw" class2="ow" class3="hw" angle="1.8242181341844732" k="836.8000000000001"/>
+    <Angle class1="hw" class2="hw" class3="ow" angle="2.2294835864975564" k="0.0"/>
+    <Angle class1="br" class2="c1" class3="br" angle="3.141592653589793" k="483.6704"/>
+    <Angle class1="br" class2="c1" class3="c1" angle="3.141592653589793" k="459.4032"/>
+    <Angle class1="c1" class2="c1" class3="c1" angle="3.141592653589793" k="531.368"/>
+    <Angle class1="c1" class2="c1" class3="c2" angle="3.141592653589793" k="506.264"/>
+    <Angle class1="c1" class2="c1" class3="c3" angle="3.115587247735078" k="470.2816"/>
+    <Angle class1="c1" class2="c1" class3="ca" angle="3.141592653589793" k="474.46560000000005"/>
+    <Angle class1="c1" class2="c1" class3="cl" angle="3.141592653589793" k="429.2784"/>
+    <Angle class1="c1" class2="c1" class3="f" angle="3.141592653589793" k="507.10080000000005"/>
+    <Angle class1="c1" class2="c1" class3="ha" angle="3.126059223247044" k="370.7024"/>
+    <Angle class1="c1" class2="c1" class3="hc" angle="3.141592653589793" k="370.7024"/>
+    <Angle class1="c1" class2="c1" class3="i" angle="3.141592653589793" k="417.5632"/>
+    <Angle class1="c1" class2="c1" class3="n1" angle="3.141592653589793" k="553.9616000000001"/>
+    <Angle class1="c1" class2="c1" class3="n2" angle="3.141592653589793" k="544.7568"/>
+    <Angle class1="c1" class2="c1" class3="n3" angle="3.141592653589793" k="508.7744"/>
+    <Angle class1="c1" class2="c1" class3="n4" angle="3.133913204881018" k="492.03839999999997"/>
+    <Angle class1="c1" class2="c1" class3="n" angle="3.0923743686835534" k="517.1424"/>
+    <Angle class1="c1" class2="c1" class3="na" angle="3.0848694528999774" k="509.6112"/>
+    <Angle class1="c1" class2="c1" class3="nh" angle="3.128851750050235" k="511.2848"/>
+    <Angle class1="c1" class2="c1" class3="no" angle="3.141592653589793" k="494.5488"/>
+    <Angle class1="c1" class2="c1" class3="o" angle="3.141592653589793" k="553.1247999999999"/>
+    <Angle class1="c1" class2="c1" class3="oh" angle="3.083124123647983" k="522.1632"/>
+    <Angle class1="c1" class2="c1" class3="os" angle="3.0880110455535674" k="523.0"/>
+    <Angle class1="c1" class2="c1" class3="p2" angle="3.141592653589793" k="545.5936"/>
+    <Angle class1="c1" class2="c1" class3="p3" angle="2.960602010157981" k="555.6352"/>
+    <Angle class1="c1" class2="c1" class3="p4" angle="3.141592653589793" k="539.736"/>
+    <Angle class1="c1" class2="c1" class3="p5" angle="3.0747465432384105" k="556.472"/>
+    <Angle class1="c1" class2="c1" class3="s4" angle="2.9229028983149035" k="452.70880000000005"/>
+    <Angle class1="c1" class2="c1" class3="s6" angle="3.0435051496277117" k="449.36160000000007"/>
+    <Angle class1="c1" class2="c1" class3="s" angle="3.141069054814195" k="471.9552"/>
+    <Angle class1="c1" class2="c1" class3="sh" angle="3.141592653589793" k="452.70880000000005"/>
+    <Angle class1="c1" class2="c1" class3="ss" angle="3.0647981665020425" k="456.05600000000004"/>
+    <Angle class1="c2" class2="c1" class3="c2" angle="3.130597079302229" k="487.8544"/>
+    <Angle class1="c2" class2="c1" class3="ce" angle="3.125012025695847" k="487.0176"/>
+    <Angle class1="c2" class2="c1" class3="n1" angle="3.141592653589793" k="526.3472"/>
+    <Angle class1="c2" class2="c1" class3="o" angle="3.132866007329821" k="526.3472"/>
+    <Angle class1="c2" class2="c1" class3="s2" angle="3.0190705400997913" k="474.46560000000005"/>
+    <Angle class1="c3" class2="c1" class3="c3" angle="3.141592653589793" k="434.2992"/>
+    <Angle class1="c3" class2="c1" class3="cg" angle="3.114190984333482" k="468.608"/>
+    <Angle class1="c3" class2="c1" class3="n1" angle="3.1168089782114734" k="485.344"/>
+    <Angle class1="ca" class2="c1" class3="ca" angle="3.141592653589793" k="441.8304"/>
+    <Angle class1="c" class2="c1" class3="c1" angle="3.141592653589793" k="469.44480000000004"/>
+    <Angle class1="cg" class2="c1" class3="ha" angle="3.12117230134146" k="367.3552"/>
+    <Angle class1="ch" class2="c1" class3="ha" angle="3.12117230134146" k="367.3552"/>
+    <Angle class1="cl" class2="c1" class3="cl" angle="3.141592653589793" k="389.9488"/>
+    <Angle class1="f" class2="c1" class3="f" angle="3.141592653589793" k="487.0176"/>
+    <Angle class1="i" class2="c1" class3="i" angle="3.141592653589793" k="446.8512"/>
+    <Angle class1="n1" class2="c1" class3="n1" angle="1.7804103699594158" k="769.856"/>
+    <Angle class1="n1" class2="c1" class3="n3" angle="3.0719540164352193" k="533.8783999999999"/>
+    <Angle class1="n1" class2="c1" class3="nh" angle="3.1005774161679263" k="533.0416"/>
+    <Angle class1="n1" class2="c1" class3="os" angle="3.1169835111366733" k="541.4096000000001"/>
+    <Angle class1="n1" class2="c1" class3="p3" angle="2.988003679414292" k="566.5136"/>
+    <Angle class1="n1" class2="c1" class3="ss" angle="3.097435823514336" k="465.2608"/>
+    <Angle class1="n2" class2="c1" class3="n2" angle="3.141592653589793" k="558.1456000000001"/>
+    <Angle class1="n2" class2="c1" class3="o" angle="3.014707216969805" k="579.0656"/>
+    <Angle class1="n2" class2="c1" class3="s" angle="3.070208687183225" k="488.6912"/>
+    <Angle class1="n3" class2="c1" class3="n3" angle="3.141592653589793" k="495.38560000000007"/>
+    <Angle class1="n4" class2="c1" class3="n4" angle="3.141592653589793" k="471.9552"/>
+    <Angle class1="na" class2="c1" class3="na" angle="3.141592653589793" k="490.36480000000006"/>
+    <Angle class1="ne" class2="c1" class3="o" angle="3.0077258999618284" k="578.2288"/>
+    <Angle class1="ne" class2="c1" class3="s" angle="3.06863789085643" k="488.6912"/>
+    <Angle class1="nf" class2="c1" class3="o" angle="3.0077258999618284" k="578.2288"/>
+    <Angle class1="nh" class2="c1" class3="nh" angle="3.141592653589793" k="497.896"/>
+    <Angle class1="n" class2="c1" class3="n" angle="3.141592653589793" k="502.08000000000004"/>
+    <Angle class1="no" class2="c1" class3="no" angle="3.141592653589793" k="475.3024"/>
+    <Angle class1="oh" class2="c1" class3="oh" angle="3.141592653589793" k="509.6112"/>
+    <Angle class1="o" class2="c1" class3="o" angle="3.141592653589793" k="576.5552"/>
+    <Angle class1="os" class2="c1" class3="os" angle="3.141592653589793" k="512.9584"/>
+    <Angle class1="p2" class2="c1" class3="p2" angle="3.141592653589793" k="674.4608"/>
+    <Angle class1="p3" class2="c1" class3="p3" angle="3.141592653589793" k="666.9296"/>
+    <Angle class1="p4" class2="c1" class3="p4" angle="3.141592653589793" k="666.9296"/>
+    <Angle class1="p5" class2="c1" class3="p5" angle="3.141592653589793" k="681.1552"/>
+    <Angle class1="s2" class2="c1" class3="s2" angle="3.141592653589793" k="466.9344"/>
+    <Angle class1="s4" class2="c1" class3="s4" angle="3.141592653589793" k="426.76800000000003"/>
+    <Angle class1="s6" class2="c1" class3="s6" angle="3.141592653589793" k="432.6256"/>
+    <Angle class1="sh" class2="c1" class3="sh" angle="3.141592653589793" k="443.504"/>
+    <Angle class1="s" class2="c1" class3="s" angle="3.141592653589793" k="464.42400000000004"/>
+    <Angle class1="ss" class2="c1" class3="ss" angle="3.141592653589793" k="440.9936"/>
+    <Angle class1="br" class2="c2" class3="br" angle="2.0081758373446754" k="570.6976000000001"/>
+    <Angle class1="br" class2="c2" class3="c2" angle="2.112371993688737" k="528.0208"/>
+    <Angle class1="br" class2="c2" class3="c3" angle="2.0127136933998604" k="530.5312"/>
+    <Angle class1="br" class2="c2" class3="ce" angle="2.1210986399487086" k="526.3472"/>
+    <Angle class1="br" class2="c2" class3="h4" angle="1.9849629582931512" k="358.1504"/>
+    <Angle class1="br" class2="c2" class3="ha" angle="1.9771089766591763" k="358.98720000000003"/>
+    <Angle class1="c1" class2="c2" class3="c1" angle="2.038020967553779" k="605.0064"/>
+    <Angle class1="c1" class2="c2" class3="c2" angle="2.122669436275504" k="586.5968"/>
+    <Angle class1="c1" class2="c2" class3="c3" angle="2.179916235740918" k="537.2256000000001"/>
+    <Angle class1="c1" class2="c2" class3="f" angle="2.179916235740918" k="569.024"/>
+    <Angle class1="c1" class2="c2" class3="ha" angle="2.1017254852515714" k="423.42080000000004"/>
+    <Angle class1="c2" class2="c2" class3="c2" angle="2.125985561854293" k="579.9024"/>
+    <Angle class1="c2" class2="c2" class3="c3" angle="2.1577505542405895" k="536.3888"/>
+    <Angle class1="c2" class2="c2" class3="ca" angle="2.0420352248333655" k="580.7392000000001"/>
+    <Angle class1="c2" class2="c2" class3="cc" angle="2.0457004162625534" k="585.76"/>
+    <Angle class1="c2" class2="c2" class3="cd" angle="2.0457004162625534" k="585.76"/>
+    <Angle class1="c2" class2="c2" class3="cl" angle="2.148674842130219" k="485.344"/>
+    <Angle class1="c2" class2="c2" class3="cx" angle="2.1783454394141226" k="538.8992000000001"/>
+    <Angle class1="c2" class2="c2" class3="cy" angle="2.067167966062084" k="547.2672000000001"/>
+    <Angle class1="c2" class2="c2" class3="f" angle="2.1444860519254325" k="568.1872000000001"/>
+    <Angle class1="c2" class2="c2" class3="h4" angle="2.140995393421444" k="413.3792"/>
+    <Angle class1="c2" class2="c2" class3="ha" angle="2.101900018176771" k="417.5632"/>
+    <Angle class1="c2" class2="c2" class3="hc" angle="2.0891591146372126" k="418.40000000000003"/>
+    <Angle class1="c2" class2="c2" class3="hx" angle="2.2069688391468296" k="407.52160000000003"/>
+    <Angle class1="c2" class2="c2" class3="i" angle="2.112371993688737" k="466.9344"/>
+    <Angle class1="c2" class2="c2" class3="n1" angle="2.1464059141026266" k="597.4752000000001"/>
+    <Angle class1="c2" class2="c2" class3="n2" angle="2.1992893904380546" k="595.8016"/>
+    <Angle class1="c2" class2="c2" class3="n3" angle="2.173807583358937" k="586.5968"/>
+    <Angle class1="c2" class2="c2" class3="n4" angle="2.120924107023509" k="553.1247999999999"/>
+    <Angle class1="c2" class2="c2" class3="n" angle="2.158448685941387" k="574.8816"/>
+    <Angle class1="c2" class2="c2" class3="na" angle="2.1282544898818854" k="578.2288"/>
+    <Angle class1="c2" class2="c2" class3="nh" angle="2.181487032067712" k="574.8816"/>
+    <Angle class1="c2" class2="c2" class3="no" angle="2.1547834945121993" k="564.0032000000001"/>
+    <Angle class1="c2" class2="c2" class3="o" angle="2.2844614579353775" k="599.1487999999999"/>
+    <Angle class1="c2" class2="c2" class3="oh" angle="2.1322687471614725" k="595.8016"/>
+    <Angle class1="c2" class2="c2" class3="os" angle="2.1270327594054894" k="591.6176"/>
+    <Angle class1="c2" class2="c2" class3="p2" angle="2.008873969045473" k="707.9327999999999"/>
+    <Angle class1="c2" class2="c2" class3="p3" angle="2.1786945052645215" k="628.4368"/>
+    <Angle class1="c2" class2="c2" class3="p4" angle="2.090206312188409" k="646.0096000000001"/>
+    <Angle class1="c2" class2="c2" class3="p5" angle="2.198591258737257" k="617.5584"/>
+    <Angle class1="c2" class2="c2" class3="s4" angle="2.0916025755900045" k="525.5104"/>
+    <Angle class1="c2" class2="c2" class3="s6" angle="2.094569635318395" k="524.6736000000001"/>
+    <Angle class1="c2" class2="c2" class3="s" angle="2.2579324533050644" k="512.1216000000001"/>
+    <Angle class1="c2" class2="c2" class3="sh" angle="2.193878869756872" k="507.10080000000005"/>
+    <Angle class1="c2" class2="c2" class3="ss" angle="2.135410339815062" k="525.5104"/>
+    <Angle class1="c3" class2="c2" class3="c3" angle="2.018473279931442" k="526.3472"/>
+    <Angle class1="c3" class2="c2" class3="cc" angle="2.184977690571701" k="528.8576"/>
+    <Angle class1="c3" class2="c2" class3="cd" angle="2.184977690571701" k="528.8576"/>
+    <Angle class1="c3" class2="c2" class3="ce" angle="2.1493729738310168" k="535.552"/>
+    <Angle class1="c3" class2="c2" class3="cf" angle="2.1493729738310168" k="535.552"/>
+    <Angle class1="c3" class2="c2" class3="h4" angle="2.077290875723651" k="379.0704"/>
+    <Angle class1="c3" class2="c2" class3="ha" angle="2.0189968787070405" k="384.0912"/>
+    <Angle class1="c3" class2="c2" class3="hc" angle="2.0943951023931953" k="377.39680000000004"/>
+    <Angle class1="c3" class2="c2" class3="n2" angle="2.154259895736601" k="556.472"/>
+    <Angle class1="c3" class2="c2" class3="n" angle="2.0036379812894904" k="559.8192"/>
+    <Angle class1="c3" class2="c2" class3="na" angle="2.0455258833373544" k="553.9616000000001"/>
+    <Angle class1="c3" class2="c2" class3="ne" angle="2.106786940082355" k="561.4928"/>
+    <Angle class1="c3" class2="c2" class3="nf" angle="2.106786940082355" k="561.4928"/>
+    <Angle class1="c3" class2="c2" class3="nh" angle="2.0282471237426103" k="558.1456000000001"/>
+    <Angle class1="c3" class2="c2" class3="o" angle="2.1436133872994354" k="568.1872000000001"/>
+    <Angle class1="c3" class2="c2" class3="oh" angle="2.0099211665966696" k="571.5344"/>
+    <Angle class1="c3" class2="c2" class3="os" angle="1.9687313962496038" k="574.8816"/>
+    <Angle class1="c3" class2="c2" class3="p2" angle="2.14221712389784" k="661.072"/>
+    <Angle class1="c3" class2="c2" class3="s" angle="2.014808088502254" k="525.5104"/>
+    <Angle class1="c3" class2="c2" class3="ss" angle="2.088460982936415" k="515.4688"/>
+    <Angle class1="ca" class2="c2" class3="ca" angle="2.0573941222509156" k="568.1872000000001"/>
+    <Angle class1="ca" class2="c2" class3="hc" angle="2.1519909677090086" k="400.8272"/>
+    <Angle class1="c" class2="c2" class3="c2" angle="2.1066124071571557" k="566.5136"/>
+    <Angle class1="c" class2="c2" class3="c3" angle="2.0891591146372126" k="533.8783999999999"/>
+    <Angle class1="c" class2="c2" class3="c" angle="2.0748474147708587" k="557.3088"/>
+    <Angle class1="cc" class2="c2" class3="h4" angle="2.091777108515204" k="412.5424"/>
+    <Angle class1="cc" class2="c2" class3="ha" angle="2.072578486743266" k="414.216"/>
+    <Angle class1="cc" class2="c2" class3="nh" angle="2.1488493750554185" k="574.0448"/>
+    <Angle class1="cc" class2="c2" class3="o" angle="2.157052422539792" k="609.1904"/>
+    <Angle class1="cd" class2="c2" class3="ha" angle="2.072578486743266" k="414.216"/>
+    <Angle class1="ce" class2="c2" class3="cl" angle="2.1549580274373983" k="484.5072"/>
+    <Angle class1="ce" class2="c2" class3="h4" angle="2.1347122081142644" k="410.8688"/>
+    <Angle class1="ce" class2="c2" class3="ha" angle="2.10224908402717" k="414.216"/>
+    <Angle class1="ce" class2="c2" class3="na" angle="2.167175332201359" k="570.6976000000001"/>
+    <Angle class1="ce" class2="c2" class3="nh" angle="2.106786940082355" k="582.4128"/>
+    <Angle class1="ce" class2="c2" class3="no" angle="2.0882864500112155" k="570.6976000000001"/>
+    <Angle class1="ce" class2="c2" class3="o" angle="2.1532126981854045" k="613.3744"/>
+    <Angle class1="ce" class2="c2" class3="oh" angle="2.149023907980618" k="590.7808"/>
+    <Angle class1="ce" class2="c2" class3="os" angle="2.1432643214490366" k="586.5968"/>
+    <Angle class1="cf" class2="c2" class3="ha" angle="2.10224908402717" k="414.216"/>
+    <Angle class1="c" class2="c2" class3="ha" angle="2.11760798144472" k="399.15360000000004"/>
+    <Angle class1="c" class2="c2" class3="hc" angle="2.0891591146372126" k="401.664"/>
+    <Angle class1="cl" class2="c2" class3="cl" angle="1.9956094667303164" k="461.07680000000005"/>
+    <Angle class1="cl" class2="c2" class3="h4" angle="1.981646832714362" k="339.74080000000004"/>
+    <Angle class1="cl" class2="c2" class3="ha" angle="1.9757127132575811" k="339.74080000000004"/>
+    <Angle class1="cx" class2="c2" class3="ha" angle="2.028596189593009" k="389.112"/>
+    <Angle class1="f" class2="c2" class3="f" angle="1.9484855769264695" k="586.5968"/>
+    <Angle class1="f" class2="c2" class3="ha" angle="1.9198621771937625" k="429.2784"/>
+    <Angle class1="h4" class2="c2" class3="n2" angle="2.111673861987939" k="439.32"/>
+    <Angle class1="h4" class2="c2" class3="n" angle="1.9799015034623675" k="424.2576"/>
+    <Angle class1="h4" class2="c2" class3="na" angle="1.971698455977994" k="425.0944"/>
+    <Angle class1="h4" class2="c2" class3="ne" angle="2.085842989058423" k="439.32"/>
+    <Angle class1="h4" class2="c2" class3="nh" angle="2.0085249031950743" k="424.2576"/>
+    <Angle class1="h4" class2="c2" class3="no" angle="1.9788543059111705" k="412.5424"/>
+    <Angle class1="h4" class2="c2" class3="os" angle="1.9849629582931512" k="435.9728"/>
+    <Angle class1="h4" class2="c2" class3="ss" angle="2.036275638301784" k="361.49760000000003"/>
+    <Angle class1="h5" class2="c2" class3="n2" angle="2.124065699677099" k="437.64639999999997"/>
+    <Angle class1="h5" class2="c2" class3="na" angle="2.205921641595633" k="400.8272"/>
+    <Angle class1="h5" class2="c2" class3="ne" angle="2.091777108515204" k="438.4832"/>
+    <Angle class1="h5" class2="c2" class3="nh" angle="1.9881045509467405" k="425.9312"/>
+    <Angle class1="ha" class2="c2" class3="ha" angle="2.0402898955813713" k="318.8208"/>
+    <Angle class1="ha" class2="c2" class3="n1" angle="2.1076596047083527" k="433.4624"/>
+    <Angle class1="ha" class2="c2" class3="n2" angle="2.103819880353965" k="440.15680000000003"/>
+    <Angle class1="ha" class2="c2" class3="n3" angle="1.981646832714362" k="438.4832"/>
+    <Angle class1="ha" class2="c2" class3="n" angle="1.9792033717615696" k="424.2576"/>
+    <Angle class1="ha" class2="c2" class3="na" angle="1.962099145092025" k="425.9312"/>
+    <Angle class1="ha" class2="c2" class3="ne" angle="2.1149899875667284" k="435.9728"/>
+    <Angle class1="ha" class2="c2" class3="nf" angle="2.1149899875667284" k="435.9728"/>
+    <Angle class1="ha" class2="c2" class3="nh" angle="2.0364501712269836" k="420.9104"/>
+    <Angle class1="ha" class2="c2" class3="no" angle="1.957212223186441" k="415.05280000000005"/>
+    <Angle class1="ha" class2="c2" class3="o" angle="2.0460494821129527" k="462.7504"/>
+    <Angle class1="ha" class2="c2" class3="oh" angle="2.027723524967012" k="436.80960000000005"/>
+    <Angle class1="ha" class2="c2" class3="os" angle="1.9668115340724097" k="437.64639999999997"/>
+    <Angle class1="ha" class2="c2" class3="p2" angle="2.1202259753227115" k="466.9344"/>
+    <Angle class1="ha" class2="c2" class3="p3" angle="1.9950858679547179" k="435.136"/>
+    <Angle class1="ha" class2="c2" class3="p4" angle="2.0570450564005167" k="431.78880000000004"/>
+    <Angle class1="ha" class2="c2" class3="p5" angle="2.0245819323134224" k="425.0944"/>
+    <Angle class1="ha" class2="c2" class3="pe" angle="2.118829711921116" k="461.07680000000005"/>
+    <Angle class1="ha" class2="c2" class3="pf" angle="2.118829711921116" k="461.07680000000005"/>
+    <Angle class1="ha" class2="c2" class3="s2" angle="2.0724039538180667" k="386.6016"/>
+    <Angle class1="ha" class2="c2" class3="s4" angle="2.012364627549462" k="358.1504"/>
+    <Angle class1="ha" class2="c2" class3="s" angle="2.0193459445574393" k="363.1712"/>
+    <Angle class1="ha" class2="c2" class3="s6" angle="2.035053907825388" k="356.4768"/>
+    <Angle class1="ha" class2="c2" class3="sh" angle="1.9502309061784637" k="358.98720000000003"/>
+    <Angle class1="ha" class2="c2" class3="ss" angle="2.0371483029277817" k="361.49760000000003"/>
+    <Angle class1="hc" class2="c2" class3="hc" angle="2.075545546471657" k="316.3104"/>
+    <Angle class1="hc" class2="c2" class3="n2" angle="2.101376419401173" k="440.15680000000003"/>
+    <Angle class1="hc" class2="c2" class3="n" angle="1.9903734789743337" k="423.42080000000004"/>
+    <Angle class1="hc" class2="c2" class3="na" angle="2.0786871391252464" k="413.3792"/>
+    <Angle class1="hc" class2="c2" class3="nh" angle="1.9785052400607719" k="427.6048"/>
+    <Angle class1="hc" class2="c2" class3="no" angle="1.9568631573360424" k="415.05280000000005"/>
+    <Angle class1="hc" class2="c2" class3="oh" angle="2.0284216566678097" k="436.80960000000005"/>
+    <Angle class1="hc" class2="c2" class3="os" angle="2.026501794490616" k="431.78880000000004"/>
+    <Angle class1="hc" class2="c2" class3="p3" angle="2.0453513504121545" k="430.1152"/>
+    <Angle class1="hc" class2="c2" class3="p5" angle="2.087064719534819" k="418.40000000000003"/>
+    <Angle class1="hc" class2="c2" class3="s4" angle="2.0266763274158155" k="357.31360000000006"/>
+    <Angle class1="hc" class2="c2" class3="s6" angle="2.0149826214274538" k="358.1504"/>
+    <Angle class1="hc" class2="c2" class3="sh" angle="2.018124214081043" k="353.12960000000004"/>
+    <Angle class1="hc" class2="c2" class3="ss" angle="2.017949681155844" k="363.1712"/>
+    <Angle class1="hx" class2="c2" class3="n4" angle="1.9727456535291907" k="397.48"/>
+    <Angle class1="i" class2="c2" class3="i" angle="2.058441319802112" k="506.264"/>
+    <Angle class1="n1" class2="c2" class3="n1" angle="2.1668262663509603" k="615.8847999999999"/>
+    <Angle class1="n2" class2="c2" class3="n2" angle="1.9865337546199457" k="655.2144"/>
+    <Angle class1="n2" class2="c2" class3="n4" angle="1.971698455977994" k="595.8016"/>
+    <Angle class1="n2" class2="c2" class3="na" angle="2.15757602131539" k="598.312"/>
+    <Angle class1="n2" class2="c2" class3="nh" angle="2.1689206614533534" k="600.8224"/>
+    <Angle class1="n2" class2="c2" class3="oh" angle="2.1306979508346777" k="622.5792000000001"/>
+    <Angle class1="n2" class2="c2" class3="os" angle="2.090555378038808" k="622.5792000000001"/>
+    <Angle class1="n2" class2="c2" class3="ss" angle="2.2649137703130418" k="526.3472"/>
+    <Angle class1="n3" class2="c2" class3="n3" angle="2.067691564837682" k="615.048"/>
+    <Angle class1="n4" class2="c2" class3="n4" angle="1.9884536167971396" k="554.7984"/>
+    <Angle class1="n4" class2="c2" class3="ss" angle="2.029294321293807" k="535.552"/>
+    <Angle class1="na" class2="c2" class3="na" angle="1.9081684712054006" k="611.7008"/>
+    <Angle class1="ne" class2="c2" class3="nh" angle="2.1547834945121993" k="600.8224"/>
+    <Angle class1="ne" class2="c2" class3="os" angle="2.0727530196684656" k="623.416"/>
+    <Angle class1="ne" class2="c2" class3="ss" angle="2.1032962815783667" k="545.5936"/>
+    <Angle class1="nf" class2="c2" class3="nh" angle="2.1547834945121993" k="600.8224"/>
+    <Angle class1="nh" class2="c2" class3="nh" angle="1.9690804621000024" k="608.3536"/>
+    <Angle class1="nh" class2="c2" class3="oh" angle="2.043955087010559" k="610.864"/>
+    <Angle class1="nh" class2="c2" class3="os" angle="1.9949113350295187" k="614.2112000000001"/>
+    <Angle class1="nh" class2="c2" class3="ss" angle="1.9469147805996745" k="559.8192"/>
+    <Angle class1="n" class2="c2" class3="n2" angle="2.1436133872994354" k="600.8224"/>
+    <Angle class1="n" class2="c2" class3="n" angle="1.9762363120331796" k="601.6592"/>
+    <Angle class1="n" class2="c2" class3="na" angle="1.839926097452422" k="623.416"/>
+    <Angle class1="n" class2="c2" class3="ne" angle="2.1875956844496924" k="593.2912000000001"/>
+    <Angle class1="n" class2="c2" class3="nh" angle="1.9085175370557992" k="615.048"/>
+    <Angle class1="no" class2="c2" class3="no" angle="1.9879300180215413" k="579.9024"/>
+    <Angle class1="n" class2="c2" class3="ss" angle="1.940631595292495" k="559.8192"/>
+    <Angle class1="oh" class2="c2" class3="oh" angle="1.995434933805117" k="633.4576000000001"/>
+    <Angle class1="o" class2="c2" class3="o" angle="2.1238911667518994" k="671.1136"/>
+    <Angle class1="o" class2="c2" class3="oh" angle="2.1158626521927255" k="640.152"/>
+    <Angle class1="o" class2="c2" class3="s" angle="2.22843638894636" k="537.2256000000001"/>
+    <Angle class1="os" class2="c2" class3="os" angle="2.008001304419476" k="621.7424"/>
+    <Angle class1="p2" class2="c2" class3="p2" angle="2.26543736908864" k="842.6576"/>
+    <Angle class1="p3" class2="c2" class3="p3" angle="2.0165534177542486" k="812.5328"/>
+    <Angle class1="p5" class2="c2" class3="p5" angle="2.12668369355509" k="779.0608"/>
+    <Angle class1="s4" class2="c2" class3="s4" angle="2.099980155999577" k="517.9792"/>
+    <Angle class1="s4" class2="c2" class3="s6" angle="2.0935224377671986" k="518.816"/>
+    <Angle class1="s6" class2="c2" class3="s6" angle="2.093871503617597" k="518.816"/>
+    <Angle class1="sh" class2="c2" class3="sh" angle="1.9282397576033352" k="533.8783999999999"/>
+    <Angle class1="sh" class2="c2" class3="ss" angle="2.056346924699719" k="523.8368"/>
+    <Angle class1="s" class2="c2" class3="s" angle="2.123542100901501" k="523.0"/>
+    <Angle class1="ss" class2="c2" class3="ss" angle="2.0315632493213998" k="533.8783999999999"/>
+    <Angle class1="br" class2="c3" class3="br" angle="1.9153243211385773" k="558.9824"/>
+    <Angle class1="br" class2="c3" class3="c1" angle="1.9512781037296603" k="523.0"/>
+    <Angle class1="br" class2="c3" class3="c3" angle="1.920036710118962" k="523.0"/>
+    <Angle class1="br" class2="c3" class3="c" angle="1.9010126212722238" k="526.3472"/>
+    <Angle class1="br" class2="c3" class3="h1" angle="1.8338174450704419" k="354.8032"/>
+    <Angle class1="br" class2="c3" class3="h2" angle="1.8640116411299437" k="352.2928"/>
+    <Angle class1="br" class2="c3" class3="hc" angle="1.858775653373961" k="352.2928"/>
+    <Angle class1="c1" class2="c3" class3="c1" angle="1.9217820393709562" k="554.7984"/>
+    <Angle class1="c1" class2="c3" class3="c2" angle="1.9359192063121102" k="544.7568"/>
+    <Angle class1="c1" class2="c3" class3="c3" angle="1.9497073074028652" k="537.2256000000001"/>
+    <Angle class1="c1" class2="c3" class3="ca" angle="1.935395607536512" k="543.9200000000001"/>
+    <Angle class1="c1" class2="c3" class3="cc" angle="1.9929914728523246" k="538.0624"/>
+    <Angle class1="c1" class2="c3" class3="cd" angle="1.9929914728523246" k="538.0624"/>
+    <Angle class1="c1" class2="c3" class3="cl" angle="1.9308577514813265" k="486.18080000000003"/>
+    <Angle class1="c1" class2="c3" class3="h1" angle="1.9065976748786053" k="405.01120000000003"/>
+    <Angle class1="c1" class2="c3" class3="hc" angle="1.9095647346069957" k="405.01120000000003"/>
+    <Angle class1="c1" class2="c3" class3="hx" angle="1.9554668939344468" k="399.99039999999997"/>
+    <Angle class1="c1" class2="c3" class3="n3" angle="1.9675096657732076" k="562.3296"/>
+    <Angle class1="c1" class2="c3" class3="n4" angle="1.9558159597848455" k="554.7984"/>
+    <Angle class1="c1" class2="c3" class3="n" angle="1.9614010133912274" k="563.1664"/>
+    <Angle class1="c1" class2="c3" class3="nh" angle="1.9647171389700164" k="562.3296"/>
+    <Angle class1="c1" class2="c3" class3="oh" angle="1.9100883333825942" k="581.576"/>
+    <Angle class1="c1" class2="c3" class3="os" angle="1.902408884673819" k="581.576"/>
+    <Angle class1="c2" class2="c3" class3="c2" angle="1.9547687622336491" k="534.7152"/>
+    <Angle class1="c2" class2="c3" class3="c3" angle="1.947089313524874" k="530.5312"/>
+    <Angle class1="c2" class2="c3" class3="ca" angle="1.9633208755684213" k="532.2048"/>
+    <Angle class1="c2" class2="c3" class3="cc" angle="1.9531979659068541" k="536.3888"/>
+    <Angle class1="c2" class2="c3" class3="cd" angle="1.9531979659068541" k="536.3888"/>
+    <Angle class1="c2" class2="c3" class3="ce" angle="1.95145263665486" k="533.8783999999999"/>
+    <Angle class1="c2" class2="c3" class3="cf" angle="1.95145263665486" k="533.8783999999999"/>
+    <Angle class1="c2" class2="c3" class3="cl" angle="1.9287633563789335" k="482.83360000000005"/>
+    <Angle class1="c2" class2="c3" class3="cx" angle="1.9577358219620395" k="532.2048"/>
+    <Angle class1="c2" class2="c3" class3="cy" angle="1.776570645605028" k="556.472"/>
+    <Angle class1="c2" class2="c3" class3="f" angle="1.9331266795089195" k="555.6352"/>
+    <Angle class1="c2" class2="c3" class3="h1" angle="1.9191640454929646" k="394.13280000000003"/>
+    <Angle class1="c2" class2="c3" class3="h2" angle="1.9493582415524666" k="390.78560000000004"/>
+    <Angle class1="c2" class2="c3" class3="hc" angle="1.9261453625009421" k="393.296"/>
+    <Angle class1="c2" class2="c3" class3="hx" angle="1.9432495891704866" k="391.62239999999997"/>
+    <Angle class1="c2" class2="c3" class3="n2" angle="1.897521962768235" k="564.0032000000001"/>
+    <Angle class1="c2" class2="c3" class3="n3" angle="1.944645852572082" k="557.3088"/>
+    <Angle class1="c2" class2="c3" class3="n" angle="1.9423769245444895" k="558.1456000000001"/>
+    <Angle class1="c2" class2="c3" class3="na" angle="1.976934443733977" k="553.1247999999999"/>
+    <Angle class1="c2" class2="c3" class3="nh" angle="1.9270180271269393" k="559.8192"/>
+    <Angle class1="c2" class2="c3" class3="oh" angle="1.9259708295757425" k="570.6976000000001"/>
+    <Angle class1="c2" class2="c3" class3="os" angle="1.8947294359650442" k="573.208"/>
+    <Angle class1="c2" class2="c3" class3="s4" angle="1.9179423150165686" k="517.9792"/>
+    <Angle class1="c2" class2="c3" class3="ss" angle="1.8320721158184476" k="528.0208"/>
+    <Angle class1="c3" class2="c3" class3="c3" angle="1.9462166488988768" k="526.3472"/>
+    <Angle class1="c3" class2="c3" class3="ca" angle="1.9559904927100449" k="528.0208"/>
+    <Angle class1="c3" class2="c3" class3="cc" angle="1.9535470317572532" k="531.368"/>
+    <Angle class1="c3" class2="c3" class3="cd" angle="1.9535470317572532" k="531.368"/>
+    <Angle class1="c3" class2="c3" class3="ce" angle="1.9359192063121102" k="531.368"/>
+    <Angle class1="c3" class2="c3" class3="cf" angle="1.9359192063121102" k="531.368"/>
+    <Angle class1="c3" class2="c3" class3="cl" angle="1.9270180271269393" k="480.3232"/>
+    <Angle class1="c3" class2="c3" class3="cx" angle="1.9435986550208855" k="528.8576"/>
+    <Angle class1="c3" class2="c3" class3="cy" angle="1.9622736780172247" k="524.6736000000001"/>
+    <Angle class1="c3" class2="c3" class3="f" angle="1.9065976748786053" k="553.1247999999999"/>
+    <Angle class1="c3" class2="c3" class3="h1" angle="1.9121827284849875" k="388.2752"/>
+    <Angle class1="c3" class2="c3" class3="h2" angle="1.9237019015481498" k="386.6016"/>
+    <Angle class1="c3" class2="c3" class3="hc" angle="1.9163715186897738" k="387.4384"/>
+    <Angle class1="c3" class2="c3" class3="hx" angle="1.9296360210049306" k="386.6016"/>
+    <Angle class1="c3" class2="c3" class3="i" angle="1.9399334635916972" k="478.6496"/>
+    <Angle class1="c3" class2="c3" class3="n1" angle="1.9020598188234203" k="563.1664"/>
+    <Angle class1="c3" class2="c3" class3="n2" angle="1.8989182261698305" k="558.1456000000001"/>
+    <Angle class1="c3" class2="c3" class3="n3" angle="1.9380136014145035" k="552.288"/>
+    <Angle class1="c3" class2="c3" class3="n4" angle="1.9933405387027237" k="537.2256000000001"/>
+    <Angle class1="c3" class2="c3" class3="n" angle="1.947961978150871" k="551.4512000000001"/>
+    <Angle class1="c3" class2="c3" class3="na" angle="1.970127659651199" k="548.104"/>
+    <Angle class1="c3" class2="c3" class3="nh" angle="1.9278906917529361" k="553.9616000000001"/>
+    <Angle class1="c3" class2="c3" class3="no" angle="1.9095647346069957" k="544.7568"/>
+    <Angle class1="c3" class2="c3" class3="o" angle="1.972396587678792" k="573.208"/>
+    <Angle class1="c3" class2="c3" class3="oh" angle="1.9231783027725518" k="564.84"/>
+    <Angle class1="c3" class2="c3" class3="os" angle="1.8844319933782776" k="569.024"/>
+    <Angle class1="c3" class2="c3" class3="p3" angle="1.9785052400607719" k="635.1312"/>
+    <Angle class1="c3" class2="c3" class3="p5" angle="1.9551178280840478" k="644.336"/>
+    <Angle class1="c3" class2="c3" class3="s4" angle="1.9219565722961558" k="514.6320000000001"/>
+    <Angle class1="c3" class2="c3" class3="s6" angle="1.9237019015481498" k="519.6528000000001"/>
+    <Angle class1="c3" class2="c3" class3="sh" angle="1.974490982781185" k="505.4272"/>
+    <Angle class1="c3" class2="c3" class3="ss" angle="1.924574566174147" k="512.9584"/>
+    <Angle class1="c3" class2="c3" class3="sy" angle="1.9184659137921671" k="519.6528000000001"/>
+    <Angle class1="ca" class2="c3" class3="ca" angle="1.9589575524384353" k="532.2048"/>
+    <Angle class1="ca" class2="c3" class3="cc" angle="1.970127659651199" k="533.0416"/>
+    <Angle class1="ca" class2="c3" class3="cd" angle="1.970127659651199" k="533.0416"/>
+    <Angle class1="ca" class2="c3" class3="ce" angle="1.958433953662837" k="532.2048"/>
+    <Angle class1="ca" class2="c3" class3="cl" angle="1.936966403863307" k="481.16"/>
+    <Angle class1="ca" class2="c3" class3="cx" angle="1.965589803596014" k="529.6944"/>
+    <Angle class1="ca" class2="c3" class3="f" angle="1.9507545049540622" k="552.288"/>
+    <Angle class1="ca" class2="c3" class3="h1" angle="1.9121827284849875" k="393.296"/>
+    <Angle class1="ca" class2="c3" class3="h2" angle="1.9146261894377794" k="393.296"/>
+    <Angle class1="ca" class2="c3" class3="hc" angle="1.9280652246781358" k="391.62239999999997"/>
+    <Angle class1="ca" class2="c3" class3="hx" angle="1.9451694513476803" k="389.9488"/>
+    <Angle class1="ca" class2="c3" class3="n2" angle="1.961575546316427" k="553.1247999999999"/>
+    <Angle class1="ca" class2="c3" class3="n3" angle="1.95756128903684" k="553.9616000000001"/>
+    <Angle class1="ca" class2="c3" class3="n4" angle="1.986184688769547" k="542.2464"/>
+    <Angle class1="ca" class2="c3" class3="n" angle="1.9614010133912274" k="553.9616000000001"/>
+    <Angle class1="ca" class2="c3" class3="na" angle="1.969953126726" k="552.288"/>
+    <Angle class1="ca" class2="c3" class3="nc" angle="1.8589501862991602" k="569.8607999999999"/>
+    <Angle class1="ca" class2="c3" class3="nd" angle="1.8589501862991602" k="569.8607999999999"/>
+    <Angle class1="ca" class2="c3" class3="nh" angle="1.9441222537964835" k="556.472"/>
+    <Angle class1="ca" class2="c3" class3="oh" angle="1.9306832185561276" k="568.1872000000001"/>
+    <Angle class1="ca" class2="c3" class3="os" angle="1.9015362200478219" k="571.5344"/>
+    <Angle class1="ca" class2="c3" class3="p5" angle="1.9826940302655582" k="641.8256"/>
+    <Angle class1="ca" class2="c3" class3="s6" angle="1.9467402476744753" k="518.816"/>
+    <Angle class1="ca" class2="c3" class3="ss" angle="1.9376645355641045" k="512.9584"/>
+    <Angle class1="ca" class2="c3" class3="sx" angle="1.9334757453593183" k="512.9584"/>
+    <Angle class1="c" class2="c3" class3="c1" angle="1.9614010133912274" k="538.0624"/>
+    <Angle class1="c" class2="c3" class3="c2" angle="1.943075056245287" k="533.8783999999999"/>
+    <Angle class1="c" class2="c3" class3="c3" angle="1.9380136014145035" k="529.6944"/>
+    <Angle class1="c" class2="c3" class3="c" angle="1.94831104400127" k="530.5312"/>
+    <Angle class1="c" class2="c3" class3="ca" angle="1.9374900026389053" k="533.0416"/>
+    <Angle class1="c" class2="c3" class3="cc" angle="1.9751891144819826" k="530.5312"/>
+    <Angle class1="cc" class2="c3" class3="cc" angle="1.961575546316427" k="536.3888"/>
+    <Angle class1="cc" class2="c3" class3="cd" angle="1.9703021925763986" k="535.552"/>
+    <Angle class1="cc" class2="c3" class3="cx" angle="1.9509290378792614" k="533.8783999999999"/>
+    <Angle class1="c" class2="c3" class3="cd" angle="1.9751891144819826" k="530.5312"/>
+    <Angle class1="c" class2="c3" class3="ce" angle="1.9528489000564555" k="531.368"/>
+    <Angle class1="cc" class2="c3" class3="f" angle="1.9427259903948884" k="556.472"/>
+    <Angle class1="cc" class2="c3" class3="h1" angle="1.913578991886583" k="396.6432"/>
+    <Angle class1="cc" class2="c3" class3="hc" angle="1.9284142905285344" k="394.9696"/>
+    <Angle class1="cc" class2="c3" class3="hx" angle="1.9374900026389053" k="394.13280000000003"/>
+    <Angle class1="c" class2="c3" class3="cl" angle="1.9270180271269393" k="481.16"/>
+    <Angle class1="cc" class2="c3" class3="n2" angle="1.925272697874945" k="561.4928"/>
+    <Angle class1="cc" class2="c3" class3="n3" angle="1.9388862660405006" k="559.8192"/>
+    <Angle class1="cc" class2="c3" class3="n4" angle="2.017251549455046" k="540.5728"/>
+    <Angle class1="cc" class2="c3" class3="n" angle="1.9505799720288628" k="558.1456000000001"/>
+    <Angle class1="cc" class2="c3" class3="na" angle="1.974840048631584" k="554.7984"/>
+    <Angle class1="cc" class2="c3" class3="nc" angle="1.8682004313347302" k="571.5344"/>
+    <Angle class1="cc" class2="c3" class3="nh" angle="1.96070288169043" k="556.472"/>
+    <Angle class1="cc" class2="c3" class3="oh" angle="1.9401079965168966" k="569.8607999999999"/>
+    <Angle class1="cc" class2="c3" class3="os" angle="1.9006635554218252" k="574.0448"/>
+    <Angle class1="cc" class2="c3" class3="p5" angle="2.028596189593009" k="635.9680000000001"/>
+    <Angle class1="cc" class2="c3" class3="sh" angle="1.9900244131239346" k="506.264"/>
+    <Angle class1="cc" class2="c3" class3="ss" angle="1.9401079965168966" k="513.7952"/>
+    <Angle class1="c" class2="c3" class3="cx" angle="1.9401079965168966" k="532.2048"/>
+    <Angle class1="cd" class2="c3" class3="cd" angle="1.961575546316427" k="536.3888"/>
+    <Angle class1="cd" class2="c3" class3="f" angle="1.9427259903948884" k="556.472"/>
+    <Angle class1="cd" class2="c3" class3="h1" angle="1.913578991886583" k="396.6432"/>
+    <Angle class1="cd" class2="c3" class3="hc" angle="1.9284142905285344" k="394.9696"/>
+    <Angle class1="cd" class2="c3" class3="n3" angle="1.9388862660405006" k="559.8192"/>
+    <Angle class1="cd" class2="c3" class3="n" angle="1.9505799720288628" k="558.1456000000001"/>
+    <Angle class1="cd" class2="c3" class3="nd" angle="1.8682004313347302" k="571.5344"/>
+    <Angle class1="cd" class2="c3" class3="nh" angle="1.96070288169043" k="556.472"/>
+    <Angle class1="cd" class2="c3" class3="oh" angle="1.9401079965168966" k="569.8607999999999"/>
+    <Angle class1="cd" class2="c3" class3="os" angle="1.9006635554218252" k="574.0448"/>
+    <Angle class1="cd" class2="c3" class3="sh" angle="1.9900244131239346" k="506.264"/>
+    <Angle class1="cd" class2="c3" class3="ss" angle="1.9401079965168966" k="513.7952"/>
+    <Angle class1="ce" class2="c3" class3="ce" angle="1.9455185171980791" k="533.8783999999999"/>
+    <Angle class1="ce" class2="c3" class3="cy" angle="1.7919295430225781" k="552.288"/>
+    <Angle class1="ce" class2="c3" class3="h1" angle="1.9118336626345886" k="393.296"/>
+    <Angle class1="ce" class2="c3" class3="hc" angle="1.930159619780529" k="391.62239999999997"/>
+    <Angle class1="ce" class2="c3" class3="n3" angle="1.9505799720288628" k="554.7984"/>
+    <Angle class1="ce" class2="c3" class3="n" angle="1.9237019015481498" k="558.9824"/>
+    <Angle class1="ce" class2="c3" class3="oh" angle="1.940631595292495" k="566.5136"/>
+    <Angle class1="ce" class2="c3" class3="os" angle="1.911135530933791" k="569.8607999999999"/>
+    <Angle class1="ce" class2="c3" class3="ss" angle="1.9324285478081218" k="513.7952"/>
+    <Angle class1="c" class2="c3" class3="f" angle="1.9198621771937625" k="554.7984"/>
+    <Angle class1="cf" class2="c3" class3="cy" angle="1.7961183332273645" k="552.288"/>
+    <Angle class1="cf" class2="c3" class3="h1" angle="1.9118336626345886" k="393.296"/>
+    <Angle class1="cf" class2="c3" class3="hc" angle="1.930159619780529" k="391.62239999999997"/>
+    <Angle class1="cf" class2="c3" class3="n3" angle="1.9505799720288628" k="554.7984"/>
+    <Angle class1="c" class2="c3" class3="h1" angle="1.8887953165082634" k="393.296"/>
+    <Angle class1="c" class2="c3" class3="h2" angle="1.9144516565125802" k="390.78560000000004"/>
+    <Angle class1="c" class2="c3" class3="hc" angle="1.898394627394232" k="392.4592"/>
+    <Angle class1="c" class2="c3" class3="hx" angle="1.8997908907958276" k="392.4592"/>
+    <Angle class1="cl" class2="c3" class3="cl" angle="1.9081684712054006" k="452.70880000000005"/>
+    <Angle class1="cl" class2="c3" class3="f" angle="1.904328746851013" k="490.36480000000006"/>
+    <Angle class1="cl" class2="c3" class3="h1" angle="1.863662575279545" k="335.5568"/>
+    <Angle class1="cl" class2="c3" class3="h2" angle="1.8673277667087331" k="334.72"/>
+    <Angle class1="cl" class2="c3" class3="hc" angle="1.8788469397718959" k="333.8832"/>
+    <Angle class1="cl" class2="c3" class3="os" angle="1.9348720087609137" k="502.9168"/>
+    <Angle class1="cl" class2="c3" class3="ss" angle="1.964019007269219" k="477.81280000000004"/>
+    <Angle class1="c" class2="c3" class3="n2" angle="1.9141025906621811" k="558.1456000000001"/>
+    <Angle class1="c" class2="c3" class3="n3" angle="1.9397589306664977" k="554.7984"/>
+    <Angle class1="c" class2="c3" class3="n4" angle="1.9326030807333212" k="548.104"/>
+    <Angle class1="c" class2="c3" class3="n" angle="1.903456082225016" k="560.6560000000001"/>
+    <Angle class1="c" class2="c3" class3="na" angle="1.9460421159736774" k="553.9616000000001"/>
+    <Angle class1="c" class2="c3" class3="nh" angle="1.9085175370557992" k="559.8192"/>
+    <Angle class1="c" class2="c3" class3="oh" angle="1.898743693244631" k="571.5344"/>
+    <Angle class1="c" class2="c3" class3="os" angle="1.9060740761030073" k="569.024"/>
+    <Angle class1="c" class2="c3" class3="p5" angle="1.934697475835714" k="648.52"/>
+    <Angle class1="c" class2="c3" class3="s6" angle="1.9315558831821247" k="519.6528000000001"/>
+    <Angle class1="c" class2="c3" class3="sh" angle="1.897521962768235" k="517.1424"/>
+    <Angle class1="c" class2="c3" class3="ss" angle="1.8996163578706282" k="517.9792"/>
+    <Angle class1="cx" class2="c3" class3="cx" angle="1.988628149722339" k="525.5104"/>
+    <Angle class1="cx" class2="c3" class3="h1" angle="1.9144516565125802" k="391.62239999999997"/>
+    <Angle class1="cx" class2="c3" class3="hc" angle="1.9228292369221527" k="390.78560000000004"/>
+    <Angle class1="cx" class2="c3" class3="hx" angle="1.9669860669976096" k="386.6016"/>
+    <Angle class1="cx" class2="c3" class3="n3" angle="1.9750145815567834" k="550.6144"/>
+    <Angle class1="cx" class2="c3" class3="n4" angle="1.7701129273726488" k="573.208"/>
+    <Angle class1="cx" class2="c3" class3="n" angle="1.9610519475408286" k="553.1247999999999"/>
+    <Angle class1="cx" class2="c3" class3="oh" angle="1.9195131113433634" k="568.1872000000001"/>
+    <Angle class1="cx" class2="c3" class3="os" angle="1.8814649336498872" k="573.208"/>
+    <Angle class1="cy" class2="c3" class3="h1" angle="1.8943803701146456" k="390.78560000000004"/>
+    <Angle class1="cy" class2="c3" class3="hc" angle="1.9333012124341187" k="386.6016"/>
+    <Angle class1="cy" class2="c3" class3="n3" angle="1.9879300180215413" k="546.4304"/>
+    <Angle class1="cy" class2="c3" class3="oh" angle="1.9449949184224806" k="562.3296"/>
+    <Angle class1="cy" class2="c3" class3="os" angle="1.8709929581379214" k="571.5344"/>
+    <Angle class1="f" class2="c3" class3="f" angle="1.8737854849411122" k="593.2912000000001"/>
+    <Angle class1="f" class2="c3" class3="h1" angle="1.8832102629018814" k="430.1152"/>
+    <Angle class1="f" class2="c3" class3="h2" angle="1.898743693244631" k="427.6048"/>
+    <Angle class1="f" class2="c3" class3="h3" angle="1.9212584405953579" k="425.9312"/>
+    <Angle class1="f" class2="c3" class3="hc" angle="1.9010126212722238" k="427.6048"/>
+    <Angle class1="f" class2="c3" class3="n2" angle="1.9268434942017398" k="580.7392000000001"/>
+    <Angle class1="f" class2="c3" class3="os" angle="1.9299850868553294" k="592.4544"/>
+    <Angle class1="f" class2="c3" class3="p5" angle="1.8781488080710982" k="664.4192"/>
+    <Angle class1="f" class2="c3" class3="s6" angle="1.9142771235873808" k="528.0208"/>
+    <Angle class1="f" class2="c3" class3="ss" angle="1.9504054391036632" k="515.4688"/>
+    <Angle class1="h1" class2="c3" class3="h1" angle="1.8929841067130497" k="328.02560000000005"/>
+    <Angle class1="h1" class2="c3" class3="n1" angle="1.8847810592286764" k="425.9312"/>
+    <Angle class1="h1" class2="c3" class3="n2" angle="1.9165460516149735" k="414.216"/>
+    <Angle class1="h1" class2="c3" class3="n3" angle="1.9177677820913692" k="414.216"/>
+    <Angle class1="h1" class2="c3" class3="n" angle="1.9003144895714261" k="416.7264"/>
+    <Angle class1="h1" class2="c3" class3="na" angle="1.8985691603194317" k="416.7264"/>
+    <Angle class1="h1" class2="c3" class3="nc" angle="1.8949039688902436" k="419.2368"/>
+    <Angle class1="h1" class2="c3" class3="nd" angle="1.8949039688902436" k="419.2368"/>
+    <Angle class1="h1" class2="c3" class3="nh" angle="1.9161969857645744" k="415.05280000000005"/>
+    <Angle class1="h1" class2="c3" class3="no" angle="1.8407987620784192" k="405.848"/>
+    <Angle class1="h1" class2="c3" class3="o" angle="2.032435913947397" k="440.15680000000003"/>
+    <Angle class1="h1" class2="c3" class3="oh" angle="1.924400033248948" k="425.9312"/>
+    <Angle class1="h1" class2="c3" class3="os" angle="1.916022452839375" k="425.0944"/>
+    <Angle class1="h1" class2="c3" class3="p5" angle="1.8896679811342605" k="446.8512"/>
+    <Angle class1="h1" class2="c3" class3="s4" angle="1.8835593287522805" k="355.64"/>
+    <Angle class1="h1" class2="c3" class3="s" angle="1.961226480466028" k="344.76160000000004"/>
+    <Angle class1="h1" class2="c3" class3="s6" angle="1.8701202935119243" k="361.49760000000003"/>
+    <Angle class1="h1" class2="c3" class3="sh" angle="1.8922859750122523" k="351.456"/>
+    <Angle class1="h1" class2="c3" class3="ss" angle="1.8982200944690328" k="352.2928"/>
+    <Angle class1="h1" class2="c3" class3="sx" angle="1.879719604397893" k="353.12960000000004"/>
+    <Angle class1="h1" class2="c3" class3="sy" angle="1.8828611970514826" k="359.824"/>
+    <Angle class1="h2" class2="c3" class3="h2" angle="1.9233528356977512" k="326.35200000000003"/>
+    <Angle class1="h2" class2="c3" class3="i" angle="1.8324211816688465" k="314.63680000000005"/>
+    <Angle class1="h2" class2="c3" class3="n2" angle="1.9233528356977512" k="413.3792"/>
+    <Angle class1="h2" class2="c3" class3="n3" angle="1.9085175370557992" k="415.05280000000005"/>
+    <Angle class1="h2" class2="c3" class3="n" angle="1.8723892215395166" k="420.07360000000006"/>
+    <Angle class1="h2" class2="c3" class3="na" angle="1.872912820315115" k="420.07360000000006"/>
+    <Angle class1="h2" class2="c3" class3="nc" angle="1.9106119321581925" k="417.5632"/>
+    <Angle class1="h2" class2="c3" class3="nd" angle="1.9106119321581925" k="417.5632"/>
+    <Angle class1="h2" class2="c3" class3="nh" angle="1.920036710118962" k="414.216"/>
+    <Angle class1="h2" class2="c3" class3="no" angle="1.8896679811342605" k="400.8272"/>
+    <Angle class1="h2" class2="c3" class3="o" angle="1.901885285898221" k="455.2192"/>
+    <Angle class1="h2" class2="c3" class3="oh" angle="1.9099138004573948" k="427.6048"/>
+    <Angle class1="h2" class2="c3" class3="os" angle="1.9125317943353861" k="425.9312"/>
+    <Angle class1="h2" class2="c3" class3="s4" angle="1.872912820315115" k="356.4768"/>
+    <Angle class1="h2" class2="c3" class3="s" angle="1.863138976503947" k="353.96639999999996"/>
+    <Angle class1="h2" class2="c3" class3="s6" angle="1.8589501862991602" k="362.3344"/>
+    <Angle class1="h2" class2="c3" class3="sh" angle="1.8826866641262834" k="352.2928"/>
+    <Angle class1="h2" class2="c3" class3="ss" angle="1.890715178685457" k="352.2928"/>
+    <Angle class1="h3" class2="c3" class3="n3" angle="1.8976964956934346" k="416.7264"/>
+    <Angle class1="h3" class2="c3" class3="nc" angle="1.9088666029061983" k="417.5632"/>
+    <Angle class1="h3" class2="c3" class3="nd" angle="1.9088666029061983" k="417.5632"/>
+    <Angle class1="h3" class2="c3" class3="nh" angle="1.9233528356977512" k="414.216"/>
+    <Angle class1="h3" class2="c3" class3="os" angle="1.9462166488988768" k="421.7472"/>
+    <Angle class1="h3" class2="c3" class3="ss" angle="1.9039796810006142" k="351.456"/>
+    <Angle class1="hc" class2="c3" class3="hc" angle="1.8776252092954997" k="329.6992"/>
+    <Angle class1="hc" class2="c3" class3="i" angle="1.8324211816688465" k="314.63680000000005"/>
+    <Angle class1="hc" class2="c3" class3="n2" angle="1.911135530933791" k="415.05280000000005"/>
+    <Angle class1="hc" class2="c3" class3="n3" angle="1.9163715186897738" k="414.216"/>
+    <Angle class1="hc" class2="c3" class3="n4" angle="1.8832102629018814" k="406.68480000000005"/>
+    <Angle class1="hc" class2="c3" class3="n" angle="1.911135530933791" k="415.88960000000003"/>
+    <Angle class1="hc" class2="c3" class3="na" angle="1.911135530933791" k="415.88960000000003"/>
+    <Angle class1="hc" class2="c3" class3="nh" angle="1.9467402476744753" k="411.70560000000006"/>
+    <Angle class1="hc" class2="c3" class3="no" angle="1.8709929581379214" k="403.33760000000007"/>
+    <Angle class1="hc" class2="c3" class3="oh" angle="1.911135530933791" k="427.6048"/>
+    <Angle class1="hc" class2="c3" class3="os" angle="1.8971728969178363" k="426.76800000000003"/>
+    <Angle class1="hc" class2="c3" class3="p2" angle="1.9230037698473523" k="438.4832"/>
+    <Angle class1="hc" class2="c3" class3="p3" angle="1.9179423150165686" k="438.4832"/>
+    <Angle class1="hc" class2="c3" class3="p4" angle="1.9102628663077938" k="444.3408"/>
+    <Angle class1="hc" class2="c3" class3="p5" angle="1.8924605079374515" k="446.01439999999997"/>
+    <Angle class1="hc" class2="c3" class3="px" angle="1.9146261894377794" k="446.8512"/>
+    <Angle class1="hc" class2="c3" class3="py" angle="1.9055504773274092" k="444.3408"/>
+    <Angle class1="hc" class2="c3" class3="s4" angle="1.876228945893904" k="355.64"/>
+    <Angle class1="hc" class2="c3" class3="s6" angle="1.8884462506578645" k="359.824"/>
+    <Angle class1="hc" class2="c3" class3="sh" angle="1.8826866641262834" k="352.2928"/>
+    <Angle class1="hc" class2="c3" class3="ss" angle="1.8982200944690328" k="352.2928"/>
+    <Angle class1="hx" class2="c3" class3="hx" angle="1.9154988540637765" k="328.02560000000005"/>
+    <Angle class1="hx" class2="c3" class3="n4" angle="1.8851301250790755" k="406.68480000000005"/>
+    <Angle class1="i" class2="c3" class3="i" angle="1.9743164498559855" k="507.10080000000005"/>
+    <Angle class1="n1" class2="c3" class3="n1" angle="1.8338174450704419" k="610.0272000000001"/>
+    <Angle class1="n2" class2="c3" class3="n2" angle="1.9142771235873808" k="584.0864"/>
+    <Angle class1="n2" class2="c3" class3="nh" angle="1.9420278586940904" k="579.9024"/>
+    <Angle class1="n2" class2="c3" class3="oh" angle="1.9528489000564555" k="589.9440000000001"/>
+    <Angle class1="n2" class2="c3" class3="os" angle="1.9380136014145035" k="589.9440000000001"/>
+    <Angle class1="n3" class2="c3" class3="n3" angle="1.9413297269932928" k="579.9024"/>
+    <Angle class1="n3" class2="c3" class3="nc" angle="1.977283509584376" k="576.5552"/>
+    <Angle class1="n3" class2="c3" class3="nd" angle="1.977283509584376" k="576.5552"/>
+    <Angle class1="n3" class2="c3" class3="nh" angle="1.930508685630928" k="582.4128"/>
+    <Angle class1="n3" class2="c3" class3="oh" angle="1.9320794819577227" k="593.2912000000001"/>
+    <Angle class1="n3" class2="c3" class3="os" angle="1.893856771339047" k="597.4752000000001"/>
+    <Angle class1="n3" class2="c3" class3="p5" angle="1.9095647346069957" k="676.1344"/>
+    <Angle class1="n3" class2="c3" class3="ss" angle="1.8741345507915108" k="538.8992000000001"/>
+    <Angle class1="n4" class2="c3" class3="n4" angle="1.9778071083599742" k="557.3088"/>
+    <Angle class1="na" class2="c3" class3="na" angle="1.9807741680883646" k="574.8816"/>
+    <Angle class1="na" class2="c3" class3="os" angle="1.9029324834494175" k="596.6384"/>
+    <Angle class1="nc" class2="c3" class3="nc" angle="1.930508685630928" k="585.76"/>
+    <Angle class1="nc" class2="c3" class3="nh" angle="1.9622736780172247" k="579.0656"/>
+    <Angle class1="nc" class2="c3" class3="os" angle="2.0142844897266556" k="581.576"/>
+    <Angle class1="nd" class2="c3" class3="nd" angle="1.930508685630928" k="585.76"/>
+    <Angle class1="nd" class2="c3" class3="nh" angle="1.9622736780172247" k="579.0656"/>
+    <Angle class1="nd" class2="c3" class3="os" angle="2.0142844897266556" k="581.576"/>
+    <Angle class1="nh" class2="c3" class3="nh" angle="1.8477800790863967" k="594.9648"/>
+    <Angle class1="nh" class2="c3" class3="oh" angle="1.9594811512140338" k="589.1072"/>
+    <Angle class1="nh" class2="c3" class3="os" angle="1.9046778127014117" k="595.8016"/>
+    <Angle class1="nh" class2="c3" class3="p5" angle="1.9634954084936207" k="666.0928"/>
+    <Angle class1="nh" class2="c3" class3="ss" angle="1.9025834175990186" k="534.7152"/>
+    <Angle class1="n" class2="c3" class3="n2" angle="1.9427259903948884" k="579.9024"/>
+    <Angle class1="n" class2="c3" class3="n3" angle="1.9392353318908995" k="581.576"/>
+    <Angle class1="n" class2="c3" class3="n" angle="1.9661134023716125" k="577.392"/>
+    <Angle class1="n" class2="c3" class3="nh" angle="1.8964747652170384" k="587.4336000000001"/>
+    <Angle class1="n" class2="c3" class3="oh" angle="1.9645426060448175" k="589.1072"/>
+    <Angle class1="no" class2="c3" class3="no" angle="1.835737307247636" k="569.8607999999999"/>
+    <Angle class1="n" class2="c3" class3="os" angle="1.9046778127014117" k="596.6384"/>
+    <Angle class1="n" class2="c3" class3="p5" angle="1.928937889304133" k="672.7872000000001"/>
+    <Angle class1="oh" class2="c3" class3="oh" angle="1.9181168479417683" k="607.5168"/>
+    <Angle class1="oh" class2="c3" class3="os" angle="1.9090411358313977" k="607.5168"/>
+    <Angle class1="oh" class2="c3" class3="p5" angle="1.8968238310674375" k="686.176"/>
+    <Angle class1="oh" class2="c3" class3="sh" angle="2.0151571543526527" k="524.6736000000001"/>
+    <Angle class1="o" class2="c3" class3="o" angle="2.134537675189065" k="622.5792000000001"/>
+    <Angle class1="os" class2="c3" class3="os" angle="1.8900170469846596" k="608.3536"/>
+    <Angle class1="os" class2="c3" class3="p5" angle="1.8847810592286764" k="687.0128"/>
+    <Angle class1="os" class2="c3" class3="ss" angle="1.8952530347406427" k="541.4096000000001"/>
+    <Angle class1="p2" class2="c3" class3="p2" angle="1.9282397576033352" k="821.7376"/>
+    <Angle class1="p3" class2="c3" class3="p3" angle="1.9226547039969533" k="820.9008"/>
+    <Angle class1="p5" class2="c3" class3="p5" angle="1.922131105221355" k="829.2687999999999"/>
+    <Angle class1="p5" class2="c3" class3="ss" angle="1.9456930501232788" k="651.8672"/>
+    <Angle class1="s4" class2="c3" class3="s4" angle="1.9598302170644328" k="515.4688"/>
+    <Angle class1="s4" class2="c3" class3="s6" angle="1.9812977668639629" k="515.4688"/>
+    <Angle class1="s6" class2="c3" class3="s6" angle="1.9411551940680933" k="524.6736000000001"/>
+    <Angle class1="sh" class2="c3" class3="sh" angle="2.029119788368608" k="502.9168"/>
+    <Angle class1="sh" class2="c3" class3="ss" angle="1.9326030807333212" k="516.3056"/>
+    <Angle class1="s" class2="c3" class3="s" angle="2.1528636323350057" k="487.8544"/>
+    <Angle class1="ss" class2="c3" class3="ss" angle="1.9449949184224806" k="514.6320000000001"/>
+    <Angle class1="br" class2="ca" class3="br" angle="2.0525072003453313" k="559.8192"/>
+    <Angle class1="br" class2="ca" class3="ca" angle="2.0821777976292353" k="525.5104"/>
+    <Angle class1="c1" class2="ca" class3="c1" angle="2.0943951023931953" k="541.4096000000001"/>
+    <Angle class1="c1" class2="ca" class3="ca" angle="2.0943951023931953" k="548.9408"/>
+    <Angle class1="c2" class2="ca" class3="c2" angle="2.0943951023931953" k="563.1664"/>
+    <Angle class1="c2" class2="ca" class3="ca" angle="2.104867077905161" k="558.9824"/>
+    <Angle class1="c3" class2="ca" class3="c2" angle="2.0943951023931953" k="535.552"/>
+    <Angle class1="c3" class2="ca" class3="c3" angle="2.0385445663293766" k="521.3264"/>
+    <Angle class1="c3" class2="ca" class3="ca" angle="2.1078341376335517" k="531.368"/>
+    <Angle class1="c3" class2="ca" class3="cp" angle="2.1053906766807597" k="530.5312"/>
+    <Angle class1="c3" class2="ca" class3="cq" angle="2.1053906766807597" k="530.5312"/>
+    <Angle class1="c3" class2="ca" class3="na" angle="2.072054887967668" k="551.4512000000001"/>
+    <Angle class1="c3" class2="ca" class3="nb" angle="2.0364501712269836" k="563.1664"/>
+    <Angle class1="ca" class2="ca" class3="ca" angle="2.094744168243594" k="557.3088"/>
+    <Angle class1="ca" class2="ca" class3="cc" angle="2.1081832034839505" k="543.9200000000001"/>
+    <Angle class1="ca" class2="ca" class3="cd" angle="2.1081832034839505" k="543.9200000000001"/>
+    <Angle class1="ca" class2="ca" class3="ce" angle="2.1087068022595488" k="539.736"/>
+    <Angle class1="ca" class2="ca" class3="cf" angle="2.1087068022595488" k="539.736"/>
+    <Angle class1="ca" class2="ca" class3="cg" angle="2.09910749137358" k="549.7776"/>
+    <Angle class1="ca" class2="ca" class3="ch" angle="2.09910749137358" k="549.7776"/>
+    <Angle class1="ca" class2="ca" class3="cl" angle="2.08374859395603" k="484.5072"/>
+    <Angle class1="ca" class2="ca" class3="cp" angle="2.1064378742319563" k="554.7984"/>
+    <Angle class1="ca" class2="ca" class3="cq" angle="2.1064378742319563" k="554.7984"/>
+    <Angle class1="ca" class2="ca" class3="cx" angle="2.1109757302871417" k="535.552"/>
+    <Angle class1="ca" class2="ca" class3="cy" angle="2.105565209605959" k="532.2048"/>
+    <Angle class1="ca" class2="ca" class3="f" angle="2.076243678172454" k="561.4928"/>
+    <Angle class1="ca" class2="ca" class3="h4" angle="2.100329221849976" k="402.5008"/>
+    <Angle class1="ca" class2="ca" class3="ha" angle="2.092300707290802" k="403.33760000000007"/>
+    <Angle class1="ca" class2="ca" class3="i" angle="2.078861672050446" k="481.16"/>
+    <Angle class1="ca" class2="ca" class3="n1" angle="2.090555378038808" k="584.0864"/>
+    <Angle class1="ca" class2="ca" class3="n2" angle="2.0868901866096197" k="590.7808"/>
+    <Angle class1="ca" class2="ca" class3="n4" angle="2.0823523305544347" k="554.7984"/>
+    <Angle class1="ca" class2="ca" class3="n" angle="2.0977112279719847" k="568.1872000000001"/>
+    <Angle class1="ca" class2="ca" class3="na" angle="2.06542263681009" k="578.2288"/>
+    <Angle class1="ca" class2="ca" class3="nb" angle="2.145707782401829" k="575.7184"/>
+    <Angle class1="ca" class2="ca" class3="nc" angle="2.089508180487611" k="581.576"/>
+    <Angle class1="ca" class2="ca" class3="nd" angle="2.089508180487611" k="581.576"/>
+    <Angle class1="ca" class2="ca" class3="ne" angle="2.105041610830361" k="567.3504"/>
+    <Angle class1="ca" class2="ca" class3="nf" angle="2.105041610830361" k="567.3504"/>
+    <Angle class1="ca" class2="ca" class3="nh" angle="2.1109757302871417" k="571.5344"/>
+    <Angle class1="ca" class2="ca" class3="no" angle="2.0771163427984516" k="558.9824"/>
+    <Angle class1="ca" class2="ca" class3="o" angle="2.1512928360082104" k="597.4752000000001"/>
+    <Angle class1="ca" class2="ca" class3="oh" angle="2.0926497731412015" k="581.576"/>
+    <Angle class1="ca" class2="ca" class3="os" angle="2.080432468377241" k="582.4128"/>
+    <Angle class1="ca" class2="ca" class3="p2" angle="1.9959585325807152" k="651.0304"/>
+    <Angle class1="ca" class2="ca" class3="p3" angle="2.094569635318395" k="639.3152000000001"/>
+    <Angle class1="ca" class2="ca" class3="p4" angle="2.0996310901491784" k="644.336"/>
+    <Angle class1="ca" class2="ca" class3="p5" angle="2.098583892597982" k="647.6832"/>
+    <Angle class1="ca" class2="ca" class3="pe" angle="2.10224908402717" k="637.6416"/>
+    <Angle class1="ca" class2="ca" class3="pf" angle="2.10224908402717" k="637.6416"/>
+    <Angle class1="ca" class2="ca" class3="px" angle="2.103645347428765" k="638.4784"/>
+    <Angle class1="ca" class2="ca" class3="py" angle="2.0987584255231813" k="641.8256"/>
+    <Angle class1="ca" class2="ca" class3="s4" angle="2.079559803751244" k="515.4688"/>
+    <Angle class1="ca" class2="ca" class3="s6" angle="2.101900018176771" k="517.9792"/>
+    <Angle class1="ca" class2="ca" class3="s" angle="2.138900998319051" k="519.6528000000001"/>
+    <Angle class1="ca" class2="ca" class3="sh" angle="2.1254619630786946" k="511.2848"/>
+    <Angle class1="ca" class2="ca" class3="ss" angle="2.0954422999443922" k="515.4688"/>
+    <Angle class1="ca" class2="ca" class3="sx" angle="2.0818287317788364" k="507.10080000000005"/>
+    <Angle class1="ca" class2="ca" class3="sy" angle="2.0842721927316283" k="514.6320000000001"/>
+    <Angle class1="c" class2="ca" class3="c3" angle="2.0605357149045056" k="523.0"/>
+    <Angle class1="c" class2="ca" class3="c" angle="2.0943951023931953" k="523.0"/>
+    <Angle class1="c" class2="ca" class3="ca" angle="2.1001546889247766" k="538.0624"/>
+    <Angle class1="cc" class2="ca" class3="cp" angle="2.1694442602289516" k="535.552"/>
+    <Angle class1="cc" class2="ca" class3="nb" angle="2.055125194223323" k="574.8816"/>
+    <Angle class1="cd" class2="ca" class3="nb" angle="2.055125194223323" k="574.8816"/>
+    <Angle class1="ce" class2="ca" class3="na" angle="2.0929988389916" k="557.3088"/>
+    <Angle class1="ce" class2="ca" class3="nb" angle="2.0518090686445336" k="570.6976000000001"/>
+    <Angle class1="cf" class2="ca" class3="nb" angle="2.0518090686445336" k="570.6976000000001"/>
+    <Angle class1="cg" class2="ca" class3="cp" angle="2.1210986399487086" k="545.5936"/>
+    <Angle class1="c" class2="ca" class3="ha" angle="2.022836603061428" k="388.2752"/>
+    <Angle class1="cl" class2="ca" class3="cl" angle="2.072054887967668" k="447.68800000000005"/>
+    <Angle class1="cl" class2="ca" class3="cp" angle="2.101201886475973" k="481.9968"/>
+    <Angle class1="cl" class2="ca" class3="nb" angle="2.027723524967012" k="507.10080000000005"/>
+    <Angle class1="c" class2="ca" class3="nb" angle="2.0556487929989213" k="566.5136"/>
+    <Angle class1="c" class2="ca" class3="nc" angle="2.282890661608583" k="535.552"/>
+    <Angle class1="c" class2="ca" class3="nd" angle="2.282890661608583" k="535.552"/>
+    <Angle class1="cp" class2="ca" class3="f" angle="2.0842721927316283" k="558.9824"/>
+    <Angle class1="cp" class2="ca" class3="h4" angle="2.0959658987199905" k="400.8272"/>
+    <Angle class1="cp" class2="ca" class3="ha" angle="2.0919516414404034" k="401.664"/>
+    <Angle class1="cp" class2="ca" class3="na" angle="1.898743693244631" k="601.6592"/>
+    <Angle class1="cp" class2="ca" class3="nb" angle="2.1568778896145924" k="573.208"/>
+    <Angle class1="cp" class2="ca" class3="nh" angle="2.121622238724307" k="568.1872000000001"/>
+    <Angle class1="cp" class2="ca" class3="oh" angle="2.109230401035147" k="577.392"/>
+    <Angle class1="cp" class2="ca" class3="ss" angle="1.9402825294420962" k="534.7152"/>
+    <Angle class1="cp" class2="ca" class3="sy" angle="1.9404570623672956" k="532.2048"/>
+    <Angle class1="cq" class2="ca" class3="ha" angle="2.0919516414404034" k="401.664"/>
+    <Angle class1="cq" class2="ca" class3="sy" angle="1.9404570623672956" k="532.2048"/>
+    <Angle class1="f" class2="ca" class3="f" angle="2.050761871093337" k="567.3504"/>
+    <Angle class1="f" class2="ca" class3="nb" angle="2.0013690532618975" k="599.1487999999999"/>
+    <Angle class1="h4" class2="ca" class3="n" angle="2.024930998163821" k="416.7264"/>
+    <Angle class1="h4" class2="ca" class3="na" angle="2.030166985919804" k="422.584"/>
+    <Angle class1="h4" class2="ca" class3="nb" angle="2.0251055310890202" k="434.2992"/>
+    <Angle class1="h4" class2="ca" class3="nc" angle="2.0657717026604883" k="426.76800000000003"/>
+    <Angle class1="h4" class2="ca" class3="nd" angle="2.0657717026604883" k="426.76800000000003"/>
+    <Angle class1="h4" class2="ca" class3="os" angle="1.9399334635916972" k="438.4832"/>
+    <Angle class1="h4" class2="ca" class3="ss" angle="2.0278980578922114" k="352.2928"/>
+    <Angle class1="h5" class2="ca" class3="nb" angle="2.0214403396598324" k="434.2992"/>
+    <Angle class1="h5" class2="ca" class3="nc" angle="2.1312215496102755" k="420.07360000000006"/>
+    <Angle class1="h5" class2="ca" class3="nd" angle="2.1312215496102755" k="420.07360000000006"/>
+    <Angle class1="ha" class2="ca" class3="n2" angle="2.0245819323134224" k="443.504"/>
+    <Angle class1="ha" class2="ca" class3="p2" angle="2.13907553124425" k="419.2368"/>
+    <Angle class1="i" class2="ca" class3="i" angle="2.0818287317788364" k="512.9584"/>
+    <Angle class1="n1" class2="ca" class3="n1" angle="2.042558823608964" k="620.9056"/>
+    <Angle class1="n2" class2="ca" class3="n2" angle="2.0943951023931953" k="627.6"/>
+    <Angle class1="n2" class2="ca" class3="na" angle="2.087413785385218" k="609.1904"/>
+    <Angle class1="n4" class2="ca" class3="n4" angle="2.038893632179776" k="558.9824"/>
+    <Angle class1="na" class2="ca" class3="na" angle="1.8783233409962974" k="624.2528"/>
+    <Angle class1="na" class2="ca" class3="nb" angle="2.2181389463595935" k="584.0864"/>
+    <Angle class1="na" class2="ca" class3="nh" angle="2.0710076904164714" k="594.128"/>
+    <Angle class1="nb" class2="ca" class3="nb" angle="2.2211060060879837" k="593.2912000000001"/>
+    <Angle class1="nb" class2="ca" class3="nc" angle="2.2078415037728267" k="592.4544"/>
+    <Angle class1="nb" class2="ca" class3="nd" angle="2.2078415037728267" k="592.4544"/>
+    <Angle class1="nb" class2="ca" class3="nh" angle="2.0409880272821685" k="608.3536"/>
+    <Angle class1="nb" class2="ca" class3="oh" angle="2.053903463746927" k="615.048"/>
+    <Angle class1="nb" class2="ca" class3="os" angle="2.089508180487611" k="608.3536"/>
+    <Angle class1="nb" class2="ca" class3="sh" angle="2.0526817332705307" k="537.2256000000001"/>
+    <Angle class1="nb" class2="ca" class3="ss" angle="2.0734511513692633" k="534.7152"/>
+    <Angle class1="nc" class2="ca" class3="nc" angle="2.2469368790175" k="584.0864"/>
+    <Angle class1="nc" class2="ca" class3="nh" angle="2.07449834892046" k="600.8224"/>
+    <Angle class1="nd" class2="ca" class3="nd" angle="2.2469368790175" k="584.0864"/>
+    <Angle class1="nd" class2="ca" class3="nh" angle="2.07449834892046" k="600.8224"/>
+    <Angle class1="nh" class2="ca" class3="nh" angle="2.11149932906274" k="588.2704"/>
+    <Angle class1="n" class2="ca" class3="nc" angle="2.1617648115201766" k="582.4128"/>
+    <Angle class1="n" class2="ca" class3="nd" angle="2.1617648115201766" k="582.4128"/>
+    <Angle class1="n" class2="ca" class3="nh" angle="2.027374459116613" k="594.128"/>
+    <Angle class1="no" class2="ca" class3="no" angle="2.0444786857861574" k="564.0032000000001"/>
+    <Angle class1="oh" class2="ca" class3="oh" angle="2.0943951023931953" k="606.6800000000001"/>
+    <Angle class1="o" class2="ca" class3="o" angle="2.2134265573792082" k="651.8672"/>
+    <Angle class1="os" class2="ca" class3="os" angle="1.9849629582931512" k="620.9056"/>
+    <Angle class1="p2" class2="ca" class3="p2" angle="2.1153390534171272" k="790.7760000000001"/>
+    <Angle class1="p3" class2="ca" class3="p3" angle="2.1198769094723127" k="795.7968"/>
+    <Angle class1="p5" class2="ca" class3="p5" angle="2.0943951023931953" k="814.2064"/>
+    <Angle class1="s4" class2="ca" class3="s4" angle="1.8467328815352002" k="543.9200000000001"/>
+    <Angle class1="s6" class2="ca" class3="s6" angle="1.8467328815352002" k="549.7776"/>
+    <Angle class1="sh" class2="ca" class3="sh" angle="2.098583892597982" k="512.1216000000001"/>
+    <Angle class1="s" class2="ca" class3="s" angle="2.184105025945704" k="513.7952"/>
+    <Angle class1="ss" class2="ca" class3="ss" angle="2.0097466336714707" k="523.0"/>
+    <Angle class1="br" class2="c" class3="br" angle="1.9739673840055865" k="559.8192"/>
+    <Angle class1="br" class2="c" class3="c3" angle="1.9327776136585204" k="528.8576"/>
+    <Angle class1="br" class2="c" class3="o" angle="2.1198769094723127" k="528.8576"/>
+    <Angle class1="c1" class2="c" class3="c1" angle="2.0127136933998604" k="544.7568"/>
+    <Angle class1="c1" class2="c" class3="o" angle="2.1352358068898627" k="584.0864"/>
+    <Angle class1="c2" class2="c" class3="c2" angle="2.038195500478978" k="562.3296"/>
+    <Angle class1="c2" class2="c" class3="ha" angle="2.0237092676874253" k="406.68480000000005"/>
+    <Angle class1="c2" class2="c" class3="o" angle="2.0790362049756452" k="608.3536"/>
+    <Angle class1="c2" class2="c" class3="s" angle="2.079734336676443" k="542.2464"/>
+    <Angle class1="c3" class2="c" class3="c3" angle="2.033308578573394" k="518.816"/>
+    <Angle class1="c3" class2="c" class3="ca" angle="2.066469834361286" k="520.4896"/>
+    <Angle class1="c3" class2="c" class3="cc" angle="2.047096679664149" k="527.184"/>
+    <Angle class1="c3" class2="c" class3="cd" angle="2.047096679664149" k="527.184"/>
+    <Angle class1="c3" class2="c" class3="ce" angle="2.032261381022197" k="526.3472"/>
+    <Angle class1="c3" class2="c" class3="cf" angle="2.032261381022197" k="526.3472"/>
+    <Angle class1="c3" class2="c" class3="cg" angle="2.007128639793479" k="534.7152"/>
+    <Angle class1="c3" class2="c" class3="ch" angle="2.007128639793479" k="534.7152"/>
+    <Angle class1="c3" class2="c" class3="cl" angle="1.9545942293084493" k="478.6496"/>
+    <Angle class1="c3" class2="c" class3="f" angle="1.9320794819577227" k="556.472"/>
+    <Angle class1="c3" class2="c" class3="h4" angle="2.0008454544862997" k="381.5808"/>
+    <Angle class1="c3" class2="c" class3="ha" angle="2.010968364147866" k="381.5808"/>
+    <Angle class1="c3" class2="c" class3="i" angle="1.9711748572023957" k="475.3024"/>
+    <Angle class1="c3" class2="c" class3="n2" angle="1.9989255923091056" k="553.9616000000001"/>
+    <Angle class1="c3" class2="c" class3="n4" angle="1.9593066182888343" k="538.0624"/>
+    <Angle class1="c3" class2="c" class3="n" angle="2.010270232447069" k="558.9824"/>
+    <Angle class1="c3" class2="c" class3="ne" angle="1.9654152706708146" k="563.1664"/>
+    <Angle class1="c3" class2="c" class3="nf" angle="1.9654152706708146" k="563.1664"/>
+    <Angle class1="c3" class2="c" class3="o" angle="2.1502456384570143" k="564.0032000000001"/>
+    <Angle class1="c3" class2="c" class3="oh" angle="1.9675096657732076" k="572.3712"/>
+    <Angle class1="c3" class2="c" class3="os" angle="1.9324285478081218" k="576.5552"/>
+    <Angle class1="c3" class2="c" class3="p3" angle="2.0319123151717986" k="622.5792000000001"/>
+    <Angle class1="c3" class2="c" class3="p5" angle="2.075196480621258" k="615.8847999999999"/>
+    <Angle class1="c3" class2="c" class3="pe" angle="2.0045106459154876" k="619.232"/>
+    <Angle class1="c3" class2="c" class3="pf" angle="2.0045106459154876" k="619.232"/>
+    <Angle class1="c3" class2="c" class3="px" angle="2.017600615305445" k="619.232"/>
+    <Angle class1="c3" class2="c" class3="py" angle="2.0622810441564994" k="621.7424"/>
+    <Angle class1="c3" class2="c" class3="s4" angle="2.003463448364291" k="497.896"/>
+    <Angle class1="c3" class2="c" class3="s6" angle="2.0022417178878946" k="497.896"/>
+    <Angle class1="c3" class2="c" class3="s" angle="2.1493729738310168" k="518.816"/>
+    <Angle class1="c3" class2="c" class3="sh" angle="1.9661134023716125" k="517.1424"/>
+    <Angle class1="c3" class2="c" class3="ss" angle="1.9811232339387637" k="514.6320000000001"/>
+    <Angle class1="c3" class2="c" class3="sx" angle="1.9891517484979375" k="496.2224"/>
+    <Angle class1="c3" class2="c" class3="sy" angle="1.9945622691791198" k="499.56960000000004"/>
+    <Angle class1="ca" class2="c" class3="ca" angle="2.0614083795305027" k="527.184"/>
+    <Angle class1="ca" class2="c" class3="cc" angle="2.0245819323134224" k="536.3888"/>
+    <Angle class1="ca" class2="c" class3="cd" angle="2.0245819323134224" k="536.3888"/>
+    <Angle class1="ca" class2="c" class3="ce" angle="2.077290875723651" k="526.3472"/>
+    <Angle class1="ca" class2="c" class3="cf" angle="2.077290875723651" k="526.3472"/>
+    <Angle class1="ca" class2="c" class3="h4" angle="2.0095721007462712" k="388.2752"/>
+    <Angle class1="ca" class2="c" class3="ha" angle="1.9917697423759289" k="390.78560000000004"/>
+    <Angle class1="ca" class2="c" class3="n" angle="2.011491962923465" k="566.5136"/>
+    <Angle class1="ca" class2="c" class3="ne" angle="2.002067184962695" k="565.6768"/>
+    <Angle class1="ca" class2="c" class3="o" angle="2.139773662945048" k="574.8816"/>
+    <Angle class1="ca" class2="c" class3="oh" angle="1.9800760363875667" k="579.0656"/>
+    <Angle class1="ca" class2="c" class3="os" angle="1.9624482109424242" k="579.9024"/>
+    <Angle class1="ca" class2="c" class3="s" angle="2.1411699263466435" k="523.8368"/>
+    <Angle class1="ca" class2="c" class3="sh" angle="2.070484091640873" k="507.10080000000005"/>
+    <Angle class1="ca" class2="c" class3="ss" angle="2.008001304419476" k="514.6320000000001"/>
+    <Angle class1="br" class2="cc" class3="c" angle="2.0294688542190062" k="533.8783999999999"/>
+    <Angle class1="br" class2="cc" class3="cc" angle="2.1650809370989657" k="518.816"/>
+    <Angle class1="br" class2="cc" class3="cd" angle="2.1682225297525557" k="521.3264"/>
+    <Angle class1="br" class2="cc" class3="na" angle="2.1219713045747057" k="539.736"/>
+    <Angle class1="c2" class2="cc" class3="c3" angle="2.201034719690049" k="528.8576"/>
+    <Angle class1="c2" class2="cc" class3="ca" angle="2.1715386553313447" k="543.0832"/>
+    <Angle class1="c2" class2="cc" class3="cc" angle="2.1326178130118714" k="553.9616000000001"/>
+    <Angle class1="c2" class2="cc" class3="cd" angle="2.0423842906837644" k="578.2288"/>
+    <Angle class1="c2" class2="cc" class3="ha" angle="2.141868058047441" k="407.52160000000003"/>
+    <Angle class1="c2" class2="cc" class3="n" angle="2.180090768666117" k="571.5344"/>
+    <Angle class1="c2" class2="cc" class3="os" angle="2.119178777771515" k="586.5968"/>
+    <Angle class1="c" class2="c" class3="c3" angle="2.0275489920418126" k="515.4688"/>
+    <Angle class1="c3" class2="cc" class3="ca" angle="2.2081905696232256" k="512.9584"/>
+    <Angle class1="c3" class2="cc" class3="cc" angle="2.0240583335378237" k="540.5728"/>
+    <Angle class1="c3" class2="cc" class3="cd" angle="2.0847957915072266" k="541.4096000000001"/>
+    <Angle class1="c3" class2="cc" class3="cf" angle="2.056695990550118" k="546.4304"/>
+    <Angle class1="c3" class2="cc" class3="ha" angle="2.120924107023509" k="376.56"/>
+    <Angle class1="c3" class2="cc" class3="n2" angle="2.1937043368316727" k="552.288"/>
+    <Angle class1="c3" class2="cc" class3="n" angle="2.080257935452041" k="553.9616000000001"/>
+    <Angle class1="c3" class2="cc" class3="na" angle="2.1420425909726406" k="546.4304"/>
+    <Angle class1="c3" class2="cc" class3="nc" angle="2.1109757302871417" k="552.288"/>
+    <Angle class1="c3" class2="cc" class3="nd" angle="2.1364575373662587" k="556.472"/>
+    <Angle class1="c3" class2="cc" class3="os" angle="2.0385445663293766" k="565.6768"/>
+    <Angle class1="c3" class2="cc" class3="ss" angle="2.1210986399487086" k="508.7744"/>
+    <Angle class1="c" class2="c" class3="c" angle="1.9491837086272672" k="522.1632"/>
+    <Angle class1="c" class2="c" class3="ca" angle="2.069960492865275" k="515.4688"/>
+    <Angle class1="ca" class2="cc" class3="cc" angle="1.9380136014145035" k="562.3296"/>
+    <Angle class1="ca" class2="cc" class3="cd" angle="1.9811232339387637" k="565.6768"/>
+    <Angle class1="ca" class2="cc" class3="ce" angle="2.2167426829579977" k="520.4896"/>
+    <Angle class1="ca" class2="cc" class3="h4" angle="2.255838058202671" k="375.7232"/>
+    <Angle class1="ca" class2="cc" class3="ha" angle="2.1649064041737662" k="383.2544"/>
+    <Angle class1="ca" class2="cc" class3="n" angle="2.0537289308217277" k="568.1872000000001"/>
+    <Angle class1="ca" class2="cc" class3="nc" angle="2.104692544979962" k="563.1664"/>
+    <Angle class1="ca" class2="cc" class3="nd" angle="2.1509437701578116" k="565.6768"/>
+    <Angle class1="ca" class2="cc" class3="nh" angle="2.131570615460675" k="558.9824"/>
+    <Angle class1="ca" class2="cc" class3="oh" angle="2.051634535719334" k="577.392"/>
+    <Angle class1="ca" class2="cc" class3="os" angle="2.002765316663493" k="581.576"/>
+    <Angle class1="ca" class2="cc" class3="ss" angle="2.10835773640915" k="514.6320000000001"/>
+    <Angle class1="c" class2="cc" class3="c2" angle="2.1148154546415294" k="547.2672000000001"/>
+    <Angle class1="c" class2="cc" class3="c3" angle="2.0552997271485225" k="529.6944"/>
+    <Angle class1="c" class2="cc" class3="c" angle="2.1130701253895348" k="528.8576"/>
+    <Angle class1="c" class2="c" class3="cc" angle="1.9490091757020678" k="535.552"/>
+    <Angle class1="c" class2="cc" class3="ca" angle="2.1458823153270283" k="527.184"/>
+    <Angle class1="c" class2="cc" class3="cc" angle="2.141344459271843" k="532.2048"/>
+    <Angle class1="cc" class2="c" class3="cc" angle="2.0217894055102312" k="540.5728"/>
+    <Angle class1="cc" class2="cc" class3="cc" angle="1.9320794819577227" k="568.1872000000001"/>
+    <Angle class1="cc" class2="cc" class3="cd" angle="1.9929914728523246" k="570.6976000000001"/>
+    <Angle class1="cc" class2="cc" class3="ce" angle="2.217615347583995" k="525.5104"/>
+    <Angle class1="cc" class2="cc" class3="cf" angle="2.141868058047441" k="551.4512000000001"/>
+    <Angle class1="cc" class2="cc" class3="cg" angle="2.19754406118606" k="533.8783999999999"/>
+    <Angle class1="c" class2="cc" class3="cd" angle="2.1179570472951186" k="544.7568"/>
+    <Angle class1="cc" class2="c" class3="cd" angle="1.9685568633244044" k="548.104"/>
+    <Angle class1="c" class2="cc" class3="ce" angle="2.1217967716495063" k="530.5312"/>
+    <Angle class1="cc" class2="c" class3="ce" angle="2.0170770165298464" k="538.8992000000001"/>
+    <Angle class1="cc" class2="cc" class3="f" angle="2.080257935452041" k="555.6352"/>
+    <Angle class1="c" class2="cc" class3="cg" angle="2.0573941222509156" k="543.9200000000001"/>
+    <Angle class1="cc" class2="cc" class3="h4" angle="2.233323310851944" k="384.0912"/>
+    <Angle class1="cc" class2="cc" class3="ha" angle="2.1130701253895348" k="394.13280000000003"/>
+    <Angle class1="c" class2="cc" class3="cl" angle="2.0312141834710005" k="487.0176"/>
+    <Angle class1="cc" class2="cc" class3="n2" angle="2.1329668788622698" k="579.0656"/>
+    <Angle class1="cc" class2="cc" class3="n" angle="2.0924752402160016" k="569.024"/>
+    <Angle class1="cc" class2="cc" class3="na" angle="2.055474260073722" k="574.0448"/>
+    <Angle class1="cc" class2="cc" class3="nc" angle="2.1289526215826835" k="565.6768"/>
+    <Angle class1="cc" class2="cc" class3="nd" angle="1.9645426060448175" k="599.1487999999999"/>
+    <Angle class1="cc" class2="cc" class3="nh" angle="2.089508180487611" k="570.6976000000001"/>
+    <Angle class1="cc" class2="cc" class3="oh" angle="2.116560783893523" k="574.8816"/>
+    <Angle class1="cc" class2="cc" class3="os" angle="2.0479693442901463" k="581.576"/>
+    <Angle class1="cc" class2="cc" class3="pd" angle="2.0134118251006585" k="676.1344"/>
+    <Angle class1="cc" class2="cc" class3="ss" angle="2.0980602938223836" k="517.9792"/>
+    <Angle class1="cc" class2="cc" class3="sy" angle="2.238384765682728" k="495.38560000000007"/>
+    <Angle class1="c" class2="c" class3="cd" angle="1.9490091757020678" k="535.552"/>
+    <Angle class1="cd" class2="cc" class3="cd" angle="2.0957913657947906" k="567.3504"/>
+    <Angle class1="cd" class2="cc" class3="ce" angle="2.2348941071787394" k="533.0416"/>
+    <Angle class1="cd" class2="cc" class3="cl" angle="2.153910829886202" k="481.16"/>
+    <Angle class1="cd" class2="cc" class3="f" angle="2.115164520491928" k="563.1664"/>
+    <Angle class1="cd" class2="cc" class3="h4" angle="2.2423990229623145" k="395.8064"/>
+    <Angle class1="cd" class2="cc" class3="ha" angle="2.1251128972282958" k="405.848"/>
+    <Angle class1="cd" class2="cc" class3="n" angle="2.11760798144472" k="576.5552"/>
+    <Angle class1="cd" class2="cc" class3="na" angle="1.8673277667087331" k="614.2112000000001"/>
+    <Angle class1="cd" class2="cc" class3="nc" angle="1.9486601098516692" k="604.1696000000001"/>
+    <Angle class1="cd" class2="cc" class3="nh" angle="2.161415745669778" k="572.3712"/>
+    <Angle class1="cd" class2="cc" class3="no" angle="2.2460642143915024" k="549.7776"/>
+    <Angle class1="cd" class2="cc" class3="oh" angle="2.160368548118581" k="581.576"/>
+    <Angle class1="cd" class2="cc" class3="os" angle="2.0996310901491784" k="586.5968"/>
+    <Angle class1="cd" class2="cc" class3="ss" angle="1.9469147805996745" k="542.2464"/>
+    <Angle class1="cd" class2="cc" class3="sy" angle="2.173807583358937" k="507.10080000000005"/>
+    <Angle class1="ce" class2="cc" class3="na" angle="2.1703169248549488" k="553.1247999999999"/>
+    <Angle class1="ce" class2="cc" class3="nc" angle="2.113593724165133" k="562.3296"/>
+    <Angle class1="ce" class2="cc" class3="nd" angle="2.124065699677099" k="569.8607999999999"/>
+    <Angle class1="ce" class2="cc" class3="os" angle="2.0727530196684656" k="572.3712"/>
+    <Angle class1="ce" class2="cc" class3="ss" angle="2.1219713045747057" k="512.9584"/>
+    <Angle class1="c" class2="cc" class3="f" angle="2.0416861589829667" k="552.288"/>
+    <Angle class1="cg" class2="cc" class3="na" angle="2.139948195870247" k="563.1664"/>
+    <Angle class1="cg" class2="cc" class3="ss" angle="2.107136005932754" k="517.1424"/>
+    <Angle class1="cc" class2="c" class3="h4" angle="2.0041615800650887" k="394.13280000000003"/>
+    <Angle class1="c" class2="cc" class3="ha" angle="2.035752039526186" k="392.4592"/>
+    <Angle class1="cl" class2="cc" class3="na" angle="2.1139427900155323" k="497.05920000000003"/>
+    <Angle class1="cl" class2="cc" class3="nd" angle="2.130523417909478" k="499.56960000000004"/>
+    <Angle class1="cl" class2="cc" class3="ss" angle="2.091777108515204" k="483.6704"/>
+    <Angle class1="c" class2="cc" class3="n2" angle="2.1629865419965726" k="564.84"/>
+    <Angle class1="c" class2="cc" class3="n" angle="2.031039650545801" k="568.1872000000001"/>
+    <Angle class1="cc" class2="c" class3="n" angle="1.9669860669976096" k="578.2288"/>
+    <Angle class1="c" class2="cc" class3="nc" angle="2.152340033559407" k="553.9616000000001"/>
+    <Angle class1="cc" class2="c" class3="nd" angle="2.0287707225182086" k="567.3504"/>
+    <Angle class1="c" class2="cc" class3="nd" angle="2.127207292330689" k="565.6768"/>
+    <Angle class1="c" class2="cc" class3="ne" angle="2.092300707290802" k="560.6560000000001"/>
+    <Angle class1="cc" class2="c" class3="o" angle="2.1629865419965726" k="578.2288"/>
+    <Angle class1="c" class2="cc" class3="oh" angle="1.983741227816755" k="584.0864"/>
+    <Angle class1="cc" class2="c" class3="oh" angle="1.9694295279504015" k="585.76"/>
+    <Angle class1="c" class2="cc" class3="os" angle="2.081479665928437" k="568.1872000000001"/>
+    <Angle class1="cc" class2="c" class3="os" angle="1.9931660057775245" k="580.7392000000001"/>
+    <Angle class1="cc" class2="c" class3="s" angle="2.2040017794184394" k="519.6528000000001"/>
+    <Angle class1="cc" class2="c" class3="ss" angle="1.9617500792416265" k="522.1632"/>
+    <Angle class1="cx" class2="cc" class3="nd" angle="2.2319270474503483" k="552.288"/>
+    <Angle class1="cx" class2="cc" class3="os" angle="2.0605357149045056" k="570.6976000000001"/>
+    <Angle class1="cd" class2="c" class3="cd" angle="2.0217894055102312" k="540.5728"/>
+    <Angle class1="cd" class2="c" class3="cx" angle="2.0493656076917417" k="530.5312"/>
+    <Angle class1="cd" class2="c" class3="n" angle="1.9669860669976096" k="578.2288"/>
+    <Angle class1="cd" class2="c" class3="nc" angle="2.0287707225182086" k="567.3504"/>
+    <Angle class1="cd" class2="c" class3="nd" angle="1.9853120241435498" k="574.0448"/>
+    <Angle class1="cd" class2="c" class3="o" angle="2.1629865419965726" k="578.2288"/>
+    <Angle class1="cd" class2="c" class3="oh" angle="1.9694295279504015" k="585.76"/>
+    <Angle class1="cd" class2="c" class3="os" angle="1.9931660057775245" k="580.7392000000001"/>
+    <Angle class1="ce" class2="c" class3="ce" angle="2.0214403396598324" k="535.552"/>
+    <Angle class1="ce" class2="c" class3="cf" angle="2.031039650545801" k="533.8783999999999"/>
+    <Angle class1="ce" class2="c" class3="cx" angle="2.00677957394308" k="533.8783999999999"/>
+    <Angle class1="ce" class2="c" class3="h4" angle="2.0052087776162852" k="390.78560000000004"/>
+    <Angle class1="ce" class2="c" class3="ha" angle="2.010968364147866" k="390.78560000000004"/>
+    <Angle class1="ce" class2="c" class3="n" angle="2.010968364147866" k="568.1872000000001"/>
+    <Angle class1="ce" class2="c" class3="o" angle="2.1502456384570143" k="575.7184"/>
+    <Angle class1="ce" class2="c" class3="oh" angle="1.9830430961159573" k="579.9024"/>
+    <Angle class1="ce" class2="c" class3="os" angle="1.9360937392373099" k="585.76"/>
+    <Angle class1="ce" class2="c" class3="s" angle="2.1402972617206464" k="525.5104"/>
+    <Angle class1="ce" class2="c" class3="ss" angle="1.9284142905285344" k="525.5104"/>
+    <Angle class1="cf" class2="c" class3="cf" angle="2.0214403396598324" k="535.552"/>
+    <Angle class1="cf" class2="c" class3="ha" angle="2.010968364147866" k="390.78560000000004"/>
+    <Angle class1="cf" class2="c" class3="n" angle="2.010968364147866" k="568.1872000000001"/>
+    <Angle class1="cf" class2="c" class3="o" angle="2.1502456384570143" k="575.7184"/>
+    <Angle class1="cf" class2="c" class3="oh" angle="1.9830430961159573" k="579.9024"/>
+    <Angle class1="cf" class2="c" class3="os" angle="1.9360937392373099" k="585.76"/>
+    <Angle class1="cf" class2="c" class3="s" angle="2.1402972617206464" k="525.5104"/>
+    <Angle class1="cg" class2="c" class3="cg" angle="2.0137608909510574" k="548.104"/>
+    <Angle class1="cg" class2="c" class3="ha" angle="1.9879300180215413" k="399.99039999999997"/>
+    <Angle class1="cg" class2="c" class3="o" angle="2.1254619630786946" k="588.2704"/>
+    <Angle class1="c" class2="c" class3="h4" angle="2.0210912738094335" k="374.8864"/>
+    <Angle class1="h4" class2="cc" class3="n" angle="2.01917141163224" k="425.0944"/>
+    <Angle class1="h4" class2="cc" class3="na" angle="2.103645347428765" k="416.7264"/>
+    <Angle class1="h4" class2="cc" class3="nc" angle="2.1142918558659307" k="418.40000000000003"/>
+    <Angle class1="h4" class2="cc" class3="nd" angle="2.067691564837682" k="435.9728"/>
+    <Angle class1="h4" class2="cc" class3="os" angle="2.0053833105414847" k="433.4624"/>
+    <Angle class1="h4" class2="cc" class3="ss" angle="2.093871503617597" k="352.2928"/>
+    <Angle class1="h5" class2="cc" class3="n" angle="2.0193459445574393" k="425.0944"/>
+    <Angle class1="h5" class2="cc" class3="na" angle="2.1214477057991075" k="415.05280000000005"/>
+    <Angle class1="h5" class2="cc" class3="nc" angle="2.1453587165514296" k="415.05280000000005"/>
+    <Angle class1="h5" class2="cc" class3="nd" angle="2.1907372771032825" k="423.42080000000004"/>
+    <Angle class1="h5" class2="cc" class3="os" angle="2.039068165104975" k="430.1152"/>
+    <Angle class1="h5" class2="cc" class3="ss" angle="2.1121974607635376" k="350.6192"/>
+    <Angle class1="c" class2="c" class3="ha" angle="2.0146335555770545" k="375.7232"/>
+    <Angle class1="ha" class2="cc" class3="na" angle="2.1205750411731104" k="415.05280000000005"/>
+    <Angle class1="ha" class2="cc" class3="nc" angle="2.0340067102741917" k="425.9312"/>
+    <Angle class1="ha" class2="cc" class3="nd" angle="2.0748474147708587" k="435.136"/>
+    <Angle class1="ha" class2="cc" class3="os" angle="1.9348720087609137" k="441.8304"/>
+    <Angle class1="ha" class2="cc" class3="pd" angle="2.1251128972282958" k="448.5248"/>
+    <Angle class1="ha" class2="cc" class3="ss" angle="2.1230185021259023" k="349.7824"/>
+    <Angle class1="ch" class2="c" class3="ch" angle="2.0137608909510574" k="548.104"/>
+    <Angle class1="ch" class2="c" class3="ha" angle="1.9879300180215413" k="399.99039999999997"/>
+    <Angle class1="ch" class2="c" class3="o" angle="2.1254619630786946" k="588.2704"/>
+    <Angle class1="cl" class2="c" class3="cl" angle="1.9425514574696885" k="449.36160000000007"/>
+    <Angle class1="cl" class2="c" class3="f" angle="1.9547687622336491" k="485.344"/>
+    <Angle class1="cl" class2="c" class3="ha" angle="1.9181168479417683" k="330.536"/>
+    <Angle class1="cl" class2="c" class3="o" angle="2.1064378742319563" k="492.03839999999997"/>
+    <Angle class1="cl" class2="c" class3="s" angle="2.2270401255447645" k="469.44480000000004"/>
+    <Angle class1="c" class2="c" class3="n" angle="1.967684198698407" k="558.9824"/>
+    <Angle class1="na" class2="cc" class3="nc" angle="2.128429022807085" k="590.7808"/>
+    <Angle class1="na" class2="cc" class3="nd" angle="1.9586084865880367" k="626.7632000000001"/>
+    <Angle class1="na" class2="cc" class3="no" angle="2.1745057150597353" k="571.5344"/>
+    <Angle class1="na" class2="cc" class3="oh" angle="2.0504128052429382" k="610.0272000000001"/>
+    <Angle class1="na" class2="cc" class3="sx" angle="2.0423842906837644" k="528.8576"/>
+    <Angle class1="na" class2="cc" class3="sy" angle="2.102423616952369" k="528.0208"/>
+    <Angle class1="nc" class2="cc" class3="nd" angle="2.021614872585032" k="619.232"/>
+    <Angle class1="nc" class2="cc" class3="nh" angle="2.0460494821129527" k="603.3328"/>
+    <Angle class1="nc" class2="cc" class3="no" angle="2.1245892984526975" k="579.9024"/>
+    <Angle class1="nc" class2="cc" class3="ss" angle="2.140471794645846" k="530.5312"/>
+    <Angle class1="nd" class2="cc" class3="nd" angle="2.2352431730291378" k="601.6592"/>
+    <Angle class1="nd" class2="cc" class3="ne" angle="2.2516492679978843" k="584.9232000000001"/>
+    <Angle class1="nd" class2="cc" class3="nh" angle="2.1057397425311586" k="605.8432"/>
+    <Angle class1="nd" class2="cc" class3="no" angle="2.1423916568230394" k="587.4336000000001"/>
+    <Angle class1="nd" class2="cc" class3="oh" angle="2.1139427900155323" k="615.048"/>
+    <Angle class1="nd" class2="cc" class3="os" angle="2.03749736877818" k="622.5792000000001"/>
+    <Angle class1="nd" class2="cc" class3="sh" angle="2.181137966217314" k="525.5104"/>
+    <Angle class1="nd" class2="cc" class3="ss" angle="1.9985765264587068" k="552.288"/>
+    <Angle class1="nd" class2="cc" class3="sx" angle="2.2294835864975564" k="509.6112"/>
+    <Angle class1="nd" class2="cc" class3="sy" angle="2.1472785787286237" k="526.3472"/>
+    <Angle class1="ne" class2="cc" class3="ss" angle="2.042558823608964" k="542.2464"/>
+    <Angle class1="nh" class2="cc" class3="nh" angle="2.0238838006126247" k="605.8432"/>
+    <Angle class1="nh" class2="cc" class3="os" angle="2.0364501712269836" k="610.0272000000001"/>
+    <Angle class1="nh" class2="cc" class3="ss" angle="2.125985561854293" k="532.2048"/>
+    <Angle class1="n" class2="cc" class3="n2" angle="2.0842721927316283" k="612.5376"/>
+    <Angle class1="n" class2="cc" class3="na" angle="2.1313960825354754" k="587.4336000000001"/>
+    <Angle class1="n" class2="cc" class3="nc" angle="2.2031291147924423" k="579.9024"/>
+    <Angle class1="n" class2="cc" class3="nd" angle="2.1467549799530254" k="598.312"/>
+    <Angle class1="n" class2="cc" class3="nh" angle="2.0409880272821685" k="601.6592"/>
+    <Angle class1="no" class2="cc" class3="os" angle="2.051634535719334" k="594.9648"/>
+    <Angle class1="no" class2="cc" class3="ss" angle="2.1128955924643353" k="528.8576"/>
+    <Angle class1="n" class2="cc" class3="ss" angle="2.144660584850632" k="528.8576"/>
+    <Angle class1="c" class2="c" class3="o" angle="2.109230401035147" k="562.3296"/>
+    <Angle class1="c" class2="c" class3="oh" angle="1.9559904927100449" k="568.1872000000001"/>
+    <Angle class1="c" class2="c" class3="os" angle="1.9444713196468826" k="569.024"/>
+    <Angle class1="os" class2="cc" class3="ss" angle="2.0818287317788364" k="541.4096000000001"/>
+    <Angle class1="ss" class2="cc" class3="ss" angle="2.118306113145518" k="517.1424"/>
+    <Angle class1="ss" class2="cc" class3="sy" angle="2.124065699677099" k="512.1216000000001"/>
+    <Angle class1="cx" class2="c" class3="cx" angle="1.9882790838719404" k="532.2048"/>
+    <Angle class1="cx" class2="c" class3="n" angle="1.9996237240099033" k="564.84"/>
+    <Angle class1="cx" class2="c" class3="o" angle="2.141868058047441" k="571.5344"/>
+    <Angle class1="cx" class2="c" class3="oh" angle="1.9648916718952163" k="578.2288"/>
+    <Angle class1="cx" class2="c" class3="os" angle="1.9486601098516692" k="579.0656"/>
+    <Angle class1="cy" class2="c" class3="cy" angle="1.6088445044883732" k="573.208"/>
+    <Angle class1="cy" class2="c" class3="n" angle="2.0031143825138917" k="553.1247999999999"/>
+    <Angle class1="cy" class2="c" class3="o" angle="2.3602087474719315" k="530.5312"/>
+    <Angle class1="cy" class2="c" class3="oh" angle="1.9558159597848455" k="567.3504"/>
+    <Angle class1="cy" class2="c" class3="os" angle="1.9409806611428937" k="568.1872000000001"/>
+    <Angle class1="c2" class2="cd" class3="c3" angle="2.201034719690049" k="528.8576"/>
+    <Angle class1="c2" class2="cd" class3="ca" angle="2.1715386553313447" k="543.0832"/>
+    <Angle class1="c2" class2="cd" class3="cc" angle="2.0423842906837644" k="578.2288"/>
+    <Angle class1="c2" class2="cd" class3="cd" angle="2.1326178130118714" k="553.9616000000001"/>
+    <Angle class1="c2" class2="cd" class3="ha" angle="2.141868058047441" k="407.52160000000003"/>
+    <Angle class1="c2" class2="cd" class3="n" angle="2.180090768666117" k="571.5344"/>
+    <Angle class1="c2" class2="cd" class3="os" angle="2.119178777771515" k="586.5968"/>
+    <Angle class1="c3" class2="cd" class3="ca" angle="2.2081905696232256" k="512.9584"/>
+    <Angle class1="c3" class2="cd" class3="cc" angle="2.0847957915072266" k="541.4096000000001"/>
+    <Angle class1="c3" class2="cd" class3="cd" angle="2.0240583335378237" k="540.5728"/>
+    <Angle class1="c3" class2="cd" class3="ce" angle="2.056695990550118" k="546.4304"/>
+    <Angle class1="c3" class2="cd" class3="ha" angle="2.120924107023509" k="376.56"/>
+    <Angle class1="c3" class2="cd" class3="n2" angle="2.1937043368316727" k="552.288"/>
+    <Angle class1="c3" class2="cd" class3="n" angle="2.080257935452041" k="553.9616000000001"/>
+    <Angle class1="c3" class2="cd" class3="na" angle="2.1420425909726406" k="546.4304"/>
+    <Angle class1="c3" class2="cd" class3="nc" angle="2.1364575373662587" k="556.472"/>
+    <Angle class1="c3" class2="cd" class3="nd" angle="2.1109757302871417" k="552.288"/>
+    <Angle class1="c3" class2="cd" class3="os" angle="2.0385445663293766" k="565.6768"/>
+    <Angle class1="c3" class2="cd" class3="ss" angle="2.1210986399487086" k="508.7744"/>
+    <Angle class1="ca" class2="cd" class3="cc" angle="1.9811232339387637" k="565.6768"/>
+    <Angle class1="ca" class2="cd" class3="cd" angle="1.9380136014145035" k="562.3296"/>
+    <Angle class1="ca" class2="cd" class3="ce" angle="2.179916235740918" k="540.5728"/>
+    <Angle class1="ca" class2="cd" class3="h4" angle="2.255838058202671" k="375.7232"/>
+    <Angle class1="ca" class2="cd" class3="ha" angle="2.1649064041737662" k="383.2544"/>
+    <Angle class1="ca" class2="cd" class3="n" angle="2.0537289308217277" k="568.1872000000001"/>
+    <Angle class1="ca" class2="cd" class3="na" angle="2.154608961587" k="554.7984"/>
+    <Angle class1="ca" class2="cd" class3="nc" angle="2.1509437701578116" k="565.6768"/>
+    <Angle class1="ca" class2="cd" class3="nd" angle="2.104692544979962" k="563.1664"/>
+    <Angle class1="ca" class2="cd" class3="oh" angle="2.051634535719334" k="577.392"/>
+    <Angle class1="ca" class2="cd" class3="os" angle="2.002765316663493" k="581.576"/>
+    <Angle class1="ca" class2="cd" class3="ss" angle="2.10835773640915" k="514.6320000000001"/>
+    <Angle class1="c" class2="cd" class3="c2" angle="2.1148154546415294" k="547.2672000000001"/>
+    <Angle class1="c" class2="cd" class3="c3" angle="2.0552997271485225" k="529.6944"/>
+    <Angle class1="c" class2="cd" class3="c" angle="2.1130701253895348" k="528.8576"/>
+    <Angle class1="c" class2="cd" class3="ca" angle="2.1458823153270283" k="527.184"/>
+    <Angle class1="c" class2="cd" class3="cc" angle="2.1179570472951186" k="544.7568"/>
+    <Angle class1="cc" class2="cd" class3="cc" angle="2.0957913657947906" k="567.3504"/>
+    <Angle class1="cc" class2="cd" class3="cd" angle="1.9929914728523246" k="570.6976000000001"/>
+    <Angle class1="cc" class2="cd" class3="cf" angle="2.2348941071787394" k="533.0416"/>
+    <Angle class1="cc" class2="cd" class3="ch" angle="2.1954496660836673" k="543.9200000000001"/>
+    <Angle class1="cc" class2="cd" class3="cl" angle="2.153910829886202" k="481.16"/>
+    <Angle class1="cc" class2="cd" class3="cy" angle="2.1289526215826835" k="534.7152"/>
+    <Angle class1="c" class2="cd" class3="cd" angle="2.141344459271843" k="532.2048"/>
+    <Angle class1="c" class2="cd" class3="cf" angle="2.1217967716495063" k="530.5312"/>
+    <Angle class1="cc" class2="cd" class3="h4" angle="2.2423990229623145" k="395.8064"/>
+    <Angle class1="cc" class2="cd" class3="ha" angle="2.1251128972282958" k="405.848"/>
+    <Angle class1="c" class2="cd" class3="cl" angle="2.0312141834710005" k="487.0176"/>
+    <Angle class1="cc" class2="cd" class3="n" angle="2.11760798144472" k="576.5552"/>
+    <Angle class1="cc" class2="cd" class3="na" angle="1.8673277667087331" k="614.2112000000001"/>
+    <Angle class1="cc" class2="cd" class3="nc" angle="2.1610666798193785" k="584.0864"/>
+    <Angle class1="cc" class2="cd" class3="nd" angle="1.9486601098516692" k="604.1696000000001"/>
+    <Angle class1="cc" class2="cd" class3="nh" angle="2.161415745669778" k="572.3712"/>
+    <Angle class1="cc" class2="cd" class3="oh" angle="2.160368548118581" k="581.576"/>
+    <Angle class1="cc" class2="cd" class3="os" angle="2.0996310901491784" k="586.5968"/>
+    <Angle class1="cc" class2="cd" class3="ss" angle="1.9469147805996745" k="542.2464"/>
+    <Angle class1="cc" class2="cd" class3="sy" angle="2.173807583358937" k="507.10080000000005"/>
+    <Angle class1="cd" class2="cd" class3="cd" angle="1.9320794819577227" k="568.1872000000001"/>
+    <Angle class1="cd" class2="cd" class3="ce" angle="2.141868058047441" k="551.4512000000001"/>
+    <Angle class1="cd" class2="cd" class3="cf" angle="2.217615347583995" k="525.5104"/>
+    <Angle class1="cd" class2="cd" class3="ch" angle="2.19754406118606" k="533.8783999999999"/>
+    <Angle class1="cd" class2="cd" class3="cy" angle="2.1467549799530254" k="524.6736000000001"/>
+    <Angle class1="cd" class2="cd" class3="h4" angle="2.233323310851944" k="384.0912"/>
+    <Angle class1="cd" class2="cd" class3="ha" angle="2.1130701253895348" k="394.13280000000003"/>
+    <Angle class1="cd" class2="cd" class3="n2" angle="2.1329668788622698" k="579.0656"/>
+    <Angle class1="cd" class2="cd" class3="n" angle="2.0924752402160016" k="569.024"/>
+    <Angle class1="cd" class2="cd" class3="na" angle="2.055474260073722" k="574.0448"/>
+    <Angle class1="cd" class2="cd" class3="nc" angle="1.9645426060448175" k="599.1487999999999"/>
+    <Angle class1="cd" class2="cd" class3="nd" angle="2.1289526215826835" k="565.6768"/>
+    <Angle class1="cd" class2="cd" class3="nh" angle="2.089508180487611" k="570.6976000000001"/>
+    <Angle class1="cd" class2="cd" class3="oh" angle="2.116560783893523" k="574.8816"/>
+    <Angle class1="cd" class2="cd" class3="os" angle="2.0479693442901463" k="581.576"/>
+    <Angle class1="cd" class2="cd" class3="pc" angle="2.0134118251006585" k="676.1344"/>
+    <Angle class1="cd" class2="cd" class3="ss" angle="2.0980602938223836" k="517.9792"/>
+    <Angle class1="ce" class2="cd" class3="nd" angle="2.1638592066225697" k="574.8816"/>
+    <Angle class1="cf" class2="cd" class3="na" angle="2.1703169248549488" k="553.1247999999999"/>
+    <Angle class1="cf" class2="cd" class3="nc" angle="2.124065699677099" k="569.8607999999999"/>
+    <Angle class1="cf" class2="cd" class3="nd" angle="2.113593724165133" k="562.3296"/>
+    <Angle class1="cf" class2="cd" class3="os" angle="2.0727530196684656" k="572.3712"/>
+    <Angle class1="cf" class2="cd" class3="ss" angle="2.1219713045747057" k="512.9584"/>
+    <Angle class1="c" class2="cd" class3="h4" angle="2.062804642932098" k="389.9488"/>
+    <Angle class1="c" class2="cd" class3="ha" angle="2.035752039526186" k="392.4592"/>
+    <Angle class1="cl" class2="cd" class3="nc" angle="2.130523417909478" k="499.56960000000004"/>
+    <Angle class1="c" class2="cd" class3="n2" angle="2.1629865419965726" k="564.84"/>
+    <Angle class1="c" class2="cd" class3="n" angle="2.031039650545801" k="568.1872000000001"/>
+    <Angle class1="c" class2="cd" class3="nc" angle="2.127207292330689" k="565.6768"/>
+    <Angle class1="c" class2="cd" class3="nd" angle="2.152340033559407" k="553.9616000000001"/>
+    <Angle class1="c" class2="cd" class3="oh" angle="1.983741227816755" k="584.0864"/>
+    <Angle class1="c" class2="cd" class3="os" angle="2.081479665928437" k="568.1872000000001"/>
+    <Angle class1="h4" class2="cd" class3="n" angle="2.01917141163224" k="425.0944"/>
+    <Angle class1="h4" class2="cd" class3="na" angle="2.103645347428765" k="416.7264"/>
+    <Angle class1="h4" class2="cd" class3="nc" angle="2.067691564837682" k="435.9728"/>
+    <Angle class1="h4" class2="cd" class3="nd" angle="2.1142918558659307" k="418.40000000000003"/>
+    <Angle class1="h4" class2="cd" class3="os" angle="2.0053833105414847" k="433.4624"/>
+    <Angle class1="h4" class2="cd" class3="ss" angle="2.093871503617597" k="352.2928"/>
+    <Angle class1="h5" class2="cd" class3="n" angle="2.0193459445574393" k="425.0944"/>
+    <Angle class1="h5" class2="cd" class3="na" angle="2.1214477057991075" k="415.05280000000005"/>
+    <Angle class1="h5" class2="cd" class3="nc" angle="2.1907372771032825" k="423.42080000000004"/>
+    <Angle class1="h5" class2="cd" class3="nd" angle="2.1453587165514296" k="415.05280000000005"/>
+    <Angle class1="h5" class2="cd" class3="os" angle="2.039068165104975" k="430.1152"/>
+    <Angle class1="h5" class2="cd" class3="ss" angle="2.1121974607635376" k="350.6192"/>
+    <Angle class1="ha" class2="cd" class3="na" angle="2.1205750411731104" k="415.05280000000005"/>
+    <Angle class1="ha" class2="cd" class3="nc" angle="2.0748474147708587" k="435.136"/>
+    <Angle class1="ha" class2="cd" class3="nd" angle="2.0340067102741917" k="425.9312"/>
+    <Angle class1="ha" class2="cd" class3="os" angle="1.9348720087609137" k="441.8304"/>
+    <Angle class1="ha" class2="cd" class3="pc" angle="2.1251128972282958" k="448.5248"/>
+    <Angle class1="ha" class2="cd" class3="ss" angle="2.1230185021259023" k="349.7824"/>
+    <Angle class1="na" class2="cd" class3="nc" angle="1.9586084865880367" k="626.7632000000001"/>
+    <Angle class1="na" class2="cd" class3="nd" angle="2.128429022807085" k="590.7808"/>
+    <Angle class1="na" class2="cd" class3="nh" angle="2.04692214673895" k="600.8224"/>
+    <Angle class1="na" class2="cd" class3="ss" angle="1.9453439842728797" k="555.6352"/>
+    <Angle class1="nc" class2="cd" class3="nd" angle="2.021614872585032" k="619.232"/>
+    <Angle class1="nc" class2="cd" class3="nh" angle="2.1057397425311586" k="605.8432"/>
+    <Angle class1="nc" class2="cd" class3="oh" angle="2.1139427900155323" k="615.048"/>
+    <Angle class1="nc" class2="cd" class3="os" angle="2.03749736877818" k="622.5792000000001"/>
+    <Angle class1="nc" class2="cd" class3="ss" angle="1.9985765264587068" k="552.288"/>
+    <Angle class1="nd" class2="cd" class3="nd" angle="2.193878869756872" k="584.0864"/>
+    <Angle class1="nd" class2="cd" class3="nh" angle="2.0460494821129527" k="603.3328"/>
+    <Angle class1="nd" class2="cd" class3="ss" angle="2.140471794645846" k="530.5312"/>
+    <Angle class1="nh" class2="cd" class3="nh" angle="2.0238838006126247" k="605.8432"/>
+    <Angle class1="nh" class2="cd" class3="os" angle="2.0364501712269836" k="610.0272000000001"/>
+    <Angle class1="nh" class2="cd" class3="ss" angle="2.125985561854293" k="532.2048"/>
+    <Angle class1="n" class2="cd" class3="na" angle="2.1313960825354754" k="587.4336000000001"/>
+    <Angle class1="n" class2="cd" class3="nc" angle="2.1467549799530254" k="598.312"/>
+    <Angle class1="n" class2="cd" class3="nd" angle="2.2031291147924423" k="579.9024"/>
+    <Angle class1="n" class2="cd" class3="nh" angle="2.0409880272821685" k="601.6592"/>
+    <Angle class1="n" class2="cd" class3="ss" angle="2.144660584850632" k="528.8576"/>
+    <Angle class1="oh" class2="cd" class3="os" angle="1.947961978150871" k="633.4576000000001"/>
+    <Angle class1="os" class2="cd" class3="ss" angle="2.0818287317788364" k="541.4096000000001"/>
+    <Angle class1="ss" class2="cd" class3="ss" angle="2.118306113145518" k="517.1424"/>
+    <Angle class1="ss" class2="cd" class3="sy" angle="2.124065699677099" k="512.1216000000001"/>
+    <Angle class1="c2" class2="ce" class3="c3" angle="2.138551932468652" k="535.552"/>
+    <Angle class1="c2" class2="ce" class3="ca" angle="2.1254619630786946" k="546.4304"/>
+    <Angle class1="c2" class2="ce" class3="cc" angle="2.152340033559407" k="548.104"/>
+    <Angle class1="c2" class2="ce" class3="ce" angle="2.1512928360082104" k="547.2672000000001"/>
+    <Angle class1="c2" class2="ce" class3="cg" angle="2.130872483759877" k="556.472"/>
+    <Angle class1="c2" class2="ce" class3="cl" angle="2.090206312188409" k="483.6704"/>
+    <Angle class1="c2" class2="ce" class3="h4" angle="2.173807583358937" k="406.68480000000005"/>
+    <Angle class1="c2" class2="ce" class3="ha" angle="2.0933479048419987" k="415.05280000000005"/>
+    <Angle class1="c2" class2="ce" class3="n1" angle="2.0635027746328958" k="605.0064"/>
+    <Angle class1="c2" class2="ce" class3="n2" angle="2.246238747316702" k="584.9232000000001"/>
+    <Angle class1="c2" class2="ce" class3="na" angle="2.080257935452041" k="578.2288"/>
+    <Angle class1="c2" class2="ce" class3="ne" angle="2.0650735709596906" k="586.5968"/>
+    <Angle class1="c2" class2="ce" class3="oh" angle="2.158972284716986" k="586.5968"/>
+    <Angle class1="c2" class2="ce" class3="p2" angle="2.063677307558095" k="651.0304"/>
+    <Angle class1="c2" class2="ce" class3="pe" angle="2.0727530196684656" k="648.52"/>
+    <Angle class1="c2" class2="ce" class3="px" angle="2.089508180487611" k="645.1727999999999"/>
+    <Angle class1="c2" class2="ce" class3="py" angle="2.132443280086672" k="643.4992000000001"/>
+    <Angle class1="c2" class2="ce" class3="sx" angle="2.08060700130244" k="511.2848"/>
+    <Angle class1="c2" class2="ce" class3="sy" angle="2.097885760897184" k="517.1424"/>
+    <Angle class1="c3" class2="ce" class3="ca" angle="2.0811306000780383" k="523.0"/>
+    <Angle class1="c3" class2="ce" class3="cc" angle="2.0600121161289073" k="528.8576"/>
+    <Angle class1="c3" class2="ce" class3="ce" angle="2.044129619935759" k="530.5312"/>
+    <Angle class1="c3" class2="ce" class3="cf" angle="2.1359339385906604" k="534.7152"/>
+    <Angle class1="c3" class2="ce" class3="cg" angle="2.0458749491877533" k="534.7152"/>
+    <Angle class1="c3" class2="ce" class3="n2" angle="2.1420425909726406" k="556.472"/>
+    <Angle class1="c3" class2="ce" class3="nf" angle="2.106263341306757" k="559.8192"/>
+    <Angle class1="c3" class2="ce" class3="nh" angle="2.0867156536844202" k="548.9408"/>
+    <Angle class1="ca" class2="ce" class3="ca" angle="2.0565214576249184" k="533.0416"/>
+    <Angle class1="ca" class2="ce" class3="cc" angle="2.0617574453809016" k="536.3888"/>
+    <Angle class1="ca" class2="ce" class3="ce" angle="2.086366587834022" k="532.2048"/>
+    <Angle class1="ca" class2="ce" class3="cf" angle="2.2256438621431687" k="533.0416"/>
+    <Angle class1="ca" class2="ce" class3="cl" angle="1.9999727898603024" k="484.5072"/>
+    <Angle class1="ca" class2="ce" class3="h4" angle="2.0418606919081657" k="389.9488"/>
+    <Angle class1="ca" class2="ce" class3="ha" angle="2.0093975678210714" k="393.296"/>
+    <Angle class1="ca" class2="ce" class3="n2" angle="2.1069614730075545" k="570.6976000000001"/>
+    <Angle class1="ca" class2="ce" class3="nf" angle="2.124240232602298" k="567.3504"/>
+    <Angle class1="ca" class2="ce" class3="nh" angle="2.017251549455046" k="566.5136"/>
+    <Angle class1="ca" class2="ce" class3="oh" angle="2.0263272615654166" k="575.7184"/>
+    <Angle class1="ca" class2="ce" class3="os" angle="2.0230111359866276" k="572.3712"/>
+    <Angle class1="ca" class2="ce" class3="ss" angle="2.051110936943736" k="514.6320000000001"/>
+    <Angle class1="c" class2="ce" class3="c2" angle="2.1017254852515714" k="548.104"/>
+    <Angle class1="c" class2="ce" class3="c3" angle="2.0458749491877533" k="526.3472"/>
+    <Angle class1="c" class2="ce" class3="c" angle="2.133315944712669" k="521.3264"/>
+    <Angle class1="c" class2="ce" class3="ca" angle="2.064375439258893" k="530.5312"/>
+    <Angle class1="cc" class2="ce" class3="cd" angle="2.279574536029794" k="528.8576"/>
+    <Angle class1="cc" class2="ce" class3="cf" angle="2.2015583184656475" k="540.5728"/>
+    <Angle class1="c" class2="ce" class3="cd" angle="2.1078341376335517" k="543.9200000000001"/>
+    <Angle class1="c" class2="ce" class3="ce" angle="2.11149932906274" k="528.0208"/>
+    <Angle class1="c" class2="ce" class3="cf" angle="2.206270707446032" k="533.8783999999999"/>
+    <Angle class1="c" class2="ce" class3="cg" angle="2.0668189002116852" k="538.8992000000001"/>
+    <Angle class1="cc" class2="ce" class3="h4" angle="2.0189968787070405" k="396.6432"/>
+    <Angle class1="cc" class2="ce" class3="ha" angle="2.014808088502254" k="397.48"/>
+    <Angle class1="c" class2="ce" class3="cl" angle="2.015331687277852" k="481.9968"/>
+    <Angle class1="cc" class2="ce" class3="n2" angle="2.1111502632123407" k="575.7184"/>
+    <Angle class1="cc" class2="ce" class3="nh" angle="2.0603611819793057" k="565.6768"/>
+    <Angle class1="c" class2="ce" class3="cy" angle="1.5456635855661782" k="605.0064"/>
+    <Angle class1="cd" class2="ce" class3="ce" angle="2.1703169248549488" k="541.4096000000001"/>
+    <Angle class1="cd" class2="ce" class3="ha" angle="2.0062559751674818" k="419.2368"/>
+    <Angle class1="ce" class2="ce" class3="ce" angle="2.1312215496102755" k="530.5312"/>
+    <Angle class1="ce" class2="ce" class3="cf" angle="2.1683970626777547" k="543.9200000000001"/>
+    <Angle class1="ce" class2="ce" class3="cl" angle="2.0458749491877533" k="481.16"/>
+    <Angle class1="ce" class2="ce" class3="h4" angle="2.0617574453809016" k="392.4592"/>
+    <Angle class1="ce" class2="ce" class3="ha" angle="2.0359265724513853" k="394.9696"/>
+    <Angle class1="ce" class2="ce" class3="n1" angle="2.21918614391079" k="557.3088"/>
+    <Angle class1="ce" class2="ce" class3="n2" angle="2.075720079396856" k="579.9024"/>
+    <Angle class1="ce" class2="ce" class3="oh" angle="2.0394172309553737" k="578.2288"/>
+    <Angle class1="cf" class2="ce" class3="cg" angle="2.149023907980618" k="553.1247999999999"/>
+    <Angle class1="cf" class2="ce" class3="cy" angle="2.3991295897914053" k="504.5904"/>
+    <Angle class1="cf" class2="ce" class3="h4" angle="2.1458823153270283" k="408.3584"/>
+    <Angle class1="cf" class2="ce" class3="ha" angle="2.0633282417076964" k="416.7264"/>
+    <Angle class1="cf" class2="ce" class3="n1" angle="2.0933479048419987" k="599.9856000000001"/>
+    <Angle class1="cf" class2="ce" class3="n" angle="1.8917623762366538" k="605.0064"/>
+    <Angle class1="cf" class2="ce" class3="nh" angle="2.1184806460707173" k="579.0656"/>
+    <Angle class1="cf" class2="ce" class3="oh" angle="2.1238911667518994" k="590.7808"/>
+    <Angle class1="cg" class2="ce" class3="cg" angle="2.033657644423793" k="553.9616000000001"/>
+    <Angle class1="cg" class2="ce" class3="ha" angle="2.0326104468725963" k="402.5008"/>
+    <Angle class1="cg" class2="ce" class3="n1" angle="2.0856684561332237" k="582.4128"/>
+    <Angle class1="cg" class2="ce" class3="n2" angle="2.1142918558659307" k="582.4128"/>
+    <Angle class1="c" class2="ce" class3="ha" angle="2.0326104468725963" k="389.112"/>
+    <Angle class1="c" class2="ce" class3="n" angle="2.067342498987283" k="552.288"/>
+    <Angle class1="c" class2="ce" class3="nh" angle="2.0134118251006585" k="565.6768"/>
+    <Angle class1="c" class2="ce" class3="oh" angle="2.020393142108636" k="574.8816"/>
+    <Angle class1="c" class2="ce" class3="os" angle="2.0013690532618975" k="574.0448"/>
+    <Angle class1="h4" class2="ce" class3="n1" angle="2.035752039526186" k="439.32"/>
+    <Angle class1="h4" class2="ce" class3="n2" angle="2.1202259753227115" k="435.9728"/>
+    <Angle class1="h4" class2="ce" class3="ne" angle="2.018473279931442" k="420.9104"/>
+    <Angle class1="ha" class2="ce" class3="n1" angle="2.0238838006126247" k="440.9936"/>
+    <Angle class1="ha" class2="ce" class3="n2" angle="2.085842989058423" k="440.15680000000003"/>
+    <Angle class1="ha" class2="ce" class3="ne" angle="2.0697859599400754" k="415.88960000000003"/>
+    <Angle class1="ha" class2="ce" class3="nh" angle="2.0069541068682795" k="423.42080000000004"/>
+    <Angle class1="ha" class2="ce" class3="p2" angle="2.0963149645703893" k="430.1152"/>
+    <Angle class1="ha" class2="ce" class3="pe" angle="2.0827013964048335" k="430.1152"/>
+    <Angle class1="ha" class2="ce" class3="px" angle="2.0577431881013144" k="431.78880000000004"/>
+    <Angle class1="ha" class2="ce" class3="py" angle="2.059313984428109" k="435.9728"/>
+    <Angle class1="ha" class2="ce" class3="sx" angle="2.0149826214274538" k="345.59839999999997"/>
+    <Angle class1="ha" class2="ce" class3="sy" angle="2.0046851788406865" k="353.12960000000004"/>
+    <Angle class1="n2" class2="ce" class3="nh" angle="2.183232361319707" k="596.6384"/>
+    <Angle class1="n2" class2="ce" class3="os" angle="2.0586158527273115" k="623.416"/>
+    <Angle class1="n2" class2="ce" class3="ss" angle="2.0460494821129527" k="541.4096000000001"/>
+    <Angle class1="ne" class2="ce" class3="ne" angle="2.161939344445376" k="577.392"/>
+    <Angle class1="ne" class2="ce" class3="nh" angle="1.983392161966356" k="604.1696000000001"/>
+    <Angle class1="nf" class2="ce" class3="nh" angle="2.0816541988536366" k="609.1904"/>
+    <Angle class1="pe" class2="ce" class3="pe" angle="2.26526283616344" k="773.2032"/>
+    <Angle class1="py" class2="ce" class3="py" angle="1.8860027897050726" k="853.5360000000001"/>
+    <Angle class1="sx" class2="ce" class3="sx" angle="2.099980155999577" k="501.2432"/>
+    <Angle class1="sy" class2="ce" class3="sy" angle="2.093871503617597" k="510.44800000000004"/>
+    <Angle class1="c2" class2="cf" class3="c3" angle="2.138551932468652" k="535.552"/>
+    <Angle class1="c2" class2="cf" class3="ca" angle="2.1254619630786946" k="546.4304"/>
+    <Angle class1="c2" class2="cf" class3="cd" angle="2.152340033559407" k="548.104"/>
+    <Angle class1="c2" class2="cf" class3="cf" angle="2.1512928360082104" k="547.2672000000001"/>
+    <Angle class1="c2" class2="cf" class3="ch" angle="2.130872483759877" k="556.472"/>
+    <Angle class1="c2" class2="cf" class3="ha" angle="2.0933479048419987" k="415.05280000000005"/>
+    <Angle class1="c2" class2="cf" class3="n2" angle="2.246238747316702" k="584.9232000000001"/>
+    <Angle class1="c2" class2="cf" class3="nf" angle="2.0650735709596906" k="586.5968"/>
+    <Angle class1="c2" class2="cf" class3="p2" angle="2.063677307558095" k="651.0304"/>
+    <Angle class1="c2" class2="cf" class3="pf" angle="2.0727530196684656" k="648.52"/>
+    <Angle class1="c2" class2="cf" class3="px" angle="2.089508180487611" k="645.1727999999999"/>
+    <Angle class1="c2" class2="cf" class3="py" angle="2.132443280086672" k="643.4992000000001"/>
+    <Angle class1="c2" class2="cf" class3="sx" angle="2.08060700130244" k="511.2848"/>
+    <Angle class1="c2" class2="cf" class3="sy" angle="2.097885760897184" k="517.1424"/>
+    <Angle class1="c3" class2="cf" class3="ca" angle="2.0811306000780383" k="523.0"/>
+    <Angle class1="c3" class2="cf" class3="cd" angle="2.0600121161289073" k="528.8576"/>
+    <Angle class1="c3" class2="cf" class3="ce" angle="2.1359339385906604" k="534.7152"/>
+    <Angle class1="c3" class2="cf" class3="cf" angle="2.044129619935759" k="530.5312"/>
+    <Angle class1="c3" class2="cf" class3="n2" angle="2.1420425909726406" k="556.472"/>
+    <Angle class1="ca" class2="cf" class3="ca" angle="2.0565214576249184" k="533.0416"/>
+    <Angle class1="ca" class2="cf" class3="cc" angle="2.2842869250101785" k="523.8368"/>
+    <Angle class1="ca" class2="cf" class3="cd" angle="2.0617574453809016" k="536.3888"/>
+    <Angle class1="ca" class2="cf" class3="ce" angle="2.2256438621431687" k="533.0416"/>
+    <Angle class1="ca" class2="cf" class3="ha" angle="2.0093975678210714" k="393.296"/>
+    <Angle class1="ca" class2="cf" class3="n2" angle="2.1069614730075545" k="570.6976000000001"/>
+    <Angle class1="ca" class2="cf" class3="ne" angle="2.124240232602298" k="567.3504"/>
+    <Angle class1="ca" class2="cf" class3="oh" angle="2.0263272615654166" k="575.7184"/>
+    <Angle class1="c" class2="cf" class3="c2" angle="2.1017254852515714" k="548.104"/>
+    <Angle class1="c" class2="cf" class3="c3" angle="2.0458749491877533" k="526.3472"/>
+    <Angle class1="c" class2="cf" class3="c" angle="2.133315944712669" k="521.3264"/>
+    <Angle class1="c" class2="cf" class3="cc" angle="2.1078341376335517" k="543.9200000000001"/>
+    <Angle class1="cc" class2="cf" class3="cf" angle="2.1703169248549488" k="541.4096000000001"/>
+    <Angle class1="c" class2="cf" class3="cd" angle="2.056346924699719" k="535.552"/>
+    <Angle class1="c" class2="cf" class3="ce" angle="2.206270707446032" k="533.8783999999999"/>
+    <Angle class1="cc" class2="cf" class3="ha" angle="2.0062559751674818" k="419.2368"/>
+    <Angle class1="cd" class2="cf" class3="ce" angle="2.2015583184656475" k="540.5728"/>
+    <Angle class1="cd" class2="cf" class3="ha" angle="2.014808088502254" k="397.48"/>
+    <Angle class1="cd" class2="cf" class3="n2" angle="2.1111502632123407" k="575.7184"/>
+    <Angle class1="ce" class2="cf" class3="cf" angle="2.1683970626777547" k="543.9200000000001"/>
+    <Angle class1="ce" class2="cf" class3="ch" angle="2.149023907980618" k="553.1247999999999"/>
+    <Angle class1="ce" class2="cf" class3="ha" angle="2.0633282417076964" k="416.7264"/>
+    <Angle class1="ce" class2="cf" class3="n" angle="1.8917623762366538" k="605.0064"/>
+    <Angle class1="ce" class2="cf" class3="oh" angle="2.1238911667518994" k="590.7808"/>
+    <Angle class1="cf" class2="cf" class3="cf" angle="2.1312215496102755" k="530.5312"/>
+    <Angle class1="cf" class2="cf" class3="h4" angle="2.0617574453809016" k="392.4592"/>
+    <Angle class1="cf" class2="cf" class3="ha" angle="2.0359265724513853" k="394.9696"/>
+    <Angle class1="cf" class2="cf" class3="n1" angle="2.21918614391079" k="557.3088"/>
+    <Angle class1="cf" class2="cf" class3="n2" angle="2.075720079396856" k="579.9024"/>
+    <Angle class1="c" class2="cf" class3="ha" angle="2.0326104468725963" k="389.112"/>
+    <Angle class1="ch" class2="cf" class3="ch" angle="2.033657644423793" k="553.9616000000001"/>
+    <Angle class1="ch" class2="cf" class3="ha" angle="2.0326104468725963" k="402.5008"/>
+    <Angle class1="ch" class2="cf" class3="n1" angle="2.0856684561332237" k="582.4128"/>
+    <Angle class1="c" class2="cf" class3="n2" angle="1.9968311972067123" k="584.9232000000001"/>
+    <Angle class1="c" class2="cf" class3="n" angle="2.067342498987283" k="552.288"/>
+    <Angle class1="c" class2="cf" class3="nh" angle="2.0134118251006585" k="565.6768"/>
+    <Angle class1="f" class2="c" class3="f" angle="1.8736109520159128" k="604.1696000000001"/>
+    <Angle class1="h4" class2="cf" class3="n2" angle="2.1202259753227115" k="435.9728"/>
+    <Angle class1="h4" class2="cf" class3="ne" angle="2.104168946204364" k="435.9728"/>
+    <Angle class1="ha" class2="cf" class3="n1" angle="2.0238838006126247" k="440.9936"/>
+    <Angle class1="ha" class2="cf" class3="n2" angle="2.085842989058423" k="440.15680000000003"/>
+    <Angle class1="ha" class2="cf" class3="nf" angle="2.0697859599400754" k="415.88960000000003"/>
+    <Angle class1="ha" class2="cf" class3="nh" angle="2.0069541068682795" k="423.42080000000004"/>
+    <Angle class1="ha" class2="cf" class3="p2" angle="2.0963149645703893" k="430.1152"/>
+    <Angle class1="ha" class2="cf" class3="pf" angle="2.0827013964048335" k="430.1152"/>
+    <Angle class1="ha" class2="cf" class3="px" angle="2.0577431881013144" k="431.78880000000004"/>
+    <Angle class1="ha" class2="cf" class3="py" angle="2.059313984428109" k="435.9728"/>
+    <Angle class1="ha" class2="cf" class3="sx" angle="2.0149826214274538" k="345.59839999999997"/>
+    <Angle class1="ha" class2="cf" class3="sy" angle="2.0046851788406865" k="353.12960000000004"/>
+    <Angle class1="n2" class2="cf" class3="nh" angle="2.183232361319707" k="596.6384"/>
+    <Angle class1="nf" class2="cf" class3="nf" angle="2.161939344445376" k="577.392"/>
+    <Angle class1="f" class2="c" class3="o" angle="2.1544344286618005" k="611.7008"/>
+    <Angle class1="pf" class2="cf" class3="pf" angle="2.26526283616344" k="773.2032"/>
+    <Angle class1="py" class2="cf" class3="py" angle="1.8860027897050726" k="853.5360000000001"/>
+    <Angle class1="f" class2="c" class3="s" angle="2.1642082724729685" k="531.368"/>
+    <Angle class1="sx" class2="cf" class3="sx" angle="2.099980155999577" k="501.2432"/>
+    <Angle class1="sy" class2="cf" class3="sy" angle="2.093871503617597" k="510.44800000000004"/>
+    <Angle class1="c1" class2="cg" class3="ca" angle="3.134087737806217" k="474.46560000000005"/>
+    <Angle class1="c1" class2="cg" class3="cc" angle="3.117332576987072" k="477.81280000000004"/>
+    <Angle class1="c1" class2="cg" class3="ce" angle="3.107558733175904" k="477.81280000000004"/>
+    <Angle class1="c1" class2="cg" class3="cg" angle="3.1358330670582113" k="489.528"/>
+    <Angle class1="c1" class2="cg" class3="ne" angle="2.9674087942407588" k="526.3472"/>
+    <Angle class1="c1" class2="cg" class3="pe" angle="3.024481060780974" k="601.6592"/>
+    <Angle class1="ca" class2="cg" class3="ch" angle="3.1316442768534256" k="476.1392"/>
+    <Angle class1="ca" class2="cg" class3="n1" angle="3.132691474404622" k="492.8752"/>
+    <Angle class1="c" class2="cg" class3="c1" angle="3.1265828220226415" k="471.1184"/>
+    <Angle class1="cc" class2="cg" class3="n1" angle="3.1175071099122715" k="496.2224"/>
+    <Angle class1="ce" class2="cg" class3="ch" angle="3.10563887099871" k="479.4864"/>
+    <Angle class1="ce" class2="cg" class3="n1" angle="3.106162469774308" k="497.05920000000003"/>
+    <Angle class1="n1" class2="cg" class3="ne" angle="3.0373964972457315" k="542.2464"/>
+    <Angle class1="h4" class2="c" class3="o" angle="2.1066124071571557" k="453.54560000000004"/>
+    <Angle class1="h5" class2="c" class3="n" angle="1.95756128903684" k="430.1152"/>
+    <Angle class1="h5" class2="c" class3="o" angle="2.1580996200909888" k="449.36160000000007"/>
+    <Angle class1="ha" class2="c" class3="ha" angle="2.0177751482306445" k="317.1472"/>
+    <Angle class1="ha" class2="c" class3="i" angle="1.9299850868553294" k="307.10560000000004"/>
+    <Angle class1="ha" class2="c" class3="n" angle="1.961226480466028" k="430.1152"/>
+    <Angle class1="ha" class2="c" class3="o" angle="2.1282544898818854" k="452.70880000000005"/>
+    <Angle class1="ha" class2="c" class3="oh" angle="1.9516271695800593" k="440.15680000000003"/>
+    <Angle class1="ha" class2="c" class3="os" angle="1.925796296650543" k="441.8304"/>
+    <Angle class1="ha" class2="c" class3="s" angle="2.0867156536844202" k="370.7024"/>
+    <Angle class1="c1" class2="ch" class3="ca" angle="3.134087737806217" k="474.46560000000005"/>
+    <Angle class1="c1" class2="ch" class3="cf" angle="3.107558733175904" k="477.81280000000004"/>
+    <Angle class1="c1" class2="ch" class3="ch" angle="3.1358330670582113" k="488.6912"/>
+    <Angle class1="c1" class2="ch" class3="nf" angle="2.9674087942407588" k="525.5104"/>
+    <Angle class1="c1" class2="ch" class3="pf" angle="3.024481060780974" k="600.8224"/>
+    <Angle class1="ca" class2="ch" class3="cg" angle="3.1316442768534256" k="476.1392"/>
+    <Angle class1="ca" class2="ch" class3="n1" angle="3.132691474404622" k="492.8752"/>
+    <Angle class1="c" class2="ch" class3="c1" angle="3.1265828220226415" k="470.2816"/>
+    <Angle class1="cd" class2="ch" class3="n1" angle="3.1176816428374705" k="496.2224"/>
+    <Angle class1="cf" class2="ch" class3="cg" angle="3.10563887099871" k="479.4864"/>
+    <Angle class1="cf" class2="ch" class3="n1" angle="3.106162469774308" k="497.05920000000003"/>
+    <Angle class1="cg" class2="ch" class3="ch" angle="3.1342622707314174" k="491.20160000000004"/>
+    <Angle class1="n1" class2="ch" class3="nf" angle="3.0373964972457315" k="542.2464"/>
+    <Angle class1="i" class2="c" class3="i" angle="2.032435913947397" k="500.4064"/>
+    <Angle class1="i" class2="c" class3="o" angle="2.1296507532834807" k="464.42400000000004"/>
+    <Angle class1="f" class2="cl" class3="f" angle="1.5271630954950381" k="0.0"/>
+    <Angle class1="n2" class2="c" class3="n2" angle="1.925272697874945" k="600.8224"/>
+    <Angle class1="n2" class2="c" class3="o" angle="2.1380283336930535" k="610.0272000000001"/>
+    <Angle class1="n4" class2="c" class3="n4" angle="2.0008454544862997" k="541.4096000000001"/>
+    <Angle class1="n4" class2="c" class3="o" angle="2.0739747501448615" k="581.576"/>
+    <Angle class1="nc" class2="c" class3="o" angle="2.149896572606615" k="618.3952"/>
+    <Angle class1="nd" class2="c" class3="o" angle="2.149896572606615" k="618.3952"/>
+    <Angle class1="ne" class2="c" class3="ne" angle="1.925272697874945" k="613.3744"/>
+    <Angle class1="ne" class2="c" class3="o" angle="2.195798731934066" k="610.864"/>
+    <Angle class1="nf" class2="c" class3="nf" angle="1.925272697874945" k="613.3744"/>
+    <Angle class1="nf" class2="c" class3="o" angle="2.195798731934066" k="610.864"/>
+    <Angle class1="n" class2="c" class3="n" angle="1.9819958985647608" k="610.0272000000001"/>
+    <Angle class1="n" class2="c" class3="nc" angle="2.043955087010559" k="599.1487999999999"/>
+    <Angle class1="n" class2="c" class3="nd" angle="2.043955087010559" k="599.1487999999999"/>
+    <Angle class1="n" class2="c" class3="ne" angle="1.924400033248948" k="616.7216000000001"/>
+    <Angle class1="n" class2="c" class3="o" angle="2.1476276445790226" k="620.9056"/>
+    <Angle class1="n" class2="c" class3="oh" angle="1.9690804621000024" k="621.7424"/>
+    <Angle class1="no" class2="c" class3="no" angle="1.9072958065794035" k="556.472"/>
+    <Angle class1="no" class2="c" class3="o" angle="2.1879447503000913" k="568.1872000000001"/>
+    <Angle class1="n" class2="c" class3="os" angle="1.9062486090282067" k="630.1104"/>
+    <Angle class1="n" class2="c" class3="s" angle="2.1650809370989657" k="547.2672000000001"/>
+    <Angle class1="n" class2="c" class3="sh" angle="1.971698455977994" k="541.4096000000001"/>
+    <Angle class1="n" class2="c" class3="ss" angle="1.924923632024546" k="547.2672000000001"/>
+    <Angle class1="oh" class2="c" class3="oh" angle="1.9296360210049306" k="638.4784"/>
+    <Angle class1="oh" class2="c" class3="s" angle="2.1544344286618005" k="553.9616000000001"/>
+    <Angle class1="o" class2="c" class3="o" angle="2.273291350722614" k="651.8672"/>
+    <Angle class1="o" class2="c" class3="oh" angle="2.131047016685076" k="635.1312"/>
+    <Angle class1="o" class2="c" class3="os" angle="2.1511183030830114" k="630.1104"/>
+    <Angle class1="o" class2="c" class3="p2" angle="2.1485003092050197" k="633.4576000000001"/>
+    <Angle class1="o" class2="c" class3="p3" angle="2.1081832034839505" k="645.1727999999999"/>
+    <Angle class1="o" class2="c" class3="p5" angle="2.1148154546415294" k="644.336"/>
+    <Angle class1="o" class2="c" class3="pe" angle="2.147104045803424" k="629.2736000000001"/>
+    <Angle class1="o" class2="c" class3="pf" angle="2.147104045803424" k="629.2736000000001"/>
+    <Angle class1="o" class2="c" class3="px" angle="2.0786871391252464" k="642.6624"/>
+    <Angle class1="o" class2="c" class3="py" angle="2.1294762203582813" k="647.6832"/>
+    <Angle class1="o" class2="c" class3="s4" angle="2.11446638879113" k="512.1216000000001"/>
+    <Angle class1="o" class2="c" class3="s6" angle="2.0847957915072266" k="516.3056"/>
+    <Angle class1="o" class2="c" class3="s" angle="2.1020745511019703" k="571.5344"/>
+    <Angle class1="o" class2="c" class3="sh" angle="2.130174352059079" k="531.368"/>
+    <Angle class1="os" class2="c" class3="os" angle="1.9423769245444895" k="632.6208"/>
+    <Angle class1="o" class2="c" class3="ss" angle="2.152340033559407" k="527.184"/>
+    <Angle class1="os" class2="c" class3="s" angle="2.1818360979181115" k="549.7776"/>
+    <Angle class1="os" class2="c" class3="ss" angle="1.9442967867216832" k="549.7776"/>
+    <Angle class1="o" class2="c" class3="sx" angle="2.11446638879113" k="508.7744"/>
+    <Angle class1="o" class2="c" class3="sy" angle="2.0825268634796337" k="517.9792"/>
+    <Angle class1="p2" class2="c" class3="p2" angle="1.9853120241435498" k="789.9392"/>
+    <Angle class1="p3" class2="c" class3="p3" angle="2.0601866490541068" k="782.408"/>
+    <Angle class1="p3" class2="c" class3="py" angle="1.5721925901964922" k="899.5600000000001"/>
+    <Angle class1="p5" class2="c" class3="p5" angle="2.1600194822681824" k="764.8352000000001"/>
+    <Angle class1="ca" class2="cp" class3="ca" angle="2.066120768510887" k="558.1456000000001"/>
+    <Angle class1="ca" class2="cp" class3="cp" angle="2.1137682570903324" k="535.552"/>
+    <Angle class1="ca" class2="cp" class3="na" angle="2.0856684561332237" k="574.0448"/>
+    <Angle class1="ca" class2="cp" class3="nb" angle="2.122669436275504" k="577.392"/>
+    <Angle class1="cp" class2="cp" class3="cp" angle="1.5707963267948966" k="605.8432"/>
+    <Angle class1="cp" class2="cp" class3="cq" angle="2.1689206614533534" k="521.3264"/>
+    <Angle class1="cp" class2="cp" class3="nb" angle="2.0352284407505876" k="570.6976000000001"/>
+    <Angle class1="pe" class2="c" class3="pe" angle="1.9856610899939486" k="785.7552000000001"/>
+    <Angle class1="pf" class2="c" class3="pf" angle="1.9856610899939486" k="785.7552000000001"/>
+    <Angle class1="nb" class2="cp" class3="nb" angle="2.1954496660836673" k="596.6384"/>
+    <Angle class1="py" class2="c" class3="py" angle="2.16071761396898" k="770.6928"/>
+    <Angle class1="ca" class2="cq" class3="ca" angle="2.066120768510887" k="558.1456000000001"/>
+    <Angle class1="ca" class2="cq" class3="cq" angle="2.1137682570903324" k="535.552"/>
+    <Angle class1="ca" class2="cq" class3="nb" angle="2.122669436275504" k="577.392"/>
+    <Angle class1="cp" class2="cq" class3="cq" angle="2.1692697273037522" k="521.3264"/>
+    <Angle class1="cq" class2="cq" class3="cq" angle="1.5707963267948966" k="605.8432"/>
+    <Angle class1="cq" class2="cq" class3="nb" angle="2.0352284407505876" k="570.6976000000001"/>
+    <Angle class1="s4" class2="c" class3="s4" angle="1.89909275909503" k="512.1216000000001"/>
+    <Angle class1="s6" class2="c" class3="s6" angle="2.0202186091834364" k="497.05920000000003"/>
+    <Angle class1="sh" class2="c" class3="sh" angle="2.0128882263250603" k="517.9792"/>
+    <Angle class1="s" class2="c" class3="s" angle="2.2078415037728267" k="531.368"/>
+    <Angle class1="s" class2="c" class3="sh" angle="2.1406463275710452" k="518.816"/>
+    <Angle class1="s" class2="c" class3="ss" angle="2.1500711055318145" k="517.1424"/>
+    <Angle class1="ss" class2="c" class3="ss" angle="1.962099145092025" k="523.8368"/>
+    <Angle class1="sx" class2="c" class3="sx" angle="1.8989182261698305" k="508.7744"/>
+    <Angle class1="sy" class2="c" class3="sy" angle="2.0207422079590347" k="497.896"/>
+    <Angle class1="c2" class2="cu" class3="cx" angle="2.5935592684635735" k="498.73280000000005"/>
+    <Angle class1="c" class2="cu" class3="cu" angle="1.0925761117484503" k="794.96"/>
+    <Angle class1="cu" class2="cu" class3="cx" angle="1.1266100321623396" k="761.488"/>
+    <Angle class1="cu" class2="cu" class3="ha" angle="2.578374903971223" k="385.76480000000004"/>
+    <Angle class1="cv" class2="cv" class3="cy" angle="1.6491616102094417" k="609.1904"/>
+    <Angle class1="cv" class2="cv" class3="ha" angle="2.3300145514124297" k="394.9696"/>
+    <Angle class1="cx" class2="cv" class3="cx" angle="1.585631625436848" k="594.9648"/>
+    <Angle class1="cy" class2="cv" class3="ha" angle="2.304009145557714" k="357.31360000000006"/>
+    <Angle class1="c1" class2="cx" class3="cx" angle="2.082875929330033" k="528.8576"/>
+    <Angle class1="c2" class2="cx" class3="cx" angle="2.098234826747583" k="520.4896"/>
+    <Angle class1="c2" class2="cx" class3="h1" angle="2.022487537211029" k="389.9488"/>
+    <Angle class1="c2" class2="cx" class3="hc" angle="2.010095699521869" k="390.78560000000004"/>
+    <Angle class1="c2" class2="cx" class3="os" angle="1.9179423150165686" k="579.9024"/>
+    <Angle class1="c3" class2="cx" class3="c3" angle="1.992642407001926" k="525.5104"/>
+    <Angle class1="c3" class2="cx" class3="cx" angle="2.0963149645703893" k="514.6320000000001"/>
+    <Angle class1="c3" class2="cx" class3="h1" angle="2.012015561699063" k="382.41760000000005"/>
+    <Angle class1="c3" class2="cx" class3="hc" angle="1.9980529276831085" k="383.2544"/>
+    <Angle class1="c3" class2="cx" class3="n3" angle="1.9509290378792614" k="557.3088"/>
+    <Angle class1="c3" class2="cx" class3="os" angle="1.9280652246781358" k="570.6976000000001"/>
+    <Angle class1="ca" class2="cx" class3="cx" angle="2.126509160629891" k="515.4688"/>
+    <Angle class1="ca" class2="cx" class3="h1" angle="2.0031143825138917" k="389.112"/>
+    <Angle class1="ca" class2="cx" class3="hc" angle="1.9847884253679515" k="390.78560000000004"/>
+    <Angle class1="ca" class2="cx" class3="oh" angle="1.9710003242771965" k="578.2288"/>
+    <Angle class1="ca" class2="cx" class3="os" angle="2.064899038034491" k="552.288"/>
+    <Angle class1="c" class2="cx" class3="c3" angle="2.053554397896528" k="520.4896"/>
+    <Angle class1="cc" class2="cx" class3="cx" angle="2.0776399415740503" k="525.5104"/>
+    <Angle class1="cc" class2="cx" class3="hc" angle="1.9863592216947463" k="396.6432"/>
+    <Angle class1="c" class2="cx" class3="cx" angle="2.0591394515029102" k="522.1632"/>
+    <Angle class1="cd" class2="cx" class3="cx" angle="2.1078341376335517" k="519.6528000000001"/>
+    <Angle class1="c" class2="cx" class3="h1" angle="2.0294688542190062" k="384.928"/>
+    <Angle class1="c" class2="cx" class3="hc" angle="2.036275638301784" k="384.0912"/>
+    <Angle class1="cl" class2="cx" class3="cl" angle="1.924923632024546" k="525.5104"/>
+    <Angle class1="cl" class2="cx" class3="cx" angle="2.0907299109640074" k="502.08000000000004"/>
+    <Angle class1="cl" class2="cx" class3="h1" angle="1.929286955154532" k="357.31360000000006"/>
+    <Angle class1="cl" class2="cx" class3="hc" angle="2.0210912738094335" k="328.8624"/>
+    <Angle class1="c" class2="cx" class3="os" angle="1.8954275676658416" k="579.0656"/>
+    <Angle class1="cu" class2="cx" class3="cu" angle="0.8885471221903132" k="814.2064"/>
+    <Angle class1="cu" class2="cx" class3="cx" angle="1.0199704148654862" k="749.7728"/>
+    <Angle class1="cu" class2="cx" class3="hc" angle="2.0715312891920696" k="388.2752"/>
+    <Angle class1="cx" class2="cx" class3="cx" angle="1.0471975511965976" k="731.3632000000001"/>
+    <Angle class1="cx" class2="cx" class3="cy" angle="2.1818360979181115" k="502.9168"/>
+    <Angle class1="cx" class2="cx" class3="f" angle="2.0736256842944627" k="535.552"/>
+    <Angle class1="cx" class2="cx" class3="h1" angle="2.0715312891920696" k="379.9072"/>
+    <Angle class1="cx" class2="cx" class3="hc" angle="2.0540779966721265" k="381.5808"/>
+    <Angle class1="cx" class2="cx" class3="hx" angle="2.0875883183104174" k="378.2336"/>
+    <Angle class1="cx" class2="cx" class3="n3" angle="2.064899038034491" k="544.7568"/>
+    <Angle class1="cx" class2="cx" class3="na" angle="2.200336587989251" k="524.6736000000001"/>
+    <Angle class1="cx" class2="cx" class3="nh" angle="2.0657717026604883" k="546.4304"/>
+    <Angle class1="cx" class2="cx" class3="os" angle="2.0429078894593626" k="557.3088"/>
+    <Angle class1="cy" class2="cx" class3="hc" angle="1.9643680731196178" k="385.76480000000004"/>
+    <Angle class1="f" class2="cx" class3="f" angle="1.9120081955597878" k="582.4128"/>
+    <Angle class1="f" class2="cx" class3="h1" angle="1.9491837086272672" k="420.9104"/>
+    <Angle class1="f" class2="cx" class3="hc" angle="1.9600047499896318" k="419.2368"/>
+    <Angle class1="h1" class2="cx" class3="h1" angle="2.0151571543526527" k="320.4944"/>
+    <Angle class1="h1" class2="cx" class3="n3" angle="1.9790288388363704" k="413.3792"/>
+    <Angle class1="h1" class2="cx" class3="n" angle="1.9942132033287208" k="414.216"/>
+    <Angle class1="h1" class2="cx" class3="na" angle="1.8896679811342605" k="419.2368"/>
+    <Angle class1="h1" class2="cx" class3="nh" angle="2.0095721007462712" k="412.5424"/>
+    <Angle class1="h1" class2="cx" class3="os" angle="1.9977038618327094" k="423.42080000000004"/>
+    <Angle class1="h2" class2="cx" class3="h2" angle="2.0165534177542486" k="321.3312"/>
+    <Angle class1="h2" class2="cx" class3="n2" angle="2.045176817486955" k="397.48"/>
+    <Angle class1="hc" class2="cx" class3="hc" angle="1.9971802630571114" k="322.168"/>
+    <Angle class1="hc" class2="cx" class3="os" angle="1.9914206765255298" k="416.7264"/>
+    <Angle class1="hx" class2="cx" class3="n4" angle="1.9237019015481498" k="405.01120000000003"/>
+    <Angle class1="n2" class2="cx" class3="n2" angle="0.8564330639536176" k="881.1504"/>
+    <Angle class1="n" class2="cx" class3="oh" angle="2.0038125142146894" k="594.128"/>
+    <Angle class1="n" class2="cx" class3="os" angle="1.1515682404658587" k="771.5296000000001"/>
+    <Angle class1="oh" class2="cx" class3="oh" angle="1.8823375982758843" k="641.8256"/>
+    <Angle class1="oh" class2="cx" class3="os" angle="2.061582912455702" k="595.8016"/>
+    <Angle class1="os" class2="cx" class3="os" angle="2.0254545969394195" k="585.76"/>
+    <Angle class1="c2" class2="cy" class3="cy" angle="2.007128639793479" k="518.816"/>
+    <Angle class1="c3" class2="cy" class3="c3" angle="1.943947720871284" k="527.184"/>
+    <Angle class1="c3" class2="cy" class3="cy" angle="2.055474260073722" k="508.7744"/>
+    <Angle class1="c3" class2="cy" class3="h1" angle="1.9509290378792614" k="384.928"/>
+    <Angle class1="c3" class2="cy" class3="hc" angle="1.9219565722961558" k="388.2752"/>
+    <Angle class1="c3" class2="cy" class3="n3" angle="1.9242255003237483" k="556.472"/>
+    <Angle class1="c3" class2="cy" class3="n" angle="1.9380136014145035" k="558.1456000000001"/>
+    <Angle class1="c3" class2="cy" class3="os" angle="1.9214329735205575" k="565.6768"/>
+    <Angle class1="c" class2="cy" class3="c3" angle="2.0367992370773824" k="512.1216000000001"/>
+    <Angle class1="cc" class2="cy" class3="cy" angle="2.122843969200703" k="507.10080000000005"/>
+    <Angle class1="c" class2="cy" class3="cy" angle="1.486322390998371" k="594.9648"/>
+    <Angle class1="cd" class2="cy" class3="cy" angle="2.1128955924643353" k="506.264"/>
+    <Angle class1="ce" class2="cy" class3="h2" angle="2.051110936943736" k="379.9072"/>
+    <Angle class1="ce" class2="cy" class3="n" angle="1.5348425442038134" k="625.0896"/>
+    <Angle class1="ce" class2="cy" class3="ss" angle="2.104867077905161" k="490.36480000000006"/>
+    <Angle class1="c" class2="cy" class3="h1" angle="1.971698455977994" k="379.0704"/>
+    <Angle class1="c" class2="cy" class3="hc" angle="1.9415042599184922" k="381.5808"/>
+    <Angle class1="cl" class2="cy" class3="cy" angle="2.046398547963351" k="501.2432"/>
+    <Angle class1="cl" class2="cy" class3="h1" angle="1.868025898409531" k="362.3344"/>
+    <Angle class1="cl" class2="cy" class3="hc" angle="1.9896753472735356" k="326.35200000000003"/>
+    <Angle class1="c" class2="cy" class3="n" angle="2.048667475990944" k="539.736"/>
+    <Angle class1="c" class2="cy" class3="os" angle="2.0099211665966696" k="549.7776"/>
+    <Angle class1="cv" class2="cy" class3="cy" angle="1.5135495273294826" k="595.8016"/>
+    <Angle class1="cv" class2="cy" class3="hc" angle="1.9966566642815131" k="383.2544"/>
+    <Angle class1="cx" class2="cy" class3="cy" angle="1.863138976503947" k="535.552"/>
+    <Angle class1="cx" class2="cy" class3="hc" angle="2.0647245051092917" k="378.2336"/>
+    <Angle class1="cy" class2="cy" class3="cy" angle="1.543569190463785" k="583.2496000000001"/>
+    <Angle class1="cy" class2="cy" class3="f" angle="2.0186478128566416" k="532.2048"/>
+    <Angle class1="cy" class2="cy" class3="h1" angle="1.9751891144819826" k="377.39680000000004"/>
+    <Angle class1="cy" class2="cy" class3="h2" angle="2.0383700334041777" k="371.5392"/>
+    <Angle class1="cy" class2="cy" class3="hc" angle="2.0029398495886928" k="374.8864"/>
+    <Angle class1="cy" class2="cy" class3="n3" angle="2.035053907825388" k="536.3888"/>
+    <Angle class1="cy" class2="cy" class3="n" angle="2.0921261743656028" k="532.2048"/>
+    <Angle class1="cy" class2="cy" class3="na" angle="2.085319390282825" k="531.368"/>
+    <Angle class1="cy" class2="cy" class3="oh" angle="2.0001473227855016" k="550.6144"/>
+    <Angle class1="cy" class2="cy" class3="os" angle="2.002067184962695" k="548.9408"/>
+    <Angle class1="cy" class2="cy" class3="s6" angle="2.043431488234961" k="493.71200000000005"/>
+    <Angle class1="cy" class2="cy" class3="ss" angle="2.0642009063336935" k="491.20160000000004"/>
+    <Angle class1="h1" class2="cy" class3="h1" angle="1.9100883333825942" k="327.1888"/>
+    <Angle class1="h1" class2="cy" class3="n3" angle="1.9226547039969533" k="415.88960000000003"/>
+    <Angle class1="h1" class2="cy" class3="n" angle="1.8847810592286764" k="425.9312"/>
+    <Angle class1="h1" class2="cy" class3="oh" angle="1.904328746851013" k="431.78880000000004"/>
+    <Angle class1="h1" class2="cy" class3="os" angle="1.9064231419534063" k="428.44160000000005"/>
+    <Angle class1="h1" class2="cy" class3="s6" angle="1.940631595292495" k="345.59839999999997"/>
+    <Angle class1="h2" class2="cy" class3="n" angle="1.9984019935335071" k="405.01120000000003"/>
+    <Angle class1="h2" class2="cy" class3="os" angle="1.8996163578706282" k="429.2784"/>
+    <Angle class1="h2" class2="cy" class3="s6" angle="1.9345229429105149" k="346.4352"/>
+    <Angle class1="h2" class2="cy" class3="ss" angle="1.9139280577369817" k="348.10880000000003"/>
+    <Angle class1="hc" class2="cy" class3="hc" angle="1.901885285898221" k="328.02560000000005"/>
+    <Angle class1="n" class2="cy" class3="os" angle="1.9357446733869108" k="599.9856000000001"/>
+    <Angle class1="n" class2="cy" class3="s6" angle="1.8008307222077493" k="546.4304"/>
+    <Angle class1="n" class2="cy" class3="ss" angle="1.8348646426216384" k="542.2464"/>
+    <Angle class1="nh" class2="cz" class3="nh" angle="2.0968385633459876" k="610.864"/>
+    <Angle class1="br" class2="n1" class3="c1" angle="3.141592653589793" k="427.6048"/>
+    <Angle class1="c1" class2="n1" class3="c1" angle="3.1401963901881977" k="535.552"/>
+    <Angle class1="c1" class2="n1" class3="c2" angle="3.1019736795695216" k="502.08000000000004"/>
+    <Angle class1="c1" class2="n1" class3="c3" angle="3.1017991466443227" k="469.44480000000004"/>
+    <Angle class1="c1" class2="n1" class3="ca" angle="3.141418120664594" k="491.20160000000004"/>
+    <Angle class1="c1" class2="n1" class3="cl" angle="3.140719988963796" k="418.40000000000003"/>
+    <Angle class1="c1" class2="n1" class3="f" angle="3.140894521888996" k="466.09760000000006"/>
+    <Angle class1="c1" class2="n1" class3="hn" angle="3.141243587739394" k="378.2336"/>
+    <Angle class1="c1" class2="n1" class3="i" angle="3.140719988963796" k="387.4384"/>
+    <Angle class1="c1" class2="n1" class3="n1" angle="3.141592653589793" k="553.1247999999999"/>
+    <Angle class1="c1" class2="n1" class3="n2" angle="2.9942868647214715" k="543.0832"/>
+    <Angle class1="c1" class2="n1" class3="n3" angle="3.0646236335768435" k="506.264"/>
+    <Angle class1="c1" class2="n1" class3="n4" angle="3.1361821329086106" k="497.896"/>
+    <Angle class1="c1" class2="n1" class3="na" angle="3.141592653589793" k="499.56960000000004"/>
+    <Angle class1="c1" class2="n1" class3="nh" angle="3.077888135892" k="507.10080000000005"/>
+    <Angle class1="c1" class2="n1" class3="o" angle="3.140719988963796" k="521.3264"/>
+    <Angle class1="c1" class2="n1" class3="oh" angle="3.0422834191513157" k="523.8368"/>
+    <Angle class1="c1" class2="n1" class3="os" angle="3.0824259919471855" k="517.9792"/>
+    <Angle class1="c1" class2="n1" class3="p2" angle="3.0164525462218" k="569.8607999999999"/>
+    <Angle class1="c1" class2="n1" class3="p3" angle="3.028320785135361" k="574.0448"/>
+    <Angle class1="c1" class2="n1" class3="p4" angle="3.0305897131629536" k="567.3504"/>
+    <Angle class1="c1" class2="n1" class3="p5" angle="3.0941196979355476" k="597.4752000000001"/>
+    <Angle class1="c1" class2="n1" class3="s2" angle="3.1086059307271006" k="503.75360000000006"/>
+    <Angle class1="c1" class2="n1" class3="s4" angle="2.9600784113823826" k="461.91360000000003"/>
+    <Angle class1="c1" class2="n1" class3="s" angle="3.141418120664594" k="446.01439999999997"/>
+    <Angle class1="c1" class2="n1" class3="s6" angle="3.070383220108424" k="515.4688"/>
+    <Angle class1="c1" class2="n1" class3="sh" angle="3.0412362216001196" k="466.09760000000006"/>
+    <Angle class1="c1" class2="n1" class3="ss" angle="3.0728266810612164" k="463.5872"/>
+    <Angle class1="c2" class2="n1" class3="n1" angle="3.141592653589793" k="513.7952"/>
+    <Angle class1="c2" class2="n1" class3="o" angle="2.0409880272821685" k="611.7008"/>
+    <Angle class1="c2" class2="n1" class3="s" angle="2.0594885173533086" k="541.4096000000001"/>
+    <Angle class1="c3" class2="n1" class3="n1" angle="3.141592653589793" k="480.3232"/>
+    <Angle class1="ca" class2="n1" class3="n1" angle="3.141592653589793" k="506.264"/>
+    <Angle class1="ce" class2="n1" class3="o" angle="2.1362830044410592" k="596.6384"/>
+    <Angle class1="ce" class2="n1" class3="s" angle="2.0479693442901463" k="542.2464"/>
+    <Angle class1="cf" class2="n1" class3="o" angle="2.1362830044410592" k="596.6384"/>
+    <Angle class1="cf" class2="n1" class3="s" angle="2.0479693442901463" k="542.2464"/>
+    <Angle class1="cl" class2="n1" class3="n1" angle="3.1405454560385966" k="429.2784"/>
+    <Angle class1="f" class2="n1" class3="n1" angle="3.140370923113397" k="479.4864"/>
+    <Angle class1="hn" class2="n1" class3="n1" angle="3.140021857262998" k="391.62239999999997"/>
+    <Angle class1="i" class2="n1" class3="n1" angle="3.1405454560385966" k="395.8064"/>
+    <Angle class1="n1" class2="n1" class3="n1" angle="3.141069054814195" k="571.5344"/>
+    <Angle class1="n1" class2="n1" class3="n2" angle="3.0168016120721983" k="558.1456000000001"/>
+    <Angle class1="n1" class2="n1" class3="n3" angle="3.0558969873168715" k="521.3264"/>
+    <Angle class1="n1" class2="n1" class3="n4" angle="3.140021857262998" k="512.1216000000001"/>
+    <Angle class1="n1" class2="n1" class3="na" angle="3.141069054814195" k="514.6320000000001"/>
+    <Angle class1="n1" class2="n1" class3="nh" angle="3.07177948351002" k="523.0"/>
+    <Angle class1="n1" class2="n1" class3="o" angle="3.1405454560385966" k="537.2256000000001"/>
+    <Angle class1="n1" class2="n1" class3="oh" angle="3.032858641190547" k="540.5728"/>
+    <Angle class1="n1" class2="n1" class3="os" angle="3.0738738786124133" k="533.8783999999999"/>
+    <Angle class1="n1" class2="n1" class3="p2" angle="3.0492647361592935" k="580.7392000000001"/>
+    <Angle class1="n1" class2="n1" class3="p3" angle="3.041585287450518" k="587.4336000000001"/>
+    <Angle class1="n1" class2="n1" class3="s" angle="3.141592653589793" k="456.8928"/>
+    <Angle class1="n1" class2="n1" class3="sh" angle="3.0555479214664722" k="476.976"/>
+    <Angle class1="n1" class2="n1" class3="ss" angle="3.0649726994272424" k="476.1392"/>
+    <Angle class1="o" class2="n1" class3="p2" angle="2.0254545969394195" k="708.7696000000001"/>
+    <Angle class1="p2" class2="n1" class3="s" angle="2.0931733719167993" k="671.9504000000001"/>
+    <Angle class1="br" class2="n2" class3="br" angle="1.8605209826259552" k="534.7152"/>
+    <Angle class1="br" class2="n2" class3="c2" angle="1.9617500792416265" k="494.5488"/>
+    <Angle class1="br" class2="n2" class3="n2" angle="1.9271925600521387" k="511.2848"/>
+    <Angle class1="br" class2="n2" class3="o" angle="1.997878394757909" k="502.9168"/>
+    <Angle class1="br" class2="n2" class3="p2" angle="1.9378390684893043" k="669.44"/>
+    <Angle class1="br" class2="n2" class3="s" angle="2.0207422079590347" k="522.1632"/>
+    <Angle class1="c1" class2="n2" class3="c1" angle="2.113593724165133" k="629.2736000000001"/>
+    <Angle class1="c1" class2="n2" class3="c3" angle="2.6508060679289875" k="495.38560000000007"/>
+    <Angle class1="c1" class2="n2" class3="cl" angle="2.0734511513692633" k="463.5872"/>
+    <Angle class1="c1" class2="n2" class3="hn" angle="2.2078415037728267" k="435.136"/>
+    <Angle class1="c1" class2="n2" class3="n2" angle="1.9792033717615696" k="646.8464"/>
+    <Angle class1="c1" class2="n2" class3="o" angle="1.9825194973403588" k="663.5824"/>
+    <Angle class1="c1" class2="n2" class3="p2" angle="2.0868901866096197" k="710.4432"/>
+    <Angle class1="c1" class2="n2" class3="s" angle="2.0537289308217277" k="585.76"/>
+    <Angle class1="c2" class2="n2" class3="c2" angle="2.0626301100068987" k="594.9648"/>
+    <Angle class1="c2" class2="n2" class3="c3" angle="2.012364627549462" k="557.3088"/>
+    <Angle class1="c2" class2="n2" class3="ca" angle="2.0933479048419987" k="585.76"/>
+    <Angle class1="c2" class2="n2" class3="cl" angle="1.9659388694464126" k="474.46560000000005"/>
+    <Angle class1="c2" class2="n2" class3="f" angle="1.8873990531066678" k="572.3712"/>
+    <Angle class1="c2" class2="n2" class3="hn" angle="1.933824811209717" k="441.8304"/>
+    <Angle class1="c2" class2="n2" class3="i" angle="2.002590783738294" k="433.4624"/>
+    <Angle class1="c2" class2="n2" class3="n1" angle="2.008699436120274" k="630.1104"/>
+    <Angle class1="c2" class2="n2" class3="n2" angle="1.807986572140926" k="655.2144"/>
+    <Angle class1="c2" class2="n2" class3="n3" angle="2.061931978306101" k="598.312"/>
+    <Angle class1="c2" class2="n2" class3="n4" angle="1.9586084865880367" k="522.1632"/>
+    <Angle class1="c2" class2="n2" class3="n" angle="2.058266786876913" k="590.7808"/>
+    <Angle class1="c2" class2="n2" class3="na" angle="2.052158134494933" k="589.9440000000001"/>
+    <Angle class1="c2" class2="n2" class3="nh" angle="2.0526817332705307" k="594.128"/>
+    <Angle class1="c2" class2="n2" class3="no" angle="2.0598375832037075" k="572.3712"/>
+    <Angle class1="c2" class2="n2" class3="o" angle="2.0409880272821685" k="631.784"/>
+    <Angle class1="c2" class2="n2" class3="oh" angle="1.9394098648160991" k="604.1696000000001"/>
+    <Angle class1="c2" class2="n2" class3="os" angle="1.9366173380129081" k="602.496"/>
+    <Angle class1="c2" class2="n2" class3="p2" angle="2.0245819323134224" k="712.1168"/>
+    <Angle class1="c2" class2="n2" class3="p3" angle="2.0821777976292353" k="649.3568"/>
+    <Angle class1="c2" class2="n2" class3="p4" angle="2.072927552593665" k="663.5824"/>
+    <Angle class1="c2" class2="n2" class3="s4" angle="1.9598302170644328" k="570.6976000000001"/>
+    <Angle class1="c2" class2="n2" class3="s6" angle="2.0287707225182086" k="576.5552"/>
+    <Angle class1="c2" class2="n2" class3="s" angle="2.0594885173533086" k="575.7184"/>
+    <Angle class1="c2" class2="n2" class3="sh" angle="2.0155062202030516" k="528.0208"/>
+    <Angle class1="c2" class2="n2" class3="ss" angle="2.0601866490541068" k="543.9200000000001"/>
+    <Angle class1="c3" class2="n2" class3="c3" angle="1.9320794819577227" k="537.2256000000001"/>
+    <Angle class1="c3" class2="n2" class3="ca" angle="2.008001304419476" k="554.7984"/>
+    <Angle class1="c3" class2="n2" class3="ce" angle="2.071182223341671" k="548.104"/>
+    <Angle class1="c3" class2="n2" class3="cf" angle="2.071182223341671" k="548.104"/>
+    <Angle class1="c3" class2="n2" class3="hn" angle="2.066469834361286" k="380.744"/>
+    <Angle class1="c3" class2="n2" class3="n1" angle="2.0263272615654166" k="575.7184"/>
+    <Angle class1="c3" class2="n2" class3="n2" angle="1.9345229429105149" k="584.0864"/>
+    <Angle class1="c3" class2="n2" class3="nh" angle="1.9196876442685629" k="573.208"/>
+    <Angle class1="c3" class2="n2" class3="o" angle="1.9617500792416265" k="590.7808"/>
+    <Angle class1="c3" class2="n2" class3="p2" angle="1.9933405387027237" k="688.6864"/>
+    <Angle class1="c3" class2="n2" class3="s6" angle="1.9868828204703448" k="555.6352"/>
+    <Angle class1="c3" class2="n2" class3="s" angle="2.0371483029277817" k="551.4512000000001"/>
+    <Angle class1="ca" class2="n2" class3="ca" angle="1.9582594207376378" k="600.8224"/>
+    <Angle class1="ca" class2="n2" class3="hn" angle="2.0943951023931953" k="419.2368"/>
+    <Angle class1="ca" class2="n2" class3="n2" angle="1.9814722997891623" k="620.0688"/>
+    <Angle class1="ca" class2="n2" class3="o" angle="2.0245819323134224" k="628.4368"/>
+    <Angle class1="ca" class2="n2" class3="p2" angle="2.0614083795305027" k="702.912"/>
+    <Angle class1="ca" class2="n2" class3="s" angle="2.0963149645703893" k="567.3504"/>
+    <Angle class1="c" class2="n2" class3="c2" angle="2.1113247961375405" k="554.7984"/>
+    <Angle class1="c" class2="n2" class3="c" angle="2.16071761396898" k="524.6736000000001"/>
+    <Angle class1="c" class2="n2" class3="ca" angle="2.1031217486531673" k="552.288"/>
+    <Angle class1="cc" class2="n2" class3="cl" angle="2.020916740884234" k="467.7712"/>
+    <Angle class1="cc" class2="n2" class3="hn" angle="1.9416787928436914" k="438.4832"/>
+    <Angle class1="cc" class2="n2" class3="na" angle="1.9065976748786053" k="610.864"/>
+    <Angle class1="cc" class2="n2" class3="nh" angle="2.067691564837682" k="589.9440000000001"/>
+    <Angle class1="cd" class2="n2" class3="cl" angle="2.020916740884234" k="467.7712"/>
+    <Angle class1="cd" class2="n2" class3="hn" angle="1.9416787928436914" k="438.4832"/>
+    <Angle class1="ce" class2="n2" class3="hn" angle="1.9373154697137058" k="440.15680000000003"/>
+    <Angle class1="ce" class2="n2" class3="n" angle="2.0591394515029102" k="589.9440000000001"/>
+    <Angle class1="ce" class2="n2" class3="nh" angle="2.06542263681009" k="590.7808"/>
+    <Angle class1="ce" class2="n2" class3="o" angle="1.95756128903684" k="643.4992000000001"/>
+    <Angle class1="ce" class2="n2" class3="oh" angle="1.9685568633244044" k="599.1487999999999"/>
+    <Angle class1="ce" class2="n2" class3="os" angle="1.9685568633244044" k="595.8016"/>
+    <Angle class1="ce" class2="n2" class3="s" angle="2.0294688542190062" k="579.0656"/>
+    <Angle class1="cf" class2="n2" class3="hn" angle="1.938188134339703" k="439.32"/>
+    <Angle class1="cf" class2="n2" class3="n" angle="2.0591394515029102" k="589.9440000000001"/>
+    <Angle class1="cf" class2="n2" class3="nh" angle="2.06542263681009" k="590.7808"/>
+    <Angle class1="cf" class2="n2" class3="o" angle="1.95756128903684" k="643.4992000000001"/>
+    <Angle class1="cf" class2="n2" class3="oh" angle="1.9685568633244044" k="599.1487999999999"/>
+    <Angle class1="cf" class2="n2" class3="os" angle="1.9685568633244044" k="595.8016"/>
+    <Angle class1="cf" class2="n2" class3="s" angle="2.0294688542190062" k="579.0656"/>
+    <Angle class1="cl" class2="n2" class3="n1" angle="1.8971728969178363" k="496.2224"/>
+    <Angle class1="cl" class2="n2" class3="n2" angle="1.9280652246781358" k="491.20160000000004"/>
+    <Angle class1="cl" class2="n2" class3="o" angle="1.9901989460491338" k="487.0176"/>
+    <Angle class1="cl" class2="n2" class3="p2" angle="1.9718729889031936" k="619.232"/>
+    <Angle class1="cl" class2="n2" class3="s" angle="2.0205676750338353" k="489.528"/>
+    <Angle class1="cx" class2="n2" class3="n2" angle="1.1391764027766988" k="766.5088"/>
+    <Angle class1="f" class2="n2" class3="n2" angle="2.0001473227855016" k="572.3712"/>
+    <Angle class1="f" class2="n2" class3="o" angle="1.9216075064457567" k="594.128"/>
+    <Angle class1="f" class2="n2" class3="p2" angle="1.8692476288859268" k="705.4224"/>
+    <Angle class1="f" class2="n2" class3="s" angle="1.9326030807333212" k="561.4928"/>
+    <Angle class1="hn" class2="n2" class3="hn" angle="2.0943951023931953" k="324.6784"/>
+    <Angle class1="hn" class2="n2" class3="n1" angle="1.9914206765255298" k="460.24"/>
+    <Angle class1="hn" class2="n2" class3="n2" angle="1.8327702475192456" k="469.44480000000004"/>
+    <Angle class1="hn" class2="n2" class3="ne" angle="1.8947294359650442" k="460.24"/>
+    <Angle class1="hn" class2="n2" class3="nf" angle="1.8947294359650442" k="460.24"/>
+    <Angle class1="hn" class2="n2" class3="o" angle="1.8739600178663118" k="480.3232"/>
+    <Angle class1="hn" class2="n2" class3="p2" angle="1.956339558560444" k="490.36480000000006"/>
+    <Angle class1="hn" class2="n2" class3="p4" angle="1.943075056245287" k="456.05600000000004"/>
+    <Angle class1="hn" class2="n2" class3="p5" angle="2.1352358068898627" k="471.1184"/>
+    <Angle class1="hn" class2="n2" class3="pe" angle="1.9444713196468826" k="512.9584"/>
+    <Angle class1="hn" class2="n2" class3="pf" angle="1.9444713196468826" k="512.9584"/>
+    <Angle class1="hn" class2="n2" class3="s2" angle="2.0210912738094335" k="396.6432"/>
+    <Angle class1="hn" class2="n2" class3="s4" angle="1.9409806611428937" k="387.4384"/>
+    <Angle class1="hn" class2="n2" class3="s" angle="1.8879226518822663" k="410.8688"/>
+    <Angle class1="hn" class2="n2" class3="s6" angle="1.9402825294420962" k="401.664"/>
+    <Angle class1="i" class2="n2" class3="n2" angle="1.951103570804461" k="449.36160000000007"/>
+    <Angle class1="i" class2="n2" class3="o" angle="2.038893632179776" k="438.4832"/>
+    <Angle class1="i" class2="n2" class3="p2" angle="1.9767599108087777" k="605.0064"/>
+    <Angle class1="i" class2="n2" class3="s" angle="2.0394172309553737" k="471.9552"/>
+    <Angle class1="n1" class2="n2" class3="n1" angle="1.9547687622336491" k="668.6032000000001"/>
+    <Angle class1="n2" class2="n2" class3="n1" angle="3.141592653589793" k="519.6528000000001"/>
+    <Angle class1="n2" class2="n2" class3="n2" angle="1.9109609980085913" k="656.888"/>
+    <Angle class1="n2" class2="n2" class3="n3" angle="1.9003144895714261" k="641.8256"/>
+    <Angle class1="n2" class2="n2" class3="n4" angle="1.857902988747964" k="550.6144"/>
+    <Angle class1="n2" class2="n2" class3="na" angle="1.958783019513236" k="621.7424"/>
+    <Angle class1="n2" class2="n2" class3="nh" angle="1.9495327744776663" k="627.6"/>
+    <Angle class1="n2" class2="n2" class3="no" angle="1.849525408338391" k="620.9056"/>
+    <Angle class1="n2" class2="n2" class3="o" angle="1.9273670929773383" k="670.2768"/>
+    <Angle class1="n2" class2="n2" class3="oh" angle="1.9462166488988768" k="620.9056"/>
+    <Angle class1="n2" class2="n2" class3="os" angle="1.8915878433114541" k="626.7632000000001"/>
+    <Angle class1="n2" class2="n2" class3="p2" angle="1.9050268785518107" k="753.9567999999999"/>
+    <Angle class1="n2" class2="n2" class3="p3" angle="1.9730947193795894" k="684.5024"/>
+    <Angle class1="n2" class2="n2" class3="p4" angle="2.072927552593665" k="681.1552"/>
+    <Angle class1="n2" class2="n2" class3="p5" angle="1.9278906917529361" k="752.2832000000001"/>
+    <Angle class1="n2" class2="n2" class3="s4" angle="1.8727382873899157" k="599.9856000000001"/>
+    <Angle class1="n2" class2="n2" class3="s6" angle="1.9416787928436914" k="605.0064"/>
+    <Angle class1="n2" class2="n2" class3="s" angle="2.0230111359866276" k="596.6384"/>
+    <Angle class1="n2" class2="n2" class3="sh" angle="1.9390607989657" k="552.288"/>
+    <Angle class1="n2" class2="n2" class3="ss" angle="1.957212223186441" k="573.208"/>
+    <Angle class1="n3" class2="n2" class3="n3" angle="2.008350370269875" k="610.864"/>
+    <Angle class1="n3" class2="n2" class3="o" angle="1.9896753472735356" k="641.8256"/>
+    <Angle class1="n3" class2="n2" class3="p2" angle="2.0130627592502597" k="725.5056000000001"/>
+    <Angle class1="n3" class2="n2" class3="s" angle="2.044304152860958" k="585.76"/>
+    <Angle class1="n4" class2="n2" class3="n4" angle="1.8622663118779497" k="502.08000000000004"/>
+    <Angle class1="n4" class2="n2" class3="o" angle="1.9582594207376378" k="542.2464"/>
+    <Angle class1="n4" class2="n2" class3="p2" angle="1.9734437852299882" k="665.256"/>
+    <Angle class1="n4" class2="n2" class3="s" angle="2.0682151636132806" k="522.1632"/>
+    <Angle class1="na" class2="n2" class3="na" angle="1.8675022996339325" k="615.048"/>
+    <Angle class1="na" class2="n2" class3="o" angle="1.9737928510803873" k="632.6208"/>
+    <Angle class1="na" class2="n2" class3="p2" angle="2.079734336676443" k="707.9327999999999"/>
+    <Angle class1="na" class2="n2" class3="s" angle="2.064026373408494" k="577.392"/>
+    <Angle class1="ne" class2="n2" class3="nh" angle="1.978156174210373" k="621.7424"/>
+    <Angle class1="ne" class2="n2" class3="o" angle="1.925272697874945" k="669.44"/>
+    <Angle class1="ne" class2="n2" class3="s" angle="2.0284216566678097" k="594.9648"/>
+    <Angle class1="nf" class2="n2" class3="nh" angle="1.978156174210373" k="621.7424"/>
+    <Angle class1="nf" class2="n2" class3="o" angle="1.925272697874945" k="669.44"/>
+    <Angle class1="nf" class2="n2" class3="s" angle="2.0284216566678097" k="594.9648"/>
+    <Angle class1="nh" class2="n2" class3="nh" angle="2.1153390534171272" k="584.0864"/>
+    <Angle class1="nh" class2="n2" class3="o" angle="1.9870573533955442" k="635.1312"/>
+    <Angle class1="nh" class2="n2" class3="p2" angle="2.0739747501448615" k="711.28"/>
+    <Angle class1="nh" class2="n2" class3="s" angle="2.0402898955813713" k="582.4128"/>
+    <Angle class1="n" class2="n2" class3="n2" angle="1.8877481189570668" k="635.1312"/>
+    <Angle class1="n" class2="n2" class3="o" angle="2.0090485019706725" k="629.2736000000001"/>
+    <Angle class1="no" class2="n2" class3="no" angle="1.8099064343181197" k="595.8016"/>
+    <Angle class1="no" class2="n2" class3="o" angle="1.7585937543094865" k="648.52"/>
+    <Angle class1="no" class2="n2" class3="p2" angle="1.9538960976076518" k="718.8112000000001"/>
+    <Angle class1="n" class2="n2" class3="p2" angle="2.047271212589348" k="714.6272000000001"/>
+    <Angle class1="n" class2="n2" class3="s" angle="2.020044076258237" k="584.0864"/>
+    <Angle class1="oh" class2="n2" class3="oh" angle="1.7749998492782333" k="627.6"/>
+    <Angle class1="oh" class2="n2" class3="p2" angle="2.0090485019706725" k="720.4848"/>
+    <Angle class1="oh" class2="n2" class3="s" angle="2.0259781957150174" k="582.4128"/>
+    <Angle class1="o" class2="n2" class3="o" angle="2.013586358025858" k="673.624"/>
+    <Angle class1="o" class2="n2" class3="oh" angle="1.9573867561116407" k="631.784"/>
+    <Angle class1="o" class2="n2" class3="os" angle="1.9259708295757425" k="633.4576000000001"/>
+    <Angle class1="o" class2="n2" class3="p2" angle="2.0259781957150174" k="741.4048"/>
+    <Angle class1="o" class2="n2" class3="p3" angle="1.979726970537168" k="688.6864"/>
+    <Angle class1="o" class2="n2" class3="p4" angle="1.930508685630928" k="712.9536"/>
+    <Angle class1="o" class2="n2" class3="p5" angle="1.904328746851013" k="766.5088"/>
+    <Angle class1="o" class2="n2" class3="pe" angle="2.34851504148357" k="712.1168"/>
+    <Angle class1="o" class2="n2" class3="pf" angle="2.34851504148357" k="712.1168"/>
+    <Angle class1="o" class2="n2" class3="s4" angle="1.9008380883470242" k="602.496"/>
+    <Angle class1="o" class2="n2" class3="s6" angle="1.9432495891704866" k="614.2112000000001"/>
+    <Angle class1="o" class2="n2" class3="s" angle="2.045176817486955" k="602.496"/>
+    <Angle class1="o" class2="n2" class3="sh" angle="2.00677957394308" k="548.104"/>
+    <Angle class1="os" class2="n2" class3="os" angle="1.924923632024546" k="598.312"/>
+    <Angle class1="os" class2="n2" class3="p2" angle="1.9233528356977512" k="734.7104"/>
+    <Angle class1="o" class2="n2" class3="ss" angle="2.0205676750338353" k="570.6976000000001"/>
+    <Angle class1="os" class2="n2" class3="s" angle="1.958783019513236" k="590.7808"/>
+    <Angle class1="p2" class2="n2" class3="p2" angle="2.0385445663293766" k="896.2128"/>
+    <Angle class1="p2" class2="n2" class3="p3" angle="2.1725858528825412" k="823.4112000000001"/>
+    <Angle class1="p2" class2="n2" class3="p4" angle="2.240479160785121" k="822.5744"/>
+    <Angle class1="p2" class2="n2" class3="p5" angle="2.1549580274373983" k="873.6192000000001"/>
+    <Angle class1="p2" class2="n2" class3="s4" angle="1.9565140914856434" k="722.1584"/>
+    <Angle class1="p2" class2="n2" class3="s6" angle="2.0193459445574393" k="722.9952000000001"/>
+    <Angle class1="p2" class2="n2" class3="s" angle="2.056695990550118" k="718.8112000000001"/>
+    <Angle class1="p2" class2="n2" class3="sh" angle="2.067342498987283" k="673.624"/>
+    <Angle class1="p2" class2="n2" class3="ss" angle="2.101900018176771" k="686.176"/>
+    <Angle class1="p3" class2="n2" class3="p3" angle="2.101376419401173" k="803.328"/>
+    <Angle class1="p3" class2="n2" class3="s" angle="2.109404933960347" k="670.2768"/>
+    <Angle class1="p4" class2="n2" class3="s" angle="2.301042085829324" k="651.0304"/>
+    <Angle class1="p5" class2="n2" class3="p5" angle="2.104867077905161" k="885.3344"/>
+    <Angle class1="p5" class2="n2" class3="s" angle="2.0924752402160016" k="713.7904"/>
+    <Angle class1="pe" class2="n2" class3="s" angle="2.0198695433330376" k="741.4048"/>
+    <Angle class1="pf" class2="n2" class3="s" angle="2.0198695433330376" k="741.4048"/>
+    <Angle class1="s4" class2="n2" class3="s4" angle="2.080083402526842" k="552.288"/>
+    <Angle class1="s4" class2="n2" class3="s6" angle="2.080083402526842" k="561.4928"/>
+    <Angle class1="s6" class2="n2" class3="s6" angle="2.080083402526842" k="572.3712"/>
+    <Angle class1="sh" class2="n2" class3="sh" angle="2.1629865419965726" k="502.08000000000004"/>
+    <Angle class1="sh" class2="n2" class3="ss" angle="2.1629865419965726" k="512.9584"/>
+    <Angle class1="s" class2="n2" class3="s" angle="2.1097539998107453" k="573.208"/>
+    <Angle class1="s" class2="n2" class3="s4" angle="1.9722220547535922" k="579.0656"/>
+    <Angle class1="s" class2="n2" class3="s6" angle="2.0875883183104174" k="573.208"/>
+    <Angle class1="s" class2="n2" class3="sh" angle="2.130174352059079" k="532.2048"/>
+    <Angle class1="s" class2="n2" class3="ss" angle="2.062804642932098" k="557.3088"/>
+    <Angle class1="ss" class2="n2" class3="ss" angle="2.1629865419965726" k="526.3472"/>
+    <Angle class1="br" class2="n3" class3="br" angle="1.8701202935119243" k="556.472"/>
+    <Angle class1="br" class2="n3" class3="c3" angle="1.8662805691575366" k="524.6736000000001"/>
+    <Angle class1="c1" class2="n3" class3="c1" angle="2.1526890994098062" k="553.9616000000001"/>
+    <Angle class1="c1" class2="n3" class3="f" angle="1.827359726838063" k="579.9024"/>
+    <Angle class1="c1" class2="n3" class3="hn" angle="2.0032889154390916" k="416.7264"/>
+    <Angle class1="c1" class2="n3" class3="o" angle="2.0355775066009865" k="596.6384"/>
+    <Angle class1="c2" class2="n3" class3="c2" angle="2.17607651138653" k="553.9616000000001"/>
+    <Angle class1="c2" class2="n3" class3="hn" angle="2.08357406103083" k="410.8688"/>
+    <Angle class1="c3" class2="n3" class3="c3" angle="1.960877414615629" k="533.8783999999999"/>
+    <Angle class1="c3" class2="n3" class3="cl" angle="1.8715165569135195" k="484.5072"/>
+    <Angle class1="c3" class2="n3" class3="cx" angle="1.9914206765255298" k="533.8783999999999"/>
+    <Angle class1="c3" class2="n3" class3="cy" angle="1.970127659651199" k="533.8783999999999"/>
+    <Angle class1="c3" class2="n3" class3="f" angle="1.799958057581752" k="559.8192"/>
+    <Angle class1="c3" class2="n3" class3="hn" angle="1.9074703395046027" k="396.6432"/>
+    <Angle class1="c3" class2="n3" class3="i" angle="1.8933331725634486" k="476.976"/>
+    <Angle class1="c3" class2="n3" class3="n2" angle="2.072578486743266" k="555.6352"/>
+    <Angle class1="c3" class2="n3" class3="n3" angle="1.933824811209717" k="555.6352"/>
+    <Angle class1="c3" class2="n3" class3="n4" angle="1.9137535248117823" k="560.6560000000001"/>
+    <Angle class1="c3" class2="n3" class3="n" angle="1.9497073074028652" k="559.8192"/>
+    <Angle class1="c3" class2="n3" class3="nh" angle="1.9507545049540622" k="557.3088"/>
+    <Angle class1="c3" class2="n3" class3="no" angle="2.0408134943569696" k="548.104"/>
+    <Angle class1="c3" class2="n3" class3="o" angle="1.9776325754347748" k="575.7184"/>
+    <Angle class1="c3" class2="n3" class3="oh" angle="1.8586011204487614" k="574.8816"/>
+    <Angle class1="c3" class2="n3" class3="os" angle="1.8465583486100006" k="571.5344"/>
+    <Angle class1="c3" class2="n3" class3="p3" angle="2.088635515861614" k="640.9888"/>
+    <Angle class1="c3" class2="n3" class3="p5" angle="2.0919516414404034" k="656.0512000000001"/>
+    <Angle class1="c3" class2="n3" class3="s4" angle="1.9982274606083077" k="512.1216000000001"/>
+    <Angle class1="c3" class2="n3" class3="s6" angle="2.034181243199391" k="525.5104"/>
+    <Angle class1="c3" class2="n3" class3="s" angle="1.9202112430441614" k="514.6320000000001"/>
+    <Angle class1="c3" class2="n3" class3="sh" angle="1.9669860669976096" k="519.6528000000001"/>
+    <Angle class1="c3" class2="n3" class3="ss" angle="2.028945255443408" k="515.4688"/>
+    <Angle class1="c3" class2="n3" class3="sy" angle="2.011491962923465" k="523.0"/>
+    <Angle class1="cl" class2="n3" class3="cl" angle="1.8898425140594601" k="448.5248"/>
+    <Angle class1="cl" class2="n3" class3="hn" angle="1.8219492061568805" k="332.2096"/>
+    <Angle class1="cl" class2="n3" class3="n3" angle="1.8788469397718959" k="497.896"/>
+    <Angle class1="cx" class2="n3" class3="cx" angle="1.0599384547361563" k="723.832"/>
+    <Angle class1="cx" class2="n3" class3="hn" angle="1.9191640454929646" k="400.8272"/>
+    <Angle class1="cx" class2="n3" class3="p5" angle="2.084097659806429" k="656.888"/>
+    <Angle class1="cx" class2="n3" class3="py" angle="2.124938364303096" k="644.336"/>
+    <Angle class1="cy" class2="n3" class3="cy" angle="1.936966403863307" k="540.5728"/>
+    <Angle class1="cy" class2="n3" class3="hn" angle="1.924400033248948" k="396.6432"/>
+    <Angle class1="f" class2="n3" class3="f" angle="1.7840755613886037" k="566.5136"/>
+    <Angle class1="f" class2="n3" class3="hn" angle="1.7418385934903406" k="425.0944"/>
+    <Angle class1="hn" class2="n3" class3="hn" angle="1.8570303241219668" k="346.4352"/>
+    <Angle class1="hn" class2="n3" class3="i" angle="1.9195131113433634" k="296.2272"/>
+    <Angle class1="hn" class2="n3" class3="n1" angle="1.9228292369221527" k="435.136"/>
+    <Angle class1="hn" class2="n3" class3="n2" angle="2.0235347347622255" k="430.1152"/>
+    <Angle class1="hn" class2="n3" class3="n3" angle="1.8793705385474944" k="415.88960000000003"/>
+    <Angle class1="hn" class2="n3" class3="n4" angle="1.8659315033071378" k="420.07360000000006"/>
+    <Angle class1="hn" class2="n3" class3="n" angle="1.8870499872562692" k="425.0944"/>
+    <Angle class1="hn" class2="n3" class3="na" angle="1.8830357299766822" k="420.9104"/>
+    <Angle class1="hn" class2="n3" class3="nh" angle="1.8903661128350582" k="421.7472"/>
+    <Angle class1="hn" class2="n3" class3="no" angle="1.8287559902396586" k="433.4624"/>
+    <Angle class1="hn" class2="n3" class3="o" angle="1.9778071083599742" k="444.3408"/>
+    <Angle class1="hn" class2="n3" class3="oh" angle="1.785471824790199" k="435.9728"/>
+    <Angle class1="hn" class2="n3" class3="os" angle="1.7933258064241737" k="428.44160000000005"/>
+    <Angle class1="hn" class2="n3" class3="p2" angle="2.0989329584483807" k="453.54560000000004"/>
+    <Angle class1="hn" class2="n3" class3="p3" angle="2.040115362656172" k="442.6672"/>
+    <Angle class1="hn" class2="n3" class3="p4" angle="1.9730947193795894" k="460.24"/>
+    <Angle class1="hn" class2="n3" class3="p5" angle="1.9952604008799173" k="465.2608"/>
+    <Angle class1="hn" class2="n3" class3="s4" angle="1.9048523456266113" k="356.4768"/>
+    <Angle class1="hn" class2="n3" class3="s" angle="1.9106119321581925" k="347.272"/>
+    <Angle class1="hn" class2="n3" class3="s6" angle="1.912880860185785" k="374.8864"/>
+    <Angle class1="hn" class2="n3" class3="sh" angle="1.8966492981422378" k="360.66080000000005"/>
+    <Angle class1="hn" class2="n3" class3="ss" angle="1.9343484099853154" k="360.66080000000005"/>
+    <Angle class1="hn" class2="n3" class3="sy" angle="1.911135530933791" k="369.86560000000003"/>
+    <Angle class1="i" class2="n3" class3="i" angle="1.9420278586940904" k="502.08000000000004"/>
+    <Angle class1="n1" class2="n3" class3="n1" angle="1.9758872461827806" k="605.8432"/>
+    <Angle class1="n2" class2="n3" class3="n2" angle="2.0722294208928678" k="600.8224"/>
+    <Angle class1="n2" class2="n3" class3="o" angle="2.0055578434666836" k="620.0688"/>
+    <Angle class1="n3" class2="n3" class3="n3" angle="1.8449875522832055" k="587.4336000000001"/>
+    <Angle class1="n4" class2="n3" class3="n4" angle="1.9805996351631652" k="571.5344"/>
+    <Angle class1="n4" class2="n3" class3="nh" angle="1.8699457605867247" k="590.7808"/>
+    <Angle class1="na" class2="n3" class3="na" angle="1.9547687622336491" k="579.0656"/>
+    <Angle class1="nh" class2="n3" class3="nh" angle="1.8701202935119243" k="594.128"/>
+    <Angle class1="n" class2="n3" class3="n" angle="1.9294614880797314" k="589.1072"/>
+    <Angle class1="no" class2="n3" class3="no" angle="2.0116664958486643" k="579.9024"/>
+    <Angle class1="oh" class2="n3" class3="oh" angle="1.8706438922875224" k="600.8224"/>
+    <Angle class1="o" class2="n3" class3="o" angle="2.2015583184656475" k="601.6592"/>
+    <Angle class1="o" class2="n3" class3="p2" angle="2.0423842906837644" k="705.4224"/>
+    <Angle class1="o" class2="n3" class3="p4" angle="2.0359265724513853" k="697.8912"/>
+    <Angle class1="o" class2="n3" class3="s4" angle="1.9912461436003308" k="542.2464"/>
+    <Angle class1="o" class2="n3" class3="s6" angle="1.986184688769547" k="564.84"/>
+    <Angle class1="o" class2="n3" class3="s" angle="2.0910789768144062" k="518.816"/>
+    <Angle class1="os" class2="n3" class3="os" angle="1.8591247192243596" k="592.4544"/>
+    <Angle class1="p2" class2="n3" class3="p2" angle="2.271196955620221" k="815.88"/>
+    <Angle class1="p3" class2="n3" class3="p3" angle="2.0724039538180667" k="825.0848"/>
+    <Angle class1="p4" class2="n3" class3="p4" angle="2.030690584695402" k="849.3520000000001"/>
+    <Angle class1="p5" class2="n3" class3="p5" angle="2.0842721927316283" k="851.8624"/>
+    <Angle class1="s4" class2="n3" class3="s4" angle="2.094744168243594" k="505.4272"/>
+    <Angle class1="s4" class2="n3" class3="s6" angle="2.1109757302871417" k="514.6320000000001"/>
+    <Angle class1="s6" class2="n3" class3="s6" angle="2.0689132953140783" k="533.0416"/>
+    <Angle class1="sh" class2="n3" class3="sh" angle="2.070484091640873" k="512.1216000000001"/>
+    <Angle class1="sh" class2="n3" class3="ss" angle="2.088635515861614" k="512.1216000000001"/>
+    <Angle class1="s" class2="n3" class3="s" angle="2.292664505419751" k="472.79200000000003"/>
+    <Angle class1="ss" class2="n3" class3="ss" angle="2.0868901866096197" k="514.6320000000001"/>
+    <Angle class1="br" class2="n4" class3="br" angle="2.003987047139889" k="544.7568"/>
+    <Angle class1="br" class2="n4" class3="hn" angle="1.8926350408626509" k="346.4352"/>
+    <Angle class1="c1" class2="n4" class3="c1" angle="1.987406419245943" k="548.104"/>
+    <Angle class1="c1" class2="n4" class3="hn" angle="1.9231783027725518" k="406.68480000000005"/>
+    <Angle class1="c2" class2="n4" class3="c2" angle="1.9648916718952163" k="516.3056"/>
+    <Angle class1="c2" class2="n4" class3="c3" angle="1.9366173380129081" k="520.4896"/>
+    <Angle class1="c2" class2="n4" class3="hn" angle="1.9263198954261416" k="383.2544"/>
+    <Angle class1="c3" class2="n4" class3="c3" angle="1.9139280577369817" k="523.8368"/>
+    <Angle class1="c3" class2="n4" class3="ca" angle="1.9291124222293323" k="526.3472"/>
+    <Angle class1="c3" class2="n4" class3="cc" angle="1.9380136014145035" k="523.8368"/>
+    <Angle class1="c3" class2="n4" class3="cl" angle="1.8856537238546736" k="483.6704"/>
+    <Angle class1="c3" class2="n4" class3="hn" angle="1.9217820393709562" k="384.0912"/>
+    <Angle class1="c3" class2="n4" class3="n3" angle="1.879719604397893" k="555.6352"/>
+    <Angle class1="c3" class2="n4" class3="n4" angle="1.9908970777499317" k="531.368"/>
+    <Angle class1="c3" class2="n4" class3="n" angle="1.9153243211385773" k="550.6144"/>
+    <Angle class1="c3" class2="n4" class3="nh" angle="1.9500563732532643" k="539.736"/>
+    <Angle class1="c3" class2="n4" class3="no" angle="1.9038051480754146" k="543.9200000000001"/>
+    <Angle class1="c3" class2="n4" class3="o" angle="1.928937889304133" k="563.1664"/>
+    <Angle class1="c3" class2="n4" class3="oh" angle="1.9849629582931512" k="548.9408"/>
+    <Angle class1="c3" class2="n4" class3="os" angle="1.8748326824923087" k="561.4928"/>
+    <Angle class1="c3" class2="n4" class3="p2" angle="1.9638444743440193" k="600.8224"/>
+    <Angle class1="c3" class2="n4" class3="p3" angle="1.9326030807333212" k="621.7424"/>
+    <Angle class1="c3" class2="n4" class3="p5" angle="1.9760617791079798" k="627.6"/>
+    <Angle class1="c3" class2="n4" class3="s4" angle="1.888969849433463" k="477.81280000000004"/>
+    <Angle class1="c3" class2="n4" class3="s6" angle="1.947089313524874" k="481.9968"/>
+    <Angle class1="c3" class2="n4" class3="s" angle="1.9818213656395611" k="494.5488"/>
+    <Angle class1="c3" class2="n4" class3="sh" angle="2.021265806734633" k="493.71200000000005"/>
+    <Angle class1="c3" class2="n4" class3="ss" angle="1.984090293667154" k="497.896"/>
+    <Angle class1="ca" class2="n4" class3="ca" angle="1.9980529276831085" k="522.1632"/>
+    <Angle class1="ca" class2="n4" class3="hn" angle="1.9285888234537343" k="389.112"/>
+    <Angle class1="c" class2="n4" class3="c" angle="1.8956021005910413" k="514.6320000000001"/>
+    <Angle class1="c" class2="n4" class3="hn" angle="1.9394098648160991" k="373.2128"/>
+    <Angle class1="cl" class2="n4" class3="cl" angle="2.0055578434666836" k="440.9936"/>
+    <Angle class1="cl" class2="n4" class3="hn" angle="1.9001399566462267" k="330.536"/>
+    <Angle class1="f" class2="n4" class3="f" angle="1.903281549299816" k="589.9440000000001"/>
+    <Angle class1="f" class2="n4" class3="hn" angle="1.8917623762366538" k="432.6256"/>
+    <Angle class1="hn" class2="n4" class3="hn" angle="1.890191579909859" k="339.74080000000004"/>
+    <Angle class1="hn" class2="n4" class3="i" angle="1.897521962768235" k="304.5952"/>
+    <Angle class1="hn" class2="n4" class3="n1" angle="1.909215668756597" k="433.4624"/>
+    <Angle class1="hn" class2="n4" class3="n2" angle="1.9142771235873808" k="353.96639999999996"/>
+    <Angle class1="hn" class2="n4" class3="n3" angle="1.9268434942017398" k="413.3792"/>
+    <Angle class1="hn" class2="n4" class3="n4" angle="1.8964747652170384" k="402.5008"/>
+    <Angle class1="hn" class2="n4" class3="n" angle="1.9038051480754146" k="415.05280000000005"/>
+    <Angle class1="hn" class2="n4" class3="na" angle="1.9039796810006142" k="414.216"/>
+    <Angle class1="hn" class2="n4" class3="nh" angle="1.9184659137921671" k="405.01120000000003"/>
+    <Angle class1="hn" class2="n4" class3="no" angle="1.821774673231681" k="411.70560000000006"/>
+    <Angle class1="hn" class2="n4" class3="o" angle="1.9434241220956858" k="431.78880000000004"/>
+    <Angle class1="hn" class2="n4" class3="oh" angle="1.8865263884806707" k="427.6048"/>
+    <Angle class1="hn" class2="n4" class3="os" angle="1.909215668756597" k="420.07360000000006"/>
+    <Angle class1="hn" class2="n4" class3="p2" angle="1.9285888234537343" k="399.15360000000004"/>
+    <Angle class1="hn" class2="n4" class3="p3" angle="1.9179423150165686" k="415.88960000000003"/>
+    <Angle class1="hn" class2="n4" class3="p4" angle="1.943075056245287" k="398.3168"/>
+    <Angle class1="hn" class2="n4" class3="p5" angle="1.9198621771937625" k="429.2784"/>
+    <Angle class1="hn" class2="n4" class3="py" angle="2.057568655176115" k="395.8064"/>
+    <Angle class1="hn" class2="n4" class3="s4" angle="1.9216075064457567" k="309.616"/>
+    <Angle class1="hn" class2="n4" class3="s" angle="1.865582437456739" k="343.088"/>
+    <Angle class1="hn" class2="n4" class3="s6" angle="1.9013616871226224" k="323.00480000000005"/>
+    <Angle class1="hn" class2="n4" class3="sh" angle="1.8947294359650442" k="345.59839999999997"/>
+    <Angle class1="hn" class2="n4" class3="ss" angle="1.9053759444022094" k="343.9248"/>
+    <Angle class1="i" class2="n4" class3="i" angle="2.068040630688081" k="493.71200000000005"/>
+    <Angle class1="n1" class2="n4" class3="n1" angle="1.9315558831821247" k="608.3536"/>
+    <Angle class1="n2" class2="n4" class3="n2" angle="1.8961256993666393" k="497.05920000000003"/>
+    <Angle class1="n3" class2="n4" class3="n3" angle="1.9385372001901016" k="577.392"/>
+    <Angle class1="n4" class2="n4" class3="n4" angle="2.015680753128251" k="545.5936"/>
+    <Angle class1="na" class2="n4" class3="na" angle="2.087413785385218" k="554.7984"/>
+    <Angle class1="nh" class2="n4" class3="nh" angle="1.9090411358313977" k="567.3504"/>
+    <Angle class1="n" class2="n4" class3="n" angle="2.0703095587156737" k="558.1456000000001"/>
+    <Angle class1="oh" class2="n4" class3="oh" angle="1.888271717732665" k="604.1696000000001"/>
+    <Angle class1="o" class2="n4" class3="o" angle="2.1113247961375405" k="588.2704"/>
+    <Angle class1="os" class2="n4" class3="os" angle="1.8221237390820801" k="606.6800000000001"/>
+    <Angle class1="p2" class2="n4" class3="p2" angle="1.9881045509467405" k="750.6096"/>
+    <Angle class1="p3" class2="n4" class3="p3" angle="2.1184806460707173" k="750.6096"/>
+    <Angle class1="p5" class2="n4" class3="p5" angle="1.8678513654843312" k="821.7376"/>
+    <Angle class1="py" class2="n4" class3="py" angle="1.2180652849668427" k="978.2192000000001"/>
+    <Angle class1="s4" class2="n4" class3="s4" angle="2.0146335555770545" k="458.5664"/>
+    <Angle class1="s6" class2="n4" class3="s6" angle="1.9113100638589904" k="484.5072"/>
+    <Angle class1="sh" class2="n4" class3="sh" angle="1.9650662048204155" k="505.4272"/>
+    <Angle class1="s" class2="n4" class3="s" angle="2.173807583358937" k="474.46560000000005"/>
+    <Angle class1="ss" class2="n4" class3="ss" angle="1.9058995431778079" k="512.9584"/>
+    <Angle class1="br" class2="na" class3="br" angle="2.1467549799530254" k="506.264"/>
+    <Angle class1="br" class2="na" class3="c2" angle="1.7537068324039025" k="532.2048"/>
+    <Angle class1="br" class2="na" class3="ca" angle="2.1783454394141226" k="477.81280000000004"/>
+    <Angle class1="br" class2="na" class3="cc" angle="2.1750293138353336" k="477.81280000000004"/>
+    <Angle class1="br" class2="na" class3="cd" angle="2.1750293138353336" k="477.81280000000004"/>
+    <Angle class1="br" class2="na" class3="nc" angle="2.0842721927316283" k="501.2432"/>
+    <Angle class1="br" class2="na" class3="nd" angle="2.0842721927316283" k="501.2432"/>
+    <Angle class1="br" class2="na" class3="os" angle="1.8324211816688465" k="534.7152"/>
+    <Angle class1="br" class2="na" class3="p2" angle="2.1120229278383382" k="635.1312"/>
+    <Angle class1="br" class2="na" class3="pc" angle="2.0989329584483807" k="639.3152000000001"/>
+    <Angle class1="br" class2="na" class3="pd" angle="2.0989329584483807" k="639.3152000000001"/>
+    <Angle class1="br" class2="na" class3="ss" angle="1.9596556841392332" k="523.0"/>
+    <Angle class1="c1" class2="na" class3="c1" angle="2.0455258833373544" k="562.3296"/>
+    <Angle class1="c1" class2="na" class3="c2" angle="2.1851522234969005" k="536.3888"/>
+    <Angle class1="c1" class2="na" class3="ca" angle="2.104343479129563" k="549.7776"/>
+    <Angle class1="c1" class2="na" class3="cc" angle="2.1179570472951186" k="548.9408"/>
+    <Angle class1="c1" class2="na" class3="cd" angle="2.1179570472951186" k="548.9408"/>
+    <Angle class1="c1" class2="na" class3="nc" angle="2.098583892597982" k="569.8607999999999"/>
+    <Angle class1="c1" class2="na" class3="nd" angle="2.098583892597982" k="570.6976000000001"/>
+    <Angle class1="c1" class2="na" class3="os" angle="1.8668041679331349" k="587.4336000000001"/>
+    <Angle class1="c1" class2="na" class3="p2" angle="2.133665010563068" k="640.152"/>
+    <Angle class1="c1" class2="na" class3="pc" angle="2.1202259753227115" k="646.8464"/>
+    <Angle class1="c1" class2="na" class3="pd" angle="2.1202259753227115" k="646.8464"/>
+    <Angle class1="c1" class2="na" class3="ss" angle="2.0647245051092917" k="517.9792"/>
+    <Angle class1="c2" class2="na" class3="c2" angle="1.9263198954261416" k="563.1664"/>
+    <Angle class1="c2" class2="na" class3="c3" angle="2.0455258833373544" k="534.7152"/>
+    <Angle class1="c2" class2="na" class3="ca" angle="2.181137966217314" k="532.2048"/>
+    <Angle class1="c2" class2="na" class3="cc" angle="2.208714168398824" k="529.6944"/>
+    <Angle class1="c2" class2="na" class3="cd" angle="2.208714168398824" k="529.6944"/>
+    <Angle class1="c2" class2="na" class3="cl" angle="1.7629570774394723" k="492.03839999999997"/>
+    <Angle class1="c2" class2="na" class3="f" angle="1.7996089917313531" k="572.3712"/>
+    <Angle class1="c2" class2="na" class3="hn" angle="2.0818287317788364" k="395.8064"/>
+    <Angle class1="c2" class2="na" class3="i" angle="1.8629644435787471" k="493.71200000000005"/>
+    <Angle class1="c2" class2="na" class3="n1" angle="2.1783454394141226" k="552.288"/>
+    <Angle class1="c2" class2="na" class3="n2" angle="2.1816615649929116" k="548.9408"/>
+    <Angle class1="c2" class2="na" class3="n3" angle="2.178170906488923" k="538.8992000000001"/>
+    <Angle class1="c2" class2="na" class3="n4" angle="2.1174334485195203" k="543.9200000000001"/>
+    <Angle class1="c2" class2="na" class3="n" angle="2.176425577236929" k="541.4096000000001"/>
+    <Angle class1="c2" class2="na" class3="na" angle="2.1746802479849343" k="543.0832"/>
+    <Angle class1="c2" class2="na" class3="nc" angle="2.10835773640915" k="560.6560000000001"/>
+    <Angle class1="c2" class2="na" class3="nd" angle="2.10835773640915" k="560.6560000000001"/>
+    <Angle class1="c2" class2="na" class3="nh" angle="2.1813124991425132" k="542.2464"/>
+    <Angle class1="c2" class2="na" class3="no" angle="2.1676989309769574" k="537.2256000000001"/>
+    <Angle class1="c2" class2="na" class3="o" angle="2.197369528260861" k="572.3712"/>
+    <Angle class1="c2" class2="na" class3="oh" angle="2.1624629432209743" k="549.7776"/>
+    <Angle class1="c2" class2="na" class3="os" angle="1.9256217637253437" k="571.5344"/>
+    <Angle class1="c2" class2="na" class3="p2" angle="2.1317451483858743" k="636.8048"/>
+    <Angle class1="c2" class2="na" class3="p3" angle="2.2008601867648494" k="622.5792000000001"/>
+    <Angle class1="c2" class2="na" class3="p4" angle="2.1816615649929116" k="681.1552"/>
+    <Angle class1="c2" class2="na" class3="p5" angle="2.183406894244906" k="638.4784"/>
+    <Angle class1="c2" class2="na" class3="pc" angle="2.121622238724307" k="642.6624"/>
+    <Angle class1="c2" class2="na" class3="pd" angle="2.121622238724307" k="642.6624"/>
+    <Angle class1="c2" class2="na" class3="s4" angle="2.179916235740918" k="487.8544"/>
+    <Angle class1="c2" class2="na" class3="s6" angle="2.171189589480946" k="503.75360000000006"/>
+    <Angle class1="c2" class2="na" class3="s" angle="2.1956241990088663" k="492.03839999999997"/>
+    <Angle class1="c2" class2="na" class3="sh" angle="2.183406894244906" k="502.9168"/>
+    <Angle class1="c2" class2="na" class3="ss" angle="2.0163788848290487" k="520.4896"/>
+    <Angle class1="c3" class2="na" class3="c3" angle="2.1919590075796784" k="505.4272"/>
+    <Angle class1="c3" class2="na" class3="ca" angle="2.170491457780148" k="521.3264"/>
+    <Angle class1="c3" class2="na" class3="cc" angle="2.207143372072029" k="517.9792"/>
+    <Angle class1="c3" class2="na" class3="cd" angle="2.207143372072029" k="517.9792"/>
+    <Angle class1="c3" class2="na" class3="cp" angle="2.087762851235617" k="531.368"/>
+    <Angle class1="c3" class2="na" class3="n2" angle="2.0811306000780383" k="548.104"/>
+    <Angle class1="c3" class2="na" class3="n" angle="1.970127659651199" k="556.472"/>
+    <Angle class1="c3" class2="na" class3="nc" angle="2.0975366950467853" k="548.104"/>
+    <Angle class1="c3" class2="na" class3="nd" angle="2.0975366950467853" k="548.104"/>
+    <Angle class1="c3" class2="na" class3="os" angle="1.8219492061568805" k="575.7184"/>
+    <Angle class1="c3" class2="na" class3="p2" angle="2.1488493750554185" k="627.6"/>
+    <Angle class1="c3" class2="na" class3="pc" angle="2.1312215496102755" k="634.2944"/>
+    <Angle class1="c3" class2="na" class3="pd" angle="2.1312215496102755" k="634.2944"/>
+    <Angle class1="c3" class2="na" class3="sh" angle="1.9247490990993465" k="529.6944"/>
+    <Angle class1="c3" class2="na" class3="ss" angle="1.9350465416861131" k="525.5104"/>
+    <Angle class1="ca" class2="na" class3="ca" angle="2.0952677670191924" k="546.4304"/>
+    <Angle class1="ca" class2="na" class3="cc" angle="1.974840048631584" k="564.0032000000001"/>
+    <Angle class1="ca" class2="na" class3="cd" angle="1.974840048631584" k="564.0032000000001"/>
+    <Angle class1="ca" class2="na" class3="cl" angle="2.1779963735637238" k="443.504"/>
+    <Angle class1="ca" class2="na" class3="cp" angle="2.109404933960347" k="544.7568"/>
+    <Angle class1="ca" class2="na" class3="cx" angle="2.177123708937726" k="521.3264"/>
+    <Angle class1="ca" class2="na" class3="f" angle="2.0315632493213998" k="542.2464"/>
+    <Angle class1="ca" class2="na" class3="hn" angle="2.1910863429536813" k="389.9488"/>
+    <Angle class1="ca" class2="na" class3="i" angle="2.122669436275504" k="461.91360000000003"/>
+    <Angle class1="ca" class2="na" class3="n2" angle="2.0781635403496477" k="565.6768"/>
+    <Angle class1="ca" class2="na" class3="n4" angle="2.0977112279719847" k="549.7776"/>
+    <Angle class1="ca" class2="na" class3="n" angle="2.129301687433082" k="550.6144"/>
+    <Angle class1="ca" class2="na" class3="na" angle="2.1600194822681824" k="548.104"/>
+    <Angle class1="ca" class2="na" class3="nb" angle="2.140471794645846" k="561.4928"/>
+    <Angle class1="ca" class2="na" class3="nc" angle="2.0568705234753173" k="570.6976000000001"/>
+    <Angle class1="ca" class2="na" class3="nd" angle="2.0568705234753173" k="571.5344"/>
+    <Angle class1="ca" class2="na" class3="nh" angle="2.1713641224061453" k="547.2672000000001"/>
+    <Angle class1="ca" class2="na" class3="o" angle="2.097362162121586" k="590.7808"/>
+    <Angle class1="ca" class2="na" class3="oh" angle="2.0952677670191924" k="561.4928"/>
+    <Angle class1="ca" class2="na" class3="os" angle="1.9104373992329928" k="577.392"/>
+    <Angle class1="ca" class2="na" class3="p2" angle="2.1964968636348634" k="628.4368"/>
+    <Angle class1="ca" class2="na" class3="p3" angle="2.170840523630547" k="628.4368"/>
+    <Angle class1="ca" class2="na" class3="p4" angle="2.181137966217314" k="683.6656"/>
+    <Angle class1="ca" class2="na" class3="p5" angle="2.1519909677090086" k="645.1727999999999"/>
+    <Angle class1="ca" class2="na" class3="pc" angle="2.131570615460675" k="643.4992000000001"/>
+    <Angle class1="ca" class2="na" class3="pd" angle="2.131570615460675" k="643.4992000000001"/>
+    <Angle class1="ca" class2="na" class3="py" angle="2.4588198502096117" k="604.1696000000001"/>
+    <Angle class1="ca" class2="na" class3="s4" angle="2.0460494821129527" k="504.5904"/>
+    <Angle class1="ca" class2="na" class3="s6" angle="2.1064378742319563" k="513.7952"/>
+    <Angle class1="ca" class2="na" class3="s" angle="2.1928316722056755" k="493.71200000000005"/>
+    <Angle class1="ca" class2="na" class3="sh" angle="2.1893410137016867" k="503.75360000000006"/>
+    <Angle class1="ca" class2="na" class3="ss" angle="2.2675317641910326" k="492.8752"/>
+    <Angle class1="cc" class2="na" class3="cc" angle="1.9181168479417683" k="573.208"/>
+    <Angle class1="cc" class2="na" class3="cd" angle="2.2341959754779412" k="531.368"/>
+    <Angle class1="cc" class2="na" class3="ce" angle="2.2097613659500204" k="526.3472"/>
+    <Angle class1="cc" class2="na" class3="cl" angle="2.174854780910134" k="443.504"/>
+    <Angle class1="cc" class2="na" class3="f" angle="2.0600121161289073" k="538.8992000000001"/>
+    <Angle class1="cc" class2="na" class3="hn" angle="2.1903882112528836" k="391.62239999999997"/>
+    <Angle class1="cc" class2="na" class3="i" angle="2.193878869756872" k="454.3824"/>
+    <Angle class1="cc" class2="na" class3="n2" angle="2.1134191912399336" k="561.4928"/>
+    <Angle class1="cc" class2="na" class3="n4" angle="2.110277598586344" k="548.104"/>
+    <Angle class1="cc" class2="na" class3="n" angle="1.9207348418197596" k="580.7392000000001"/>
+    <Angle class1="cc" class2="na" class3="na" angle="2.048318410140545" k="564.0032000000001"/>
+    <Angle class1="cc" class2="na" class3="nc" angle="1.9610519475408286" k="585.76"/>
+    <Angle class1="cc" class2="na" class3="nd" angle="2.2031291147924423" k="553.1247999999999"/>
+    <Angle class1="cc" class2="na" class3="nh" angle="2.157052422539792" k="549.7776"/>
+    <Angle class1="cc" class2="na" class3="no" angle="2.1544344286618005" k="543.0832"/>
+    <Angle class1="cc" class2="na" class3="o" angle="2.1853267564221" k="579.9024"/>
+    <Angle class1="cc" class2="na" class3="oh" angle="2.1359339385906604" k="557.3088"/>
+    <Angle class1="cc" class2="na" class3="os" angle="2.0395917638805736" k="558.9824"/>
+    <Angle class1="cc" class2="na" class3="p2" angle="2.196671396560063" k="629.2736000000001"/>
+    <Angle class1="cc" class2="na" class3="p3" angle="2.1860248881228976" k="626.7632000000001"/>
+    <Angle class1="cc" class2="na" class3="p4" angle="2.229309053572357" k="676.9712000000001"/>
+    <Angle class1="cc" class2="na" class3="p5" angle="2.176425577236929" k="641.8256"/>
+    <Angle class1="cc" class2="na" class3="s4" angle="2.112371993688737" k="497.05920000000003"/>
+    <Angle class1="cc" class2="na" class3="s6" angle="2.156354290838994" k="507.93760000000003"/>
+    <Angle class1="cc" class2="na" class3="s" angle="2.1931807380560744" k="493.71200000000005"/>
+    <Angle class1="cc" class2="na" class3="sh" angle="2.163510140772171" k="507.10080000000005"/>
+    <Angle class1="cc" class2="na" class3="ss" angle="2.1141173229407313" k="510.44800000000004"/>
+    <Angle class1="cd" class2="na" class3="cd" angle="1.9181168479417683" k="573.208"/>
+    <Angle class1="cd" class2="na" class3="cl" angle="2.174854780910134" k="443.504"/>
+    <Angle class1="cd" class2="na" class3="f" angle="2.0600121161289073" k="538.8992000000001"/>
+    <Angle class1="cd" class2="na" class3="hn" angle="2.1903882112528836" k="391.62239999999997"/>
+    <Angle class1="cd" class2="na" class3="i" angle="2.193878869756872" k="454.3824"/>
+    <Angle class1="cd" class2="na" class3="n2" angle="2.1134191912399336" k="561.4928"/>
+    <Angle class1="cd" class2="na" class3="n4" angle="2.110277598586344" k="548.104"/>
+    <Angle class1="cd" class2="na" class3="n" angle="1.9207348418197596" k="580.7392000000001"/>
+    <Angle class1="cd" class2="na" class3="na" angle="2.048318410140545" k="564.0032000000001"/>
+    <Angle class1="cd" class2="na" class3="nc" angle="2.2031291147924423" k="552.288"/>
+    <Angle class1="cd" class2="na" class3="nd" angle="1.9610519475408286" k="585.76"/>
+    <Angle class1="cd" class2="na" class3="nh" angle="2.157925087165789" k="549.7776"/>
+    <Angle class1="cd" class2="na" class3="no" angle="2.1544344286618005" k="543.0832"/>
+    <Angle class1="cd" class2="na" class3="o" angle="2.1853267564221" k="579.9024"/>
+    <Angle class1="cd" class2="na" class3="oh" angle="2.1359339385906604" k="557.3088"/>
+    <Angle class1="cd" class2="na" class3="os" angle="2.0395917638805736" k="558.9824"/>
+    <Angle class1="cd" class2="na" class3="p2" angle="2.196671396560063" k="629.2736000000001"/>
+    <Angle class1="cd" class2="na" class3="p3" angle="2.1860248881228976" k="626.7632000000001"/>
+    <Angle class1="cd" class2="na" class3="p4" angle="2.229309053572357" k="676.9712000000001"/>
+    <Angle class1="cd" class2="na" class3="p5" angle="2.176425577236929" k="641.8256"/>
+    <Angle class1="cd" class2="na" class3="s4" angle="2.112371993688737" k="497.05920000000003"/>
+    <Angle class1="cd" class2="na" class3="s6" angle="2.156354290838994" k="507.93760000000003"/>
+    <Angle class1="cd" class2="na" class3="s" angle="2.1931807380560744" k="493.71200000000005"/>
+    <Angle class1="cd" class2="na" class3="sh" angle="2.163510140772171" k="507.10080000000005"/>
+    <Angle class1="cd" class2="na" class3="ss" angle="2.1141173229407313" k="510.44800000000004"/>
+    <Angle class1="cl" class2="na" class3="cl" angle="2.1432643214490366" k="407.52160000000003"/>
+    <Angle class1="cl" class2="na" class3="nc" angle="2.083224995180432" k="466.09760000000006"/>
+    <Angle class1="cl" class2="na" class3="nd" angle="2.083224995180432" k="466.09760000000006"/>
+    <Angle class1="cl" class2="na" class3="os" angle="1.8601719167755564" k="490.36480000000006"/>
+    <Angle class1="cl" class2="na" class3="p2" angle="2.116909849743922" k="574.8816"/>
+    <Angle class1="cl" class2="na" class3="pc" angle="2.1032962815783667" k="579.0656"/>
+    <Angle class1="cl" class2="na" class3="pd" angle="2.1032962815783667" k="579.0656"/>
+    <Angle class1="cl" class2="na" class3="ss" angle="1.9531979659068541" k="474.46560000000005"/>
+    <Angle class1="f" class2="na" class3="f" angle="2.097885760897184" k="520.4896"/>
+    <Angle class1="f" class2="na" class3="nc" angle="2.0603611819793057" k="556.472"/>
+    <Angle class1="f" class2="na" class3="nd" angle="2.0603611819793057" k="556.472"/>
+    <Angle class1="f" class2="na" class3="os" angle="1.8126989611213105" k="579.0656"/>
+    <Angle class1="f" class2="na" class3="p2" angle="2.0935224377671986" k="631.784"/>
+    <Angle class1="f" class2="na" class3="pc" angle="2.0786871391252464" k="639.3152000000001"/>
+    <Angle class1="f" class2="na" class3="pd" angle="2.0786871391252464" k="639.3152000000001"/>
+    <Angle class1="f" class2="na" class3="ss" angle="1.8851301250790755" k="530.5312"/>
+    <Angle class1="hn" class2="na" class3="hn" angle="2.0385445663293766" k="333.8832"/>
+    <Angle class1="hn" class2="na" class3="n" angle="1.9449949184224806" k="418.40000000000003"/>
+    <Angle class1="hn" class2="na" class3="nc" angle="2.086541120759221" k="416.7264"/>
+    <Angle class1="hn" class2="na" class3="nd" angle="2.086541120759221" k="417.5632"/>
+    <Angle class1="hn" class2="na" class3="os" angle="1.7823302321366095" k="429.2784"/>
+    <Angle class1="hn" class2="na" class3="p2" angle="2.1383773995434523" k="426.76800000000003"/>
+    <Angle class1="hn" class2="na" class3="pc" angle="2.1202259753227115" k="433.4624"/>
+    <Angle class1="hn" class2="na" class3="pd" angle="2.1202259753227115" k="433.4624"/>
+    <Angle class1="hn" class2="na" class3="ss" angle="1.9888026826475385" k="353.12960000000004"/>
+    <Angle class1="i" class2="na" class3="i" angle="2.1676989309769574" k="487.8544"/>
+    <Angle class1="i" class2="na" class3="nc" angle="2.0949187011687935" k="476.976"/>
+    <Angle class1="i" class2="na" class3="nd" angle="2.0949187011687935" k="476.976"/>
+    <Angle class1="i" class2="na" class3="os" angle="1.9182913808669673" k="501.2432"/>
+    <Angle class1="i" class2="na" class3="p2" angle="2.134188609338666" k="614.2112000000001"/>
+    <Angle class1="i" class2="na" class3="pc" angle="2.118829711921116" k="617.5584"/>
+    <Angle class1="i" class2="na" class3="pd" angle="2.118829711921116" k="617.5584"/>
+    <Angle class1="i" class2="na" class3="ss" angle="2.066469834361286" k="493.71200000000005"/>
+    <Angle class1="n2" class2="na" class3="n2" angle="2.036973770002582" k="589.1072"/>
+    <Angle class1="n2" class2="na" class3="nc" angle="2.0936969706923976" k="583.2496000000001"/>
+    <Angle class1="n2" class2="na" class3="nd" angle="2.0936969706923976" k="584.0864"/>
+    <Angle class1="n2" class2="na" class3="os" angle="1.9465657147492759" k="588.2704"/>
+    <Angle class1="n2" class2="na" class3="p2" angle="2.1795671698905186" k="648.52"/>
+    <Angle class1="n2" class2="na" class3="pc" angle="2.149896572606615" k="657.7248"/>
+    <Angle class1="n2" class2="na" class3="pd" angle="2.149896572606615" k="657.7248"/>
+    <Angle class1="n2" class2="na" class3="ss" angle="2.175378379685732" k="516.3056"/>
+    <Angle class1="n3" class2="na" class3="n3" angle="2.1642082724729685" k="550.6144"/>
+    <Angle class1="n4" class2="na" class3="n4" angle="1.9495327744776663" k="574.0448"/>
+    <Angle class1="n4" class2="na" class3="nc" angle="2.032261381022197" k="577.392"/>
+    <Angle class1="n4" class2="na" class3="nd" angle="2.032261381022197" k="577.392"/>
+    <Angle class1="n4" class2="na" class3="os" angle="1.7971655307785612" k="599.1487999999999"/>
+    <Angle class1="n4" class2="na" class3="p2" angle="2.1565288237641935" k="644.336"/>
+    <Angle class1="n4" class2="na" class3="pc" angle="2.1289526215826835" k="653.5408"/>
+    <Angle class1="n4" class2="na" class3="pd" angle="2.1289526215826835" k="653.5408"/>
+    <Angle class1="na" class2="na" class3="na" angle="2.157226955464991" k="558.9824"/>
+    <Angle class1="na" class2="na" class3="nc" angle="2.088111917086016" k="576.5552"/>
+    <Angle class1="na" class2="na" class3="nd" angle="2.088111917086016" k="577.392"/>
+    <Angle class1="na" class2="na" class3="os" angle="1.9106119321581925" k="587.4336000000001"/>
+    <Angle class1="na" class2="na" class3="p2" angle="2.124414765527498" k="653.5408"/>
+    <Angle class1="na" class2="na" class3="pc" angle="2.110277598586344" k="660.2352000000001"/>
+    <Angle class1="na" class2="na" class3="pd" angle="2.110277598586344" k="660.2352000000001"/>
+    <Angle class1="na" class2="na" class3="ss" angle="2.033308578573394" k="531.368"/>
+    <Angle class1="nc" class2="na" class3="nc" angle="2.029817920069405" k="594.9648"/>
+    <Angle class1="nc" class2="na" class3="nd" angle="2.142566189748239" k="579.9024"/>
+    <Angle class1="nc" class2="na" class3="nh" angle="2.1039944132791644" k="574.8816"/>
+    <Angle class1="nc" class2="na" class3="no" angle="2.08060700130244" k="570.6976000000001"/>
+    <Angle class1="nc" class2="na" class3="o" angle="2.1430897885238376" k="606.6800000000001"/>
+    <Angle class1="nc" class2="na" class3="oh" angle="2.0807815342276395" k="583.2496000000001"/>
+    <Angle class1="nc" class2="na" class3="os" angle="2.0882864500112155" k="570.6976000000001"/>
+    <Angle class1="nc" class2="na" class3="p2" angle="2.094220569467996" k="662.7456000000001"/>
+    <Angle class1="nc" class2="na" class3="p3" angle="2.095616832869591" k="658.5616"/>
+    <Angle class1="nc" class2="na" class3="p4" angle="2.090380845113608" k="720.4848"/>
+    <Angle class1="nc" class2="na" class3="p5" angle="2.076069145247255" k="676.1344"/>
+    <Angle class1="nc" class2="na" class3="pc" angle="2.0710076904164714" k="671.1136"/>
+    <Angle class1="nc" class2="na" class3="s4" angle="2.080432468377241" k="514.6320000000001"/>
+    <Angle class1="nc" class2="na" class3="s6" angle="2.0811306000780383" k="531.368"/>
+    <Angle class1="nc" class2="na" class3="s" angle="2.1338395434882673" k="514.6320000000001"/>
+    <Angle class1="nc" class2="na" class3="sh" angle="2.1031217486531673" k="528.8576"/>
+    <Angle class1="nc" class2="na" class3="ss" angle="2.1031217486531673" k="526.3472"/>
+    <Angle class1="nd" class2="na" class3="nd" angle="2.029817920069405" k="595.8016"/>
+    <Angle class1="nd" class2="na" class3="nh" angle="2.1039944132791644" k="575.7184"/>
+    <Angle class1="nd" class2="na" class3="no" angle="2.08060700130244" k="570.6976000000001"/>
+    <Angle class1="nd" class2="na" class3="o" angle="2.1430897885238376" k="606.6800000000001"/>
+    <Angle class1="nd" class2="na" class3="oh" angle="2.0807815342276395" k="583.2496000000001"/>
+    <Angle class1="nd" class2="na" class3="os" angle="2.0882864500112155" k="570.6976000000001"/>
+    <Angle class1="nd" class2="na" class3="p2" angle="2.094220569467996" k="662.7456000000001"/>
+    <Angle class1="nd" class2="na" class3="p3" angle="2.095616832869591" k="658.5616"/>
+    <Angle class1="nd" class2="na" class3="p4" angle="2.090380845113608" k="721.3216000000001"/>
+    <Angle class1="nd" class2="na" class3="p5" angle="2.076069145247255" k="676.1344"/>
+    <Angle class1="nd" class2="na" class3="pd" angle="2.0710076904164714" k="671.9504000000001"/>
+    <Angle class1="nd" class2="na" class3="s4" angle="2.080432468377241" k="514.6320000000001"/>
+    <Angle class1="nd" class2="na" class3="s6" angle="2.0811306000780383" k="531.368"/>
+    <Angle class1="nd" class2="na" class3="s" angle="2.1338395434882673" k="514.6320000000001"/>
+    <Angle class1="nd" class2="na" class3="sh" angle="2.1031217486531673" k="528.8576"/>
+    <Angle class1="nd" class2="na" class3="ss" angle="2.1031217486531673" k="526.3472"/>
+    <Angle class1="nh" class2="na" class3="nh" angle="2.157226955464991" k="558.9824"/>
+    <Angle class1="nh" class2="na" class3="os" angle="1.9437731879460847" k="583.2496000000001"/>
+    <Angle class1="nh" class2="na" class3="p2" angle="2.109404933960347" k="656.0512000000001"/>
+    <Angle class1="nh" class2="na" class3="pc" angle="2.1010273535507737" k="661.9087999999999"/>
+    <Angle class1="nh" class2="na" class3="pd" angle="2.1010273535507737" k="661.9087999999999"/>
+    <Angle class1="nh" class2="na" class3="ss" angle="1.960877414615629" k="541.4096000000001"/>
+    <Angle class1="n" class2="na" class3="n" angle="2.16071761396898" k="555.6352"/>
+    <Angle class1="n" class2="na" class3="nc" angle="2.091777108515204" k="574.8816"/>
+    <Angle class1="n" class2="na" class3="nd" angle="2.091777108515204" k="575.7184"/>
+    <Angle class1="no" class2="na" class3="no" angle="2.1432643214490366" k="547.2672000000001"/>
+    <Angle class1="no" class2="na" class3="os" angle="1.8596483179999581" k="589.1072"/>
+    <Angle class1="no" class2="na" class3="pc" angle="2.0963149645703893" k="658.5616"/>
+    <Angle class1="no" class2="na" class3="pd" angle="2.0963149645703893" k="658.5616"/>
+    <Angle class1="n" class2="na" class3="os" angle="1.8275342597632624" k="599.9856000000001"/>
+    <Angle class1="no" class2="na" class3="ss" angle="2.0062559751674818" k="532.2048"/>
+    <Angle class1="n" class2="na" class3="p2" angle="2.1179570472951186" k="653.5408"/>
+    <Angle class1="n" class2="na" class3="pc" angle="2.105565209605959" k="660.2352000000001"/>
+    <Angle class1="n" class2="na" class3="pd" angle="2.105565209605959" k="660.2352000000001"/>
+    <Angle class1="n" class2="na" class3="ss" angle="2.0263272615654166" k="532.2048"/>
+    <Angle class1="oh" class2="na" class3="oh" angle="2.1327923459370703" k="571.5344"/>
+    <Angle class1="oh" class2="na" class3="p2" angle="2.1076596047083527" k="660.2352000000001"/>
+    <Angle class1="oh" class2="na" class3="pc" angle="2.094220569467996" k="667.7664"/>
+    <Angle class1="oh" class2="na" class3="pd" angle="2.094220569467996" k="667.7664"/>
+    <Angle class1="oh" class2="na" class3="ss" angle="1.9729201864543902" k="543.0832"/>
+    <Angle class1="o" class2="na" class3="o" angle="2.2026055160168436" k="632.6208"/>
+    <Angle class1="o" class2="na" class3="os" angle="2.0731020855188644" k="594.9648"/>
+    <Angle class1="o" class2="na" class3="p2" angle="2.1432643214490366" k="666.9296"/>
+    <Angle class1="o" class2="na" class3="pc" angle="2.1352358068898627" k="673.624"/>
+    <Angle class1="o" class2="na" class3="pd" angle="2.1352358068898627" k="673.624"/>
+    <Angle class1="os" class2="na" class3="os" angle="1.8229964037080773" k="596.6384"/>
+    <Angle class1="os" class2="na" class3="p2" angle="2.0570450564005167" k="662.7456000000001"/>
+    <Angle class1="os" class2="na" class3="p3" angle="1.827359726838063" k="699.5648"/>
+    <Angle class1="os" class2="na" class3="p5" angle="1.9444713196468826" k="691.1967999999999"/>
+    <Angle class1="os" class2="na" class3="pc" angle="2.0928243060664005" k="661.9087999999999"/>
+    <Angle class1="os" class2="na" class3="pd" angle="2.0928243060664005" k="661.9087999999999"/>
+    <Angle class1="os" class2="na" class3="s4" angle="1.847954612011596" k="542.2464"/>
+    <Angle class1="os" class2="na" class3="s6" angle="1.9547687622336491" k="543.0832"/>
+    <Angle class1="os" class2="na" class3="ss" angle="1.913578991886583" k="546.4304"/>
+    <Angle class1="p2" class2="na" class3="p2" angle="2.110277598586344" k="808.3488"/>
+    <Angle class1="p2" class2="na" class3="p3" angle="2.178170906488923" k="792.4496"/>
+    <Angle class1="p2" class2="na" class3="p5" angle="2.164033739547769" k="805.8384"/>
+    <Angle class1="p2" class2="na" class3="pc" angle="2.1069614730075545" k="813.3696000000001"/>
+    <Angle class1="p2" class2="na" class3="pd" angle="2.1069614730075545" k="813.3696000000001"/>
+    <Angle class1="p2" class2="na" class3="s4" angle="2.137504734917455" k="626.7632000000001"/>
+    <Angle class1="p2" class2="na" class3="s6" angle="2.1380283336930535" k="639.3152000000001"/>
+    <Angle class1="p2" class2="na" class3="s" angle="2.12668369355509" k="633.4576000000001"/>
+    <Angle class1="p2" class2="na" class3="sh" angle="2.124938364303096" k="641.8256"/>
+    <Angle class1="p2" class2="na" class3="ss" angle="2.127207292330689" k="639.3152000000001"/>
+    <Angle class1="p3" class2="na" class3="p3" angle="2.2095868330248214" k="784.0816000000001"/>
+    <Angle class1="p3" class2="na" class3="pc" angle="2.152340033559407" k="801.6544"/>
+    <Angle class1="p3" class2="na" class3="pd" angle="2.152340033559407" k="801.6544"/>
+    <Angle class1="p5" class2="na" class3="p5" angle="2.1746802479849343" k="812.5328"/>
+    <Angle class1="p5" class2="na" class3="pc" angle="2.141344459271843" k="814.2064"/>
+    <Angle class1="p5" class2="na" class3="pd" angle="2.141344459271843" k="814.2064"/>
+    <Angle class1="p5" class2="na" class3="ss" angle="2.068564229463679" k="654.3776"/>
+    <Angle class1="pc" class2="na" class3="pc" angle="2.108008670558751" k="816.7168"/>
+    <Angle class1="pc" class2="na" class3="s4" angle="2.1207495740983098" k="631.784"/>
+    <Angle class1="pc" class2="na" class3="s6" angle="2.1214477057991075" k="645.1727999999999"/>
+    <Angle class1="pc" class2="na" class3="s" angle="2.120051442397512" k="637.6416"/>
+    <Angle class1="pc" class2="na" class3="sh" angle="2.113244658314734" k="646.8464"/>
+    <Angle class1="pc" class2="na" class3="ss" angle="2.1153390534171272" k="644.336"/>
+    <Angle class1="pd" class2="na" class3="pd" angle="2.108008670558751" k="816.7168"/>
+    <Angle class1="pd" class2="na" class3="s4" angle="2.1207495740983098" k="631.784"/>
+    <Angle class1="pd" class2="na" class3="s6" angle="2.1214477057991075" k="645.1727999999999"/>
+    <Angle class1="pd" class2="na" class3="s" angle="2.120051442397512" k="637.6416"/>
+    <Angle class1="pd" class2="na" class3="sh" angle="2.113244658314734" k="646.8464"/>
+    <Angle class1="pd" class2="na" class3="ss" angle="2.1153390534171272" k="644.336"/>
+    <Angle class1="py" class2="na" class3="py" angle="1.3657201396855627" k="1026.7536"/>
+    <Angle class1="s4" class2="na" class3="s4" angle="2.1676989309769574" k="485.344"/>
+    <Angle class1="s4" class2="na" class3="s6" angle="1.9697785938008003" k="519.6528000000001"/>
+    <Angle class1="s4" class2="na" class3="ss" angle="1.9533724988320535" k="520.4896"/>
+    <Angle class1="s6" class2="na" class3="s6" angle="2.1502456384570143" k="507.93760000000003"/>
+    <Angle class1="s6" class2="na" class3="ss" angle="2.0786871391252464" k="514.6320000000001"/>
+    <Angle class1="sh" class2="na" class3="sh" angle="2.1746802479849343" k="505.4272"/>
+    <Angle class1="sh" class2="na" class3="ss" angle="2.0732766184440643" k="515.4688"/>
+    <Angle class1="s" class2="na" class3="s" angle="2.199114857512855" k="489.528"/>
+    <Angle class1="s" class2="na" class3="ss" angle="1.9633208755684213" k="523.0"/>
+    <Angle class1="ss" class2="na" class3="ss" angle="1.9764108449583786" k="526.3472"/>
+    <Angle class1="sy" class2="na" class3="sy" angle="2.1502456384570143" k="506.264"/>
+    <Angle class1="ca" class2="nb" class3="ca" angle="2.0458749491877533" k="571.5344"/>
+    <Angle class1="ca" class2="nb" class3="cp" angle="2.0603611819793057" k="569.8607999999999"/>
+    <Angle class1="ca" class2="nb" class3="cq" angle="2.0603611819793057" k="569.8607999999999"/>
+    <Angle class1="ca" class2="nb" class3="nb" angle="2.0952677670191924" k="579.9024"/>
+    <Angle class1="cp" class2="nb" class3="nb" angle="2.1111502632123407" k="578.2288"/>
+    <Angle class1="nb" class2="nb" class3="nb" angle="2.1125465266139365" k="593.2912000000001"/>
+    <Angle class1="br" class2="n" class3="br" angle="2.028072590817411" k="557.3088"/>
+    <Angle class1="br" class2="n" class3="c" angle="2.1162117180431244" k="515.4688"/>
+    <Angle class1="br" class2="n" class3="ca" angle="2.062804642932098" k="519.6528000000001"/>
+    <Angle class1="br" class2="n" class3="cc" angle="2.062804642932098" k="521.3264"/>
+    <Angle class1="br" class2="n" class3="cd" angle="2.062804642932098" k="521.3264"/>
+    <Angle class1="c1" class2="n" class3="c1" angle="1.7922786088729767" k="615.048"/>
+    <Angle class1="c1" class2="n" class3="ca" angle="2.0748474147708587" k="553.9616000000001"/>
+    <Angle class1="c1" class2="n" class3="cc" angle="2.0748474147708587" k="560.6560000000001"/>
+    <Angle class1="c1" class2="n" class3="cd" angle="2.0748474147708587" k="560.6560000000001"/>
+    <Angle class1="c2" class2="n" class3="c2" angle="2.0376719017033795" k="548.104"/>
+    <Angle class1="c2" class2="n" class3="c3" angle="2.0961404316451895" k="528.0208"/>
+    <Angle class1="c2" class2="n" class3="ca" angle="2.0340067102741917" k="546.4304"/>
+    <Angle class1="c2" class2="n" class3="cc" angle="2.0340067102741917" k="552.288"/>
+    <Angle class1="c2" class2="n" class3="cd" angle="2.0340067102741917" k="552.288"/>
+    <Angle class1="c2" class2="n" class3="hn" angle="2.0577431881013144" k="398.3168"/>
+    <Angle class1="c3" class2="n" class3="c3" angle="2.018298747006243" k="527.184"/>
+    <Angle class1="c3" class2="n" class3="ca" angle="2.091428042664805" k="527.184"/>
+    <Angle class1="c3" class2="n" class3="cc" angle="2.109230401035147" k="529.6944"/>
+    <Angle class1="c3" class2="n" class3="cd" angle="2.109230401035147" k="529.6944"/>
+    <Angle class1="c3" class2="n" class3="cy" angle="1.9799015034623675" k="538.0624"/>
+    <Angle class1="c3" class2="n" class3="hn" angle="2.053903463746927" k="383.2544"/>
+    <Angle class1="c3" class2="n" class3="n2" angle="2.124240232602298" k="543.9200000000001"/>
+    <Angle class1="c3" class2="n" class3="n" angle="2.013935423876257" k="551.4512000000001"/>
+    <Angle class1="c3" class2="n" class3="nc" angle="2.012015561699063" k="558.9824"/>
+    <Angle class1="c3" class2="n" class3="nd" angle="2.012015561699063" k="558.9824"/>
+    <Angle class1="c3" class2="n" class3="oh" angle="1.971698455977994" k="559.8192"/>
+    <Angle class1="c3" class2="n" class3="os" angle="1.9641935401944184" k="560.6560000000001"/>
+    <Angle class1="c3" class2="n" class3="sy" angle="2.1097539998107453" k="507.10080000000005"/>
+    <Angle class1="ca" class2="n" class3="ca" angle="2.0484929430657446" k="542.2464"/>
+    <Angle class1="ca" class2="n" class3="cc" angle="1.9898498801987352" k="555.6352"/>
+    <Angle class1="ca" class2="n" class3="cd" angle="1.9898498801987352" k="555.6352"/>
+    <Angle class1="ca" class2="n" class3="cl" angle="2.054601595447725" k="479.4864"/>
+    <Angle class1="ca" class2="n" class3="f" angle="2.0057323763918835" k="543.0832"/>
+    <Angle class1="ca" class2="n" class3="hn" angle="2.0245819323134224" k="398.3168"/>
+    <Angle class1="ca" class2="n" class3="i" angle="2.0821777976292353" k="473.6288"/>
+    <Angle class1="ca" class2="n" class3="n2" angle="2.1296507532834807" k="553.9616000000001"/>
+    <Angle class1="ca" class2="n" class3="n4" angle="2.1464059141026266" k="538.8992000000001"/>
+    <Angle class1="ca" class2="n" class3="n" angle="2.0690878282392777" k="553.9616000000001"/>
+    <Angle class1="ca" class2="n" class3="na" angle="2.0821777976292353" k="551.4512000000001"/>
+    <Angle class1="ca" class2="n" class3="nc" angle="2.033308578573394" k="567.3504"/>
+    <Angle class1="ca" class2="n" class3="nd" angle="2.033308578573394" k="567.3504"/>
+    <Angle class1="ca" class2="n" class3="nh" angle="2.032435913947397" k="559.8192"/>
+    <Angle class1="ca" class2="n" class3="p2" angle="1.9603538158400309" k="666.9296"/>
+    <Angle class1="ca" class2="n" class3="p3" angle="2.1835814271701057" k="621.7424"/>
+    <Angle class1="ca" class2="n" class3="s4" angle="2.066469834361286" k="505.4272"/>
+    <Angle class1="ca" class2="n" class3="s6" angle="2.0476202784397475" k="518.816"/>
+    <Angle class1="ca" class2="n" class3="ss" angle="2.035053907825388" k="518.816"/>
+    <Angle class1="c" class2="n" class3="c1" angle="2.042733356534163" k="565.6768"/>
+    <Angle class1="c" class2="n" class3="c2" angle="2.1319196813110737" k="539.736"/>
+    <Angle class1="c" class2="n" class3="c3" angle="2.1064378742319563" k="530.5312"/>
+    <Angle class1="c3" class2="nc" class3="cd" angle="1.9113100638589904" k="568.1872000000001"/>
+    <Angle class1="c" class2="n" class3="c" angle="2.2179644134343937" k="533.0416"/>
+    <Angle class1="c" class2="n" class3="ca" angle="2.159146817642185" k="533.8783999999999"/>
+    <Angle class1="ca" class2="nc" class3="ca" angle="1.9189895125677654" k="584.9232000000001"/>
+    <Angle class1="ca" class2="nc" class3="cd" angle="1.8305013194916528" k="606.6800000000001"/>
+    <Angle class1="ca" class2="nc" class3="n" angle="1.8271851939128636" k="612.5376"/>
+    <Angle class1="ca" class2="nc" class3="na" angle="1.793500339349373" k="619.232"/>
+    <Angle class1="ca" class2="nc" class3="os" angle="1.8235200024836755" k="606.6800000000001"/>
+    <Angle class1="ca" class2="nc" class3="ss" angle="1.8687240301103285" k="572.3712"/>
+    <Angle class1="c" class2="n" class3="cc" angle="2.15146736893341" k="541.4096000000001"/>
+    <Angle class1="c" class2="nc" class3="ca" angle="2.105914275456358" k="551.4512000000001"/>
+    <Angle class1="cc" class2="n" class3="cc" angle="1.9010126212722238" k="575.7184"/>
+    <Angle class1="cc" class2="nc" class3="cc" angle="1.8109536318693162" k="594.128"/>
+    <Angle class1="cc" class2="nc" class3="cd" angle="1.841147827928818" k="600.8224"/>
+    <Angle class1="c" class2="nc" class3="cd" angle="2.1029472157279674" k="558.1456000000001"/>
+    <Angle class1="cc" class2="n" class3="cl" angle="2.054601595447725" k="481.9968"/>
+    <Angle class1="cc" class2="nc" class3="na" angle="1.7971655307785612" k="614.2112000000001"/>
+    <Angle class1="cc" class2="nc" class3="nd" angle="1.8957766335162407" k="610.0272000000001"/>
+    <Angle class1="c" class2="n" class3="cd" angle="2.15146736893341" k="541.4096000000001"/>
+    <Angle class1="cd" class2="nc" class3="cd" angle="2.047271212589348" k="581.576"/>
+    <Angle class1="cd" class2="nc" class3="n" angle="2.0453513504121545" k="585.76"/>
+    <Angle class1="cd" class2="nc" class3="na" angle="1.8120008294205128" k="623.416"/>
+    <Angle class1="cd" class2="nc" class3="nc" angle="1.881813999500286" k="610.0272000000001"/>
+    <Angle class1="cd" class2="nc" class3="os" angle="1.8268361280624645" k="613.3744"/>
+    <Angle class1="cd" class2="nc" class3="ss" angle="1.8861773226302716" k="573.208"/>
+    <Angle class1="c" class2="n" class3="ce" angle="2.29301357127015" k="515.4688"/>
+    <Angle class1="cc" class2="n" class3="f" angle="2.0057323763918835" k="548.9408"/>
+    <Angle class1="cc" class2="n" class3="hn" angle="2.081479665928437" k="400.8272"/>
+    <Angle class1="cc" class2="n" class3="i" angle="2.0821777976292353" k="473.6288"/>
+    <Angle class1="c" class2="n" class3="cl" angle="2.030690584695402" k="485.344"/>
+    <Angle class1="cc" class2="n" class3="n2" angle="1.9350465416861131" k="588.2704"/>
+    <Angle class1="cc" class2="n" class3="n" angle="2.118306113145518" k="553.9616000000001"/>
+    <Angle class1="cc" class2="n" class3="na" angle="2.051983601569733" k="562.3296"/>
+    <Angle class1="cc" class2="n" class3="nc" angle="1.9528489000564555" k="585.76"/>
+    <Angle class1="cc" class2="n" class3="nh" angle="2.051110936943736" k="563.1664"/>
+    <Angle class1="cc" class2="n" class3="no" angle="2.0231856689118266" k="555.6352"/>
+    <Angle class1="cc" class2="n" class3="o" angle="2.103819880353965" k="589.9440000000001"/>
+    <Angle class1="cc" class2="n" class3="oh" angle="2.0821777976292353" k="561.4928"/>
+    <Angle class1="cc" class2="n" class3="os" angle="2.016902483604647" k="569.8607999999999"/>
+    <Angle class1="cc" class2="n" class3="p2" angle="1.9603538158400309" k="671.1136"/>
+    <Angle class1="cc" class2="n" class3="p3" angle="2.1835814271701057" k="625.0896"/>
+    <Angle class1="cc" class2="n" class3="p5" angle="2.111848394913139" k="651.0304"/>
+    <Angle class1="cc" class2="n" class3="s4" angle="2.066469834361286" k="507.93760000000003"/>
+    <Angle class1="cc" class2="n" class3="s6" angle="2.0476202784397475" k="522.1632"/>
+    <Angle class1="cc" class2="n" class3="s" angle="2.0645499721840923" k="508.7744"/>
+    <Angle class1="cc" class2="n" class3="sh" angle="2.0792107379008447" k="515.4688"/>
+    <Angle class1="cc" class2="n" class3="ss" angle="2.035053907825388" k="522.1632"/>
+    <Angle class1="c" class2="n" class3="cx" angle="2.1319196813110737" k="533.0416"/>
+    <Angle class1="c" class2="n" class3="cy" angle="2.124240232602298" k="533.8783999999999"/>
+    <Angle class1="cd" class2="n" class3="cd" angle="1.9010126212722238" k="575.7184"/>
+    <Angle class1="cd" class2="n" class3="cl" angle="2.054601595447725" k="481.9968"/>
+    <Angle class1="cd" class2="n" class3="f" angle="2.0057323763918835" k="548.9408"/>
+    <Angle class1="cd" class2="n" class3="hn" angle="2.081479665928437" k="400.8272"/>
+    <Angle class1="cd" class2="n" class3="i" angle="2.0821777976292353" k="473.6288"/>
+    <Angle class1="cd" class2="n" class3="n2" angle="1.9350465416861131" k="588.2704"/>
+    <Angle class1="cd" class2="n" class3="n" angle="2.118306113145518" k="553.9616000000001"/>
+    <Angle class1="cd" class2="n" class3="na" angle="2.051983601569733" k="562.3296"/>
+    <Angle class1="cd" class2="n" class3="nd" angle="1.9528489000564555" k="585.76"/>
+    <Angle class1="cd" class2="n" class3="nh" angle="2.051110936943736" k="563.1664"/>
+    <Angle class1="cd" class2="n" class3="no" angle="2.0231856689118266" k="555.6352"/>
+    <Angle class1="cd" class2="n" class3="o" angle="2.103819880353965" k="589.9440000000001"/>
+    <Angle class1="cd" class2="n" class3="oh" angle="2.0821777976292353" k="561.4928"/>
+    <Angle class1="cd" class2="n" class3="os" angle="2.016902483604647" k="569.8607999999999"/>
+    <Angle class1="cd" class2="n" class3="p2" angle="1.9603538158400309" k="671.1136"/>
+    <Angle class1="cd" class2="n" class3="p3" angle="2.1835814271701057" k="625.0896"/>
+    <Angle class1="cd" class2="n" class3="p5" angle="2.111848394913139" k="651.0304"/>
+    <Angle class1="cd" class2="n" class3="s4" angle="2.066469834361286" k="507.93760000000003"/>
+    <Angle class1="cd" class2="n" class3="s6" angle="2.0476202784397475" k="522.1632"/>
+    <Angle class1="cd" class2="n" class3="s" angle="2.0645499721840923" k="508.7744"/>
+    <Angle class1="cd" class2="n" class3="sh" angle="2.0792107379008447" k="515.4688"/>
+    <Angle class1="cd" class2="n" class3="ss" angle="2.035053907825388" k="522.1632"/>
+    <Angle class1="ce" class2="n" class3="cy" angle="1.9497073074028652" k="542.2464"/>
+    <Angle class1="c" class2="n" class3="f" angle="1.8959511664414401" k="564.84"/>
+    <Angle class1="cf" class2="n" class3="cy" angle="1.9497073074028652" k="542.2464"/>
+    <Angle class1="c" class2="n" class3="hn" angle="2.051634535719334" k="404.1744"/>
+    <Angle class1="c" class2="n" class3="i" angle="2.1010273535507737" k="471.9552"/>
+    <Angle class1="cl" class2="n" class3="cl" angle="1.9493582415524666" k="456.8928"/>
+    <Angle class1="c" class2="n" class3="n2" angle="2.0928243060664005" k="566.5136"/>
+    <Angle class1="c" class2="n" class3="n3" angle="2.0961404316451895" k="557.3088"/>
+    <Angle class1="c" class2="n" class3="n4" angle="1.9603538158400309" k="569.8607999999999"/>
+    <Angle class1="c" class2="n" class3="n" angle="2.0668189002116852" k="560.6560000000001"/>
+    <Angle class1="c" class2="n" class3="na" angle="1.9460421159736774" k="577.392"/>
+    <Angle class1="na" class2="nc" class3="nd" angle="1.8542377973187756" k="635.9680000000001"/>
+    <Angle class1="c" class2="n" class3="nc" angle="2.1792181040401197" k="554.7984"/>
+    <Angle class1="nc" class2="nc" class3="nd" angle="1.9453439842728797" k="618.3952"/>
+    <Angle class1="c" class2="n" class3="nd" angle="2.1792181040401197" k="554.7984"/>
+    <Angle class1="nd" class2="nc" class3="os" angle="1.87134202398832" k="624.2528"/>
+    <Angle class1="c" class2="n" class3="nh" angle="2.0718803550424685" k="560.6560000000001"/>
+    <Angle class1="c" class2="n" class3="no" angle="2.0622810441564994" k="550.6144"/>
+    <Angle class1="c" class2="n" class3="o" angle="2.0657717026604883" k="595.8016"/>
+    <Angle class1="c" class2="n" class3="oh" angle="2.01602981897865" k="570.6976000000001"/>
+    <Angle class1="c" class2="n" class3="os" angle="1.9746655157063844" k="575.7184"/>
+    <Angle class1="c" class2="n" class3="p2" angle="2.173982116284137" k="636.8048"/>
+    <Angle class1="c" class2="n" class3="p3" angle="2.1387264653938516" k="631.784"/>
+    <Angle class1="c" class2="n" class3="p4" angle="2.1544344286618005" k="640.152"/>
+    <Angle class1="c" class2="n" class3="p5" angle="2.2427480888127134" k="631.784"/>
+    <Angle class1="c" class2="n" class3="pc" angle="2.133315944712669" k="640.9888"/>
+    <Angle class1="c" class2="n" class3="pd" angle="2.133315944712669" k="640.9888"/>
+    <Angle class1="c" class2="n" class3="s4" angle="2.101550952326372" k="503.75360000000006"/>
+    <Angle class1="c" class2="n" class3="s6" angle="2.1774727747881255" k="506.264"/>
+    <Angle class1="c" class2="n" class3="s" angle="2.208714168398824" k="492.03839999999997"/>
+    <Angle class1="c" class2="n" class3="sh" angle="2.086366587834022" k="514.6320000000001"/>
+    <Angle class1="c" class2="n" class3="ss" angle="2.124240232602298" k="510.44800000000004"/>
+    <Angle class1="c" class2="n" class3="sy" angle="2.176251044311729" k="507.10080000000005"/>
+    <Angle class1="cx" class2="n" class3="hn" angle="2.067167966062084" k="389.112"/>
+    <Angle class1="cx" class2="n" class3="os" angle="2.0996310901491784" k="548.104"/>
+    <Angle class1="cy" class2="n" class3="hn" angle="2.074323815995261" k="388.2752"/>
+    <Angle class1="c3" class2="nd" class3="cc" angle="1.9113100638589904" k="568.1872000000001"/>
+    <Angle class1="ca" class2="nd" class3="ca" angle="1.9189895125677654" k="584.9232000000001"/>
+    <Angle class1="ca" class2="nd" class3="cc" angle="1.8305013194916528" k="606.6800000000001"/>
+    <Angle class1="ca" class2="nd" class3="n" angle="1.8271851939128636" k="612.5376"/>
+    <Angle class1="ca" class2="nd" class3="na" angle="1.793500339349373" k="619.232"/>
+    <Angle class1="ca" class2="nd" class3="nc" angle="1.8908897116106567" k="615.048"/>
+    <Angle class1="ca" class2="nd" class3="os" angle="1.8235200024836755" k="606.6800000000001"/>
+    <Angle class1="ca" class2="nd" class3="ss" angle="1.8687240301103285" k="572.3712"/>
+    <Angle class1="c" class2="nd" class3="ca" angle="2.105914275456358" k="551.4512000000001"/>
+    <Angle class1="c" class2="nd" class3="cc" angle="2.1029472157279674" k="558.1456000000001"/>
+    <Angle class1="cc" class2="nd" class3="cc" angle="2.047271212589348" k="581.576"/>
+    <Angle class1="cc" class2="nd" class3="cd" angle="1.841147827928818" k="600.8224"/>
+    <Angle class1="cc" class2="nd" class3="n" angle="2.0453513504121545" k="585.76"/>
+    <Angle class1="cc" class2="nd" class3="na" angle="1.8120008294205128" k="624.2528"/>
+    <Angle class1="cc" class2="nd" class3="nd" angle="1.881813999500286" k="610.0272000000001"/>
+    <Angle class1="cc" class2="nd" class3="os" angle="1.8268361280624645" k="613.3744"/>
+    <Angle class1="cc" class2="nd" class3="ss" angle="1.8861773226302716" k="573.208"/>
+    <Angle class1="cd" class2="nd" class3="cd" angle="1.8109536318693162" k="594.128"/>
+    <Angle class1="cd" class2="nd" class3="na" angle="1.7971655307785612" k="615.048"/>
+    <Angle class1="cd" class2="nd" class3="nc" angle="1.8957766335162407" k="610.0272000000001"/>
+    <Angle class1="na" class2="nd" class3="nc" angle="1.8542377973187756" k="635.9680000000001"/>
+    <Angle class1="nc" class2="nd" class3="nd" angle="1.9453439842728797" k="618.3952"/>
+    <Angle class1="nc" class2="nd" class3="os" angle="1.87134202398832" k="624.2528"/>
+    <Angle class1="c1" class2="ne" class3="ca" angle="2.6520277984053835" k="508.7744"/>
+    <Angle class1="c1" class2="ne" class3="cg" angle="2.443460952792061" k="551.4512000000001"/>
+    <Angle class1="c2" class2="ne" class3="ca" angle="2.108881335184748" k="556.472"/>
+    <Angle class1="c2" class2="ne" class3="ce" angle="2.024756465238622" k="571.5344"/>
+    <Angle class1="c2" class2="ne" class3="cg" angle="2.150769237232612" k="570.6976000000001"/>
+    <Angle class1="c2" class2="ne" class3="n2" angle="1.9776325754347748" k="622.5792000000001"/>
+    <Angle class1="c2" class2="ne" class3="ne" angle="1.9348720087609137" k="591.6176"/>
+    <Angle class1="c2" class2="ne" class3="p2" angle="2.339264796448" k="674.4608"/>
+    <Angle class1="c2" class2="ne" class3="pe" angle="2.103470814503566" k="661.9087999999999"/>
+    <Angle class1="c2" class2="ne" class3="px" angle="2.055125194223323" k="673.624"/>
+    <Angle class1="c2" class2="ne" class3="py" angle="2.042733356534163" k="707.9327999999999"/>
+    <Angle class1="c2" class2="ne" class3="sx" angle="1.9544196963832503" k="509.6112"/>
+    <Angle class1="c2" class2="ne" class3="sy" angle="2.104867077905161" k="533.0416"/>
+    <Angle class1="ca" class2="ne" class3="cf" angle="2.124240232602298" k="553.9616000000001"/>
+    <Angle class1="ca" class2="ne" class3="n2" angle="1.9957839996555158" k="589.9440000000001"/>
+    <Angle class1="ca" class2="ne" class3="nf" angle="2.010095699521869" k="589.1072"/>
+    <Angle class1="ca" class2="ne" class3="o" angle="2.01917141163224" k="596.6384"/>
+    <Angle class1="ca" class2="ne" class3="p2" angle="2.061059313680104" k="699.5648"/>
+    <Angle class1="ca" class2="ne" class3="s" angle="2.0963149645703893" k="553.9616000000001"/>
+    <Angle class1="c" class2="ne" class3="c2" angle="2.068738762388879" k="566.5136"/>
+    <Angle class1="ce" class2="ne" class3="n2" angle="1.940631595292495" k="601.6592"/>
+    <Angle class1="ce" class2="ne" class3="o" angle="1.95756128903684" k="610.0272000000001"/>
+    <Angle class1="ce" class2="ne" class3="p2" angle="2.0423842906837644" k="705.4224"/>
+    <Angle class1="ce" class2="ne" class3="s" angle="2.0294688542190062" k="564.84"/>
+    <Angle class1="cg" class2="ne" class3="n1" angle="2.097885760897184" k="599.9856000000001"/>
+    <Angle class1="cg" class2="ne" class3="n2" angle="1.9790288388363704" k="613.3744"/>
+    <Angle class1="cg" class2="ne" class3="o" angle="2.001892652037496" k="622.5792000000001"/>
+    <Angle class1="cg" class2="ne" class3="p2" angle="2.0868901866096197" k="709.6064"/>
+    <Angle class1="cg" class2="ne" class3="s" angle="2.054252529597326" k="571.5344"/>
+    <Angle class1="c" class2="ne" class3="sy" angle="2.032086848096998" k="533.8783999999999"/>
+    <Angle class1="n2" class2="ne" class3="n2" angle="1.87134202398832" k="661.072"/>
+    <Angle class1="n2" class2="ne" class3="ne" angle="1.9324285478081218" k="610.0272000000001"/>
+    <Angle class1="n2" class2="ne" class3="o" angle="1.9914206765255298" k="654.3776"/>
+    <Angle class1="n2" class2="ne" class3="p2" angle="1.9139280577369817" k="767.3456000000001"/>
+    <Angle class1="n2" class2="ne" class3="pe" angle="1.9573867561116407" k="704.5856"/>
+    <Angle class1="n2" class2="ne" class3="px" angle="2.0240583335378237" k="697.0544"/>
+    <Angle class1="n2" class2="ne" class3="py" angle="2.0001473227855016" k="735.5472000000001"/>
+    <Angle class1="n2" class2="ne" class3="s" angle="2.022836603061428" k="597.4752000000001"/>
+    <Angle class1="n2" class2="ne" class3="sx" angle="1.8725637544647162" k="533.8783999999999"/>
+    <Angle class1="n2" class2="ne" class3="sy" angle="1.9409806611428937" k="570.6976000000001"/>
+    <Angle class1="ne" class2="ne" class3="o" angle="1.9277161588277372" k="621.7424"/>
+    <Angle class1="ne" class2="ne" class3="p2" angle="1.9964821313563135" k="725.5056000000001"/>
+    <Angle class1="ne" class2="ne" class3="s" angle="2.0237092676874253" k="574.8816"/>
+    <Angle class1="o" class2="ne" class3="o" angle="2.1657790687997633" k="641.8256"/>
+    <Angle class1="o" class2="ne" class3="pe" angle="2.3094196662388966" k="655.2144"/>
+    <Angle class1="o" class2="ne" class3="px" angle="1.9306832185561276" k="720.4848"/>
+    <Angle class1="o" class2="ne" class3="py" angle="1.9336502782845175" k="757.304"/>
+    <Angle class1="o" class2="ne" class3="s" angle="2.0453513504121545" k="602.496"/>
+    <Angle class1="o" class2="ne" class3="sx" angle="1.9010126212722238" k="533.8783999999999"/>
+    <Angle class1="o" class2="ne" class3="sy" angle="1.9432495891704866" k="576.5552"/>
+    <Angle class1="p2" class2="ne" class3="pe" angle="2.0387190992545765" k="875.2927999999999"/>
+    <Angle class1="p2" class2="ne" class3="px" angle="2.2401300949347216" k="837.6368"/>
+    <Angle class1="p2" class2="ne" class3="py" angle="2.1549580274373983" k="882.8240000000001"/>
+    <Angle class1="p2" class2="ne" class3="sx" angle="1.9568631573360424" k="673.624"/>
+    <Angle class1="p2" class2="ne" class3="sy" angle="2.0198695433330376" k="704.5856"/>
+    <Angle class1="pe" class2="ne" class3="s" angle="2.0198695433330376" k="698.7280000000001"/>
+    <Angle class1="px" class2="ne" class3="s" angle="2.301042085829324" k="656.888"/>
+    <Angle class1="py" class2="ne" class3="s" angle="2.027723524967012" k="724.6688"/>
+    <Angle class1="s" class2="ne" class3="s" angle="2.1095794668855463" k="574.8816"/>
+    <Angle class1="s" class2="ne" class3="sx" angle="1.9715239230527946" k="533.0416"/>
+    <Angle class1="s" class2="ne" class3="sy" angle="2.087937384160816" k="551.4512000000001"/>
+    <Angle class1="c1" class2="nf" class3="ca" angle="2.6520277984053835" k="508.7744"/>
+    <Angle class1="c1" class2="nf" class3="ch" angle="2.443460952792061" k="551.4512000000001"/>
+    <Angle class1="c2" class2="nf" class3="ca" angle="2.108881335184748" k="556.472"/>
+    <Angle class1="c2" class2="nf" class3="cf" angle="2.024756465238622" k="571.5344"/>
+    <Angle class1="c2" class2="nf" class3="n2" angle="1.9776325754347748" k="622.5792000000001"/>
+    <Angle class1="c2" class2="nf" class3="nf" angle="1.9348720087609137" k="591.6176"/>
+    <Angle class1="c2" class2="nf" class3="p2" angle="2.339264796448" k="674.4608"/>
+    <Angle class1="c2" class2="nf" class3="pf" angle="2.103470814503566" k="661.9087999999999"/>
+    <Angle class1="c2" class2="nf" class3="px" angle="2.055125194223323" k="673.624"/>
+    <Angle class1="c2" class2="nf" class3="py" angle="2.042733356534163" k="707.9327999999999"/>
+    <Angle class1="c2" class2="nf" class3="sx" angle="1.9544196963832503" k="509.6112"/>
+    <Angle class1="c2" class2="nf" class3="sy" angle="2.104867077905161" k="533.0416"/>
+    <Angle class1="ca" class2="nf" class3="ce" angle="2.124240232602298" k="553.9616000000001"/>
+    <Angle class1="ca" class2="nf" class3="n2" angle="1.9957839996555158" k="589.9440000000001"/>
+    <Angle class1="ca" class2="nf" class3="ne" angle="2.010095699521869" k="589.1072"/>
+    <Angle class1="ca" class2="nf" class3="o" angle="2.01917141163224" k="596.6384"/>
+    <Angle class1="ca" class2="nf" class3="p2" angle="2.061059313680104" k="699.5648"/>
+    <Angle class1="ca" class2="nf" class3="s" angle="2.0963149645703893" k="553.9616000000001"/>
+    <Angle class1="c" class2="nf" class3="c2" angle="2.068738762388879" k="566.5136"/>
+    <Angle class1="cf" class2="nf" class3="n2" angle="1.940631595292495" k="601.6592"/>
+    <Angle class1="cf" class2="nf" class3="o" angle="1.95756128903684" k="610.0272000000001"/>
+    <Angle class1="cf" class2="nf" class3="p2" angle="2.0423842906837644" k="705.4224"/>
+    <Angle class1="cf" class2="nf" class3="s" angle="2.0294688542190062" k="564.84"/>
+    <Angle class1="ch" class2="nf" class3="n1" angle="2.097885760897184" k="599.9856000000001"/>
+    <Angle class1="ch" class2="nf" class3="n2" angle="1.9790288388363704" k="613.3744"/>
+    <Angle class1="ch" class2="nf" class3="o" angle="2.001892652037496" k="622.5792000000001"/>
+    <Angle class1="ch" class2="nf" class3="p2" angle="2.0868901866096197" k="709.6064"/>
+    <Angle class1="ch" class2="nf" class3="s" angle="2.054252529597326" k="571.5344"/>
+    <Angle class1="f" class2="n" class3="f" angle="1.7973400637037606" k="568.1872000000001"/>
+    <Angle class1="n2" class2="nf" class3="n2" angle="1.87134202398832" k="661.072"/>
+    <Angle class1="n2" class2="nf" class3="nf" angle="1.9324285478081218" k="610.0272000000001"/>
+    <Angle class1="n2" class2="nf" class3="o" angle="1.9914206765255298" k="654.3776"/>
+    <Angle class1="n2" class2="nf" class3="p2" angle="1.9139280577369817" k="767.3456000000001"/>
+    <Angle class1="n2" class2="nf" class3="pf" angle="1.9573867561116407" k="704.5856"/>
+    <Angle class1="n2" class2="nf" class3="px" angle="2.0240583335378237" k="697.0544"/>
+    <Angle class1="n2" class2="nf" class3="py" angle="2.0001473227855016" k="735.5472000000001"/>
+    <Angle class1="n2" class2="nf" class3="s" angle="2.022836603061428" k="597.4752000000001"/>
+    <Angle class1="n2" class2="nf" class3="sx" angle="1.8725637544647162" k="533.8783999999999"/>
+    <Angle class1="n2" class2="nf" class3="sy" angle="1.9409806611428937" k="570.6976000000001"/>
+    <Angle class1="nf" class2="nf" class3="o" angle="1.9277161588277372" k="621.7424"/>
+    <Angle class1="nf" class2="nf" class3="p2" angle="1.9964821313563135" k="725.5056000000001"/>
+    <Angle class1="nf" class2="nf" class3="s" angle="2.0237092676874253" k="574.8816"/>
+    <Angle class1="o" class2="nf" class3="o" angle="2.1657790687997633" k="641.8256"/>
+    <Angle class1="o" class2="nf" class3="pf" angle="2.3094196662388966" k="655.2144"/>
+    <Angle class1="o" class2="nf" class3="px" angle="1.9306832185561276" k="720.4848"/>
+    <Angle class1="o" class2="nf" class3="py" angle="1.9336502782845175" k="757.304"/>
+    <Angle class1="o" class2="nf" class3="s" angle="2.0453513504121545" k="602.496"/>
+    <Angle class1="o" class2="nf" class3="sx" angle="1.9010126212722238" k="533.8783999999999"/>
+    <Angle class1="o" class2="nf" class3="sy" angle="1.9432495891704866" k="576.5552"/>
+    <Angle class1="p2" class2="nf" class3="pf" angle="2.0387190992545765" k="875.2927999999999"/>
+    <Angle class1="p2" class2="nf" class3="px" angle="2.2401300949347216" k="837.6368"/>
+    <Angle class1="p2" class2="nf" class3="py" angle="2.1549580274373983" k="882.8240000000001"/>
+    <Angle class1="p2" class2="nf" class3="sx" angle="1.9568631573360424" k="673.624"/>
+    <Angle class1="p2" class2="nf" class3="sy" angle="2.0198695433330376" k="704.5856"/>
+    <Angle class1="pf" class2="nf" class3="s" angle="2.0198695433330376" k="698.7280000000001"/>
+    <Angle class1="px" class2="nf" class3="s" angle="2.301042085829324" k="656.888"/>
+    <Angle class1="py" class2="nf" class3="s" angle="2.027723524967012" k="724.6688"/>
+    <Angle class1="s" class2="nf" class3="s" angle="2.1095794668855463" k="574.8816"/>
+    <Angle class1="s" class2="nf" class3="sx" angle="1.9715239230527946" k="533.0416"/>
+    <Angle class1="s" class2="nf" class3="sy" angle="2.087937384160816" k="551.4512000000001"/>
+    <Angle class1="br" class2="nh" class3="br" angle="1.854761396094374" k="561.4928"/>
+    <Angle class1="br" class2="nh" class3="ca" angle="1.9526743671312556" k="518.816"/>
+    <Angle class1="br" class2="nh" class3="hn" angle="1.772556388325441" k="352.2928"/>
+    <Angle class1="c1" class2="nh" class3="c1" angle="2.0416861589829667" k="570.6976000000001"/>
+    <Angle class1="c1" class2="nh" class3="c2" angle="2.1528636323350057" k="546.4304"/>
+    <Angle class1="c1" class2="nh" class3="ca" angle="2.1355848727402615" k="548.9408"/>
+    <Angle class1="c1" class2="nh" class3="hn" angle="2.049016541841343" k="414.216"/>
+    <Angle class1="c2" class2="nh" class3="c2" angle="2.1769491760125272" k="535.552"/>
+    <Angle class1="c2" class2="nh" class3="c3" angle="2.159146817642185" k="522.1632"/>
+    <Angle class1="c2" class2="nh" class3="ca" angle="2.226341993843967" k="529.6944"/>
+    <Angle class1="c2" class2="nh" class3="cc" angle="2.2052235098948354" k="534.7152"/>
+    <Angle class1="c2" class2="nh" class3="cd" angle="2.2052235098948354" k="534.7152"/>
+    <Angle class1="c2" class2="nh" class3="cx" angle="2.1710150565557464" k="526.3472"/>
+    <Angle class1="c2" class2="nh" class3="hn" angle="2.008699436120274" k="406.68480000000005"/>
+    <Angle class1="c2" class2="nh" class3="n2" angle="2.098234826747583" k="565.6768"/>
+    <Angle class1="c2" class2="nh" class3="n3" angle="2.039766296805773" k="560.6560000000001"/>
+    <Angle class1="c2" class2="nh" class3="no" angle="2.1924826063552767" k="546.4304"/>
+    <Angle class1="c2" class2="nh" class3="oh" angle="1.9579103548872387" k="575.7184"/>
+    <Angle class1="c2" class2="nh" class3="os" angle="1.9713493901275951" k="573.208"/>
+    <Angle class1="c2" class2="nh" class3="sy" angle="2.1141173229407313" k="513.7952"/>
+    <Angle class1="c3" class2="nh" class3="c3" angle="1.9985765264587068" k="528.8576"/>
+    <Angle class1="c3" class2="nh" class3="ca" angle="2.0940460365427964" k="530.5312"/>
+    <Angle class1="c3" class2="nh" class3="cc" angle="2.089508180487611" k="533.0416"/>
+    <Angle class1="c3" class2="nh" class3="cd" angle="2.089508180487611" k="533.0416"/>
+    <Angle class1="c3" class2="nh" class3="cf" angle="2.0964894974955888" k="529.6944"/>
+    <Angle class1="c3" class2="nh" class3="cz" angle="2.1896900795520855" k="526.3472"/>
+    <Angle class1="c3" class2="nh" class3="hn" angle="2.0244073993882226" k="385.76480000000004"/>
+    <Angle class1="c3" class2="nh" class3="n2" angle="1.960877414615629" k="567.3504"/>
+    <Angle class1="c3" class2="nh" class3="n" angle="1.9420278586940904" k="561.4928"/>
+    <Angle class1="c3" class2="nh" class3="na" angle="1.961575546316427" k="558.9824"/>
+    <Angle class1="c3" class2="nh" class3="p2" angle="2.1528636323350057" k="644.336"/>
+    <Angle class1="c3" class2="nh" class3="sy" angle="2.030166985919804" k="517.1424"/>
+    <Angle class1="ca" class2="nh" class3="ca" angle="2.2245966645919726" k="529.6944"/>
+    <Angle class1="ca" class2="nh" class3="cc" angle="2.26543736908864" k="527.184"/>
+    <Angle class1="ca" class2="nh" class3="cd" angle="2.26543736908864" k="527.184"/>
+    <Angle class1="ca" class2="nh" class3="cl" angle="1.974840048631584" k="481.16"/>
+    <Angle class1="ca" class2="nh" class3="cx" angle="2.1682225297525557" k="527.184"/>
+    <Angle class1="ca" class2="nh" class3="f" angle="1.8516198034407843" k="564.0032000000001"/>
+    <Angle class1="ca" class2="nh" class3="hn" angle="2.0258036627898184" k="405.01120000000003"/>
+    <Angle class1="ca" class2="nh" class3="i" angle="2.0565214576249184" k="465.2608"/>
+    <Angle class1="ca" class2="nh" class3="n1" angle="2.044304152860958" k="575.7184"/>
+    <Angle class1="ca" class2="nh" class3="n2" angle="2.1141173229407313" k="563.1664"/>
+    <Angle class1="ca" class2="nh" class3="n3" angle="2.0565214576249184" k="558.9824"/>
+    <Angle class1="ca" class2="nh" class3="n4" angle="1.9013616871226224" k="569.8607999999999"/>
+    <Angle class1="ca" class2="nh" class3="n" angle="2.0251055310890202" k="565.6768"/>
+    <Angle class1="ca" class2="nh" class3="na" angle="2.0238838006126247" k="566.5136"/>
+    <Angle class1="ca" class2="nh" class3="nh" angle="2.004336112990288" k="569.024"/>
+    <Angle class1="ca" class2="nh" class3="no" angle="1.9882790838719404" k="574.0448"/>
+    <Angle class1="ca" class2="nh" class3="o" angle="2.1279054240314865" k="581.576"/>
+    <Angle class1="ca" class2="nh" class3="oh" angle="1.971698455977994" k="573.208"/>
+    <Angle class1="ca" class2="nh" class3="os" angle="1.9521507683556574" k="576.5552"/>
+    <Angle class1="ca" class2="nh" class3="p2" angle="2.1863739539732965" k="650.1936000000001"/>
+    <Angle class1="ca" class2="nh" class3="p3" angle="2.193878869756872" k="634.2944"/>
+    <Angle class1="ca" class2="nh" class3="p4" angle="2.1643828053981684" k="645.1727999999999"/>
+    <Angle class1="ca" class2="nh" class3="p5" angle="2.236988502281132" k="645.1727999999999"/>
+    <Angle class1="ca" class2="nh" class3="s4" angle="2.017949681155844" k="517.9792"/>
+    <Angle class1="ca" class2="nh" class3="s6" angle="2.1441369860750337" k="514.6320000000001"/>
+    <Angle class1="ca" class2="nh" class3="s" angle="2.1387264653938516" k="495.38560000000007"/>
+    <Angle class1="ca" class2="nh" class3="sh" angle="2.1190042448463156" k="514.6320000000001"/>
+    <Angle class1="ca" class2="nh" class3="ss" angle="2.1205750411731104" k="514.6320000000001"/>
+    <Angle class1="ca" class2="nh" class3="sy" angle="2.185675822272499" k="505.4272"/>
+    <Angle class1="cc" class2="nh" class3="cx" angle="2.2258183950683685" k="522.1632"/>
+    <Angle class1="cc" class2="nh" class3="hn" angle="2.018124214081043" k="409.1952"/>
+    <Angle class1="cc" class2="nh" class3="n2" angle="2.0959658987199905" k="569.024"/>
+    <Angle class1="cc" class2="nh" class3="sy" angle="2.1383773995434523" k="512.1216000000001"/>
+    <Angle class1="cd" class2="nh" class3="cx" angle="2.158972284716986" k="526.3472"/>
+    <Angle class1="cd" class2="nh" class3="hn" angle="2.018124214081043" k="409.1952"/>
+    <Angle class1="ce" class2="nh" class3="hn" angle="2.0189968787070405" k="405.01120000000003"/>
+    <Angle class1="ce" class2="nh" class3="o" angle="2.258979650856261" k="563.1664"/>
+    <Angle class1="ce" class2="nh" class3="sy" angle="1.9790288388363704" k="531.368"/>
+    <Angle class1="cf" class2="nh" class3="hn" angle="2.0189968787070405" k="405.01120000000003"/>
+    <Angle class1="cf" class2="nh" class3="o" angle="2.258979650856261" k="563.1664"/>
+    <Angle class1="cl" class2="nh" class3="cl" angle="1.8605209826259552" k="455.2192"/>
+    <Angle class1="cl" class2="nh" class3="hn" angle="1.817585883026895" k="335.5568"/>
+    <Angle class1="cx" class2="nh" class3="cx" angle="1.0822786691616837" k="723.832"/>
+    <Angle class1="cx" class2="nh" class3="hn" angle="2.0748474147708587" k="388.2752"/>
+    <Angle class1="cz" class2="nh" class3="hn" angle="2.11446638879113" k="408.3584"/>
+    <Angle class1="f" class2="nh" class3="f" angle="1.7749998492782333" k="559.8192"/>
+    <Angle class1="f" class2="nh" class3="hn" angle="1.7667968017938598" k="416.7264"/>
+    <Angle class1="hn" class2="nh" class3="hn" angle="2.009223034895872" k="335.5568"/>
+    <Angle class1="hn" class2="nh" class3="i" angle="1.8774506763703" k="305.432"/>
+    <Angle class1="hn" class2="nh" class3="n1" angle="1.92981055393013" k="437.64639999999997"/>
+    <Angle class1="hn" class2="nh" class3="n2" angle="2.061931978306101" k="420.07360000000006"/>
+    <Angle class1="hn" class2="nh" class3="n3" angle="1.9891517484979375" k="410.8688"/>
+    <Angle class1="hn" class2="nh" class3="n4" angle="1.8221237390820801" k="415.88960000000003"/>
+    <Angle class1="hn" class2="nh" class3="n" angle="1.8879226518822663" k="425.9312"/>
+    <Angle class1="hn" class2="nh" class3="na" angle="1.889144382358662" k="425.9312"/>
+    <Angle class1="hn" class2="nh" class3="nh" angle="1.9348720087609137" k="420.07360000000006"/>
+    <Angle class1="hn" class2="nh" class3="no" angle="1.9188149796425658" k="426.76800000000003"/>
+    <Angle class1="hn" class2="nh" class3="o" angle="2.032435913947397" k="450.1984"/>
+    <Angle class1="hn" class2="nh" class3="oh" angle="1.8586011204487614" k="427.6048"/>
+    <Angle class1="hn" class2="nh" class3="os" angle="1.8512707375903852" k="428.44160000000005"/>
+    <Angle class1="hn" class2="nh" class3="p2" angle="2.0626301100068987" k="455.2192"/>
+    <Angle class1="hn" class2="nh" class3="p3" angle="2.0278980578922114" k="443.504"/>
+    <Angle class1="hn" class2="nh" class3="p4" angle="1.965240737745615" k="457.72960000000006"/>
+    <Angle class1="hn" class2="nh" class3="p5" angle="2.008699436120274" k="463.5872"/>
+    <Angle class1="hn" class2="nh" class3="s4" angle="1.8758798800435055" k="359.824"/>
+    <Angle class1="hn" class2="nh" class3="s" angle="1.9961330655059148" k="341.4144"/>
+    <Angle class1="hn" class2="nh" class3="s6" angle="1.9184659137921671" k="368.192"/>
+    <Angle class1="hn" class2="nh" class3="sh" angle="1.959132085363635" k="362.3344"/>
+    <Angle class1="hn" class2="nh" class3="ss" angle="1.9914206765255298" k="358.98720000000003"/>
+    <Angle class1="hn" class2="nh" class3="sy" angle="1.9357446733869108" k="363.1712"/>
+    <Angle class1="i" class2="nh" class3="i" angle="2.0214403396598324" k="500.4064"/>
+    <Angle class1="n1" class2="nh" class3="n1" angle="1.8624408448031489" k="628.4368"/>
+    <Angle class1="n2" class2="nh" class3="n2" angle="2.050761871093337" k="593.2912000000001"/>
+    <Angle class1="n2" class2="nh" class3="n3" angle="2.0779890074244487" k="575.7184"/>
+    <Angle class1="n2" class2="nh" class3="o" angle="2.2001620550640517" k="594.9648"/>
+    <Angle class1="n3" class2="nh" class3="n3" angle="1.936966403863307" k="583.2496000000001"/>
+    <Angle class1="n4" class2="nh" class3="n4" angle="1.8912387774610553" k="570.6976000000001"/>
+    <Angle class1="na" class2="nh" class3="na" angle="1.9549432951588488" k="587.4336000000001"/>
+    <Angle class1="hn" class2="n" class3="hn" angle="2.0586158527273115" k="331.37280000000004"/>
+    <Angle class1="nh" class2="nh" class3="nh" angle="1.958783019513236" k="585.76"/>
+    <Angle class1="hn" class2="n" class3="i" angle="2.0462240150381517" k="302.08480000000003"/>
+    <Angle class1="hn" class2="n" class3="n2" angle="2.0783380732748475" k="416.7264"/>
+    <Angle class1="hn" class2="n" class3="n3" angle="2.0462240150381517" k="408.3584"/>
+    <Angle class1="hn" class2="n" class3="n4" angle="1.9666370011472105" k="409.1952"/>
+    <Angle class1="hn" class2="n" class3="n" angle="1.9757127132575811" k="415.05280000000005"/>
+    <Angle class1="hn" class2="n" class3="na" angle="1.9957839996555158" k="412.5424"/>
+    <Angle class1="hn" class2="n" class3="nc" angle="2.014459022651855" k="423.42080000000004"/>
+    <Angle class1="hn" class2="n" class3="nh" angle="1.9758872461827806" k="415.88960000000003"/>
+    <Angle class1="hn" class2="n" class3="no" angle="1.9217820393709562" k="407.52160000000003"/>
+    <Angle class1="hn" class2="n" class3="o" angle="2.030166985919804" k="456.05600000000004"/>
+    <Angle class1="n" class2="nh" class3="o" angle="2.018124214081043" k="607.5168"/>
+    <Angle class1="hn" class2="n" class3="oh" angle="1.9327776136585204" k="421.7472"/>
+    <Angle class1="no" class2="nh" class3="no" angle="1.8945549030398445" k="602.496"/>
+    <Angle class1="hn" class2="n" class3="os" angle="1.920036710118962" k="422.584"/>
+    <Angle class1="hn" class2="n" class3="p2" angle="2.0603611819793057" k="439.32"/>
+    <Angle class1="hn" class2="n" class3="p3" angle="2.087937384160816" k="426.76800000000003"/>
+    <Angle class1="hn" class2="n" class3="p4" angle="2.0195204774826387" k="443.504"/>
+    <Angle class1="hn" class2="n" class3="p5" angle="1.9828685631907579" k="452.70880000000005"/>
+    <Angle class1="hn" class2="n" class3="s4" angle="1.962797276792823" k="348.10880000000003"/>
+    <Angle class1="hn" class2="n" class3="s" angle="2.0057323763918835" k="344.76160000000004"/>
+    <Angle class1="hn" class2="n" class3="s6" angle="1.9645426060448175" k="358.98720000000003"/>
+    <Angle class1="hn" class2="n" class3="sh" angle="2.0055578434666836" k="353.12960000000004"/>
+    <Angle class1="hn" class2="n" class3="ss" angle="2.017600615305445" k="352.2928"/>
+    <Angle class1="hn" class2="n" class3="sy" angle="1.9605283487652303" k="359.824"/>
+    <Angle class1="oh" class2="nh" class3="oh" angle="1.854761396094374" k="603.3328"/>
+    <Angle class1="o" class2="nh" class3="o" angle="2.2350686401039384" k="615.8847999999999"/>
+    <Angle class1="os" class2="nh" class3="os" angle="1.8373081035744305" k="606.6800000000001"/>
+    <Angle class1="p2" class2="nh" class3="p2" angle="2.2223277365643797" k="820.9008"/>
+    <Angle class1="p3" class2="nh" class3="p3" angle="2.1830578283945075" k="803.328"/>
+    <Angle class1="p5" class2="nh" class3="p5" angle="1.968033264548806" k="876.1296000000001"/>
+    <Angle class1="s4" class2="nh" class3="s4" angle="1.961575546316427" k="523.8368"/>
+    <Angle class1="s6" class2="nh" class3="s6" angle="2.09910749137358" k="521.3264"/>
+    <Angle class1="sh" class2="nh" class3="sh" angle="2.076941809873252" k="521.3264"/>
+    <Angle class1="s" class2="nh" class3="s" angle="2.0722294208928678" k="499.56960000000004"/>
+    <Angle class1="ss" class2="nh" class3="ss" angle="2.081305133003238" k="519.6528000000001"/>
+    <Angle class1="i" class2="n" class3="i" angle="2.0629791758572975" k="507.93760000000003"/>
+    <Angle class1="n2" class2="n" class3="n2" angle="2.040115362656172" k="591.6176"/>
+    <Angle class1="n3" class2="n" class3="n3" angle="2.058441319802112" k="570.6976000000001"/>
+    <Angle class1="n4" class2="n" class3="n4" angle="1.9668115340724097" k="572.3712"/>
+    <Angle class1="na" class2="n" class3="na" angle="2.048667475990944" k="570.6976000000001"/>
+    <Angle class1="nc" class2="n" class3="nc" angle="2.031737782246599" k="593.2912000000001"/>
+    <Angle class1="nc" class2="n" class3="p2" angle="2.0457004162625534" k="675.2976000000001"/>
+    <Angle class1="nc" class2="n" class3="pc" angle="2.0457004162625534" k="672.7872000000001"/>
+    <Angle class1="nd" class2="n" class3="nd" angle="2.031737782246599" k="593.2912000000001"/>
+    <Angle class1="nd" class2="n" class3="p2" angle="2.0457004162625534" k="675.2976000000001"/>
+    <Angle class1="nd" class2="n" class3="pd" angle="2.0457004162625534" k="672.7872000000001"/>
+    <Angle class1="nh" class2="n" class3="nh" angle="2.010270232447069" k="578.2288"/>
+    <Angle class1="n" class2="n" class3="n" angle="2.0004963886359004" k="579.0656"/>
+    <Angle class1="no" class2="n" class3="no" angle="1.8964747652170384" k="573.208"/>
+    <Angle class1="br" class2="no" class3="o" angle="1.9755381803323815" k="489.528"/>
+    <Angle class1="c1" class2="no" class3="o" angle="2.0355775066009865" k="595.8016"/>
+    <Angle class1="c2" class2="no" class3="o" angle="2.0537289308217277" k="580.7392000000001"/>
+    <Angle class1="c3" class2="no" class3="o" angle="2.0408134943569696" k="558.9824"/>
+    <Angle class1="ca" class2="no" class3="o" angle="2.0552997271485225" k="574.8816"/>
+    <Angle class1="cc" class2="no" class3="o" angle="2.0505873381681377" k="586.5968"/>
+    <Angle class1="cl" class2="no" class3="o" angle="2.0085249031950743" k="479.4864"/>
+    <Angle class1="c" class2="no" class3="o" angle="2.0116664958486643" k="560.6560000000001"/>
+    <Angle class1="hn" class2="no" class3="o" angle="2.015680753128251" k="461.07680000000005"/>
+    <Angle class1="oh" class2="n" class3="oh" angle="1.872040155689118" k="604.1696000000001"/>
+    <Angle class1="i" class2="no" class3="o" angle="2.029992452994605" k="457.72960000000006"/>
+    <Angle class1="n1" class2="no" class3="o" angle="2.007128639793479" k="615.8847999999999"/>
+    <Angle class1="n2" class2="no" class3="o" angle="2.033657644423793" k="602.496"/>
+    <Angle class1="n3" class2="no" class3="o" angle="2.038020967553779" k="612.5376"/>
+    <Angle class1="n4" class2="no" class3="o" angle="1.902408884673819" k="609.1904"/>
+    <Angle class1="na" class2="no" class3="o" angle="2.0170770165298464" k="604.1696000000001"/>
+    <Angle class1="nh" class2="no" class3="o" angle="2.0259781957150174" k="617.5584"/>
+    <Angle class1="n" class2="no" class3="o" angle="2.0174260823802457" k="598.312"/>
+    <Angle class1="no" class2="no" class3="o" angle="1.9614010133912274" k="501.2432"/>
+    <Angle class1="o" class2="n" class3="o" angle="2.2446679509899075" k="624.2528"/>
+    <Angle class1="o" class2="no" class3="o" angle="2.1830578283945075" k="641.8256"/>
+    <Angle class1="o" class2="no" class3="oh" angle="2.001892652037496" k="619.232"/>
+    <Angle class1="o" class2="no" class3="os" angle="2.0029398495886928" k="614.2112000000001"/>
+    <Angle class1="o" class2="no" class3="p2" angle="2.048667475990944" k="686.176"/>
+    <Angle class1="o" class2="no" class3="p3" angle="2.038195500478978" k="650.1936000000001"/>
+    <Angle class1="o" class2="no" class3="p4" angle="2.035752039526186" k="641.8256"/>
+    <Angle class1="o" class2="no" class3="p5" angle="2.036624704152183" k="654.3776"/>
+    <Angle class1="o" class2="no" class3="s4" angle="1.9982274606083077" k="478.6496"/>
+    <Angle class1="o" class2="no" class3="s6" angle="1.9964821313563135" k="483.6704"/>
+    <Angle class1="o" class2="no" class3="s" angle="2.0910789768144062" k="535.552"/>
+    <Angle class1="o" class2="no" class3="sh" angle="2.0263272615654166" k="526.3472"/>
+    <Angle class1="o" class2="no" class3="ss" angle="2.017251549455046" k="521.3264"/>
+    <Angle class1="os" class2="n" class3="os" angle="1.8592992521495593" k="605.0064"/>
+    <Angle class1="p2" class2="n" class3="p2" angle="2.087762851235617" k="820.0640000000001"/>
+    <Angle class1="p3" class2="n" class3="p3" angle="1.8976964956934346" k="842.6576"/>
+    <Angle class1="p4" class2="n" class3="p4" angle="1.8945549030398445" k="860.2304"/>
+    <Angle class1="p5" class2="n" class3="p5" angle="1.74515471906913" k="905.4176000000001"/>
+    <Angle class1="pc" class2="n" class3="pc" angle="2.087762851235617" k="816.7168"/>
+    <Angle class1="pd" class2="n" class3="pd" angle="2.087762851235617" k="816.7168"/>
+    <Angle class1="s4" class2="n" class3="s4" angle="1.9853120241435498" k="514.6320000000001"/>
+    <Angle class1="s6" class2="n" class3="s6" angle="2.0888100487868138" k="516.3056"/>
+    <Angle class1="sh" class2="n" class3="sh" angle="2.0774654086488504" k="514.6320000000001"/>
+    <Angle class1="s" class2="n" class3="s" angle="2.199114857512855" k="489.528"/>
+    <Angle class1="ss" class2="n" class3="ss" angle="2.068040630688081" k="516.3056"/>
+    <Angle class1="br" class2="oh" class3="ho" angle="1.7732545200262386" k="352.2928"/>
+    <Angle class1="c1" class2="oh" class3="ho" angle="1.8982200944690328" k="420.07360000000006"/>
+    <Angle class1="c2" class2="oh" class3="ho" angle="1.8784978739214968" k="418.40000000000003"/>
+    <Angle class1="c3" class2="oh" class3="ho" angle="1.872040155689118" k="396.6432"/>
+    <Angle class1="ca" class2="oh" class3="ho" angle="1.895078501815443" k="410.03200000000004"/>
+    <Angle class1="cc" class2="oh" class3="ho" angle="1.8695966947363258" k="417.5632"/>
+    <Angle class1="cd" class2="oh" class3="ho" angle="1.8695966947363258" k="417.5632"/>
+    <Angle class1="ce" class2="oh" class3="ho" angle="1.8645352399055422" k="417.5632"/>
+    <Angle class1="cf" class2="oh" class3="ho" angle="1.8645352399055422" k="417.5632"/>
+    <Angle class1="c" class2="oh" class3="ho" angle="1.8596483179999581" k="417.5632"/>
+    <Angle class1="cl" class2="oh" class3="ho" angle="1.7872171540421935" k="338.904"/>
+    <Angle class1="cx" class2="oh" class3="ho" angle="1.8633135094291462" k="404.1744"/>
+    <Angle class1="cy" class2="oh" class3="ho" angle="1.8814649336498872" k="398.3168"/>
+    <Angle class1="f" class2="oh" class3="ho" angle="1.6894787159305111" k="405.848"/>
+    <Angle class1="ho" class2="oh" class3="ho" angle="1.8586011204487614" k="348.10880000000003"/>
+    <Angle class1="ho" class2="oh" class3="i" angle="1.884606526303477" k="298.73760000000004"/>
+    <Angle class1="ho" class2="oh" class3="n1" angle="1.8816394665750866" k="439.32"/>
+    <Angle class1="ho" class2="oh" class3="n2" angle="1.7992599258809543" k="423.42080000000004"/>
+    <Angle class1="ho" class2="oh" class3="n3" angle="1.7847736930894014" k="418.40000000000003"/>
+    <Angle class1="ho" class2="oh" class3="n4" angle="1.8610445814015537" k="414.216"/>
+    <Angle class1="ho" class2="oh" class3="n" angle="1.7678439993450565" k="422.584"/>
+    <Angle class1="ho" class2="oh" class3="na" angle="1.8216001403064819" k="420.07360000000006"/>
+    <Angle class1="ho" class2="oh" class3="nh" angle="1.7936748722745723" k="416.7264"/>
+    <Angle class1="ho" class2="oh" class3="no" angle="1.7832028967626066" k="420.9104"/>
+    <Angle class1="ho" class2="oh" class3="o" angle="1.7605136164866801" k="395.8064"/>
+    <Angle class1="ho" class2="oh" class3="oh" angle="1.722989037568802" k="412.5424"/>
+    <Angle class1="ho" class2="oh" class3="os" angle="1.7397441983879478" k="414.216"/>
+    <Angle class1="ho" class2="oh" class3="p2" angle="1.9102628663077938" k="467.7712"/>
+    <Angle class1="ho" class2="oh" class3="p3" angle="1.9310322844065262" k="450.1984"/>
+    <Angle class1="ho" class2="oh" class3="p4" angle="1.9231783027725518" k="462.7504"/>
+    <Angle class1="ho" class2="oh" class3="p5" angle="1.9212584405953579" k="471.1184"/>
+    <Angle class1="ho" class2="oh" class3="py" angle="1.9284142905285344" k="469.44480000000004"/>
+    <Angle class1="ho" class2="oh" class3="s4" angle="1.8648843057559408" k="357.31360000000006"/>
+    <Angle class1="ho" class2="oh" class3="s" angle="1.747947245872321" k="342.2512"/>
+    <Angle class1="ho" class2="oh" class3="s6" angle="1.872040155689118" k="372.37600000000003"/>
+    <Angle class1="ho" class2="oh" class3="sh" angle="1.8542377973187756" k="359.824"/>
+    <Angle class1="ho" class2="oh" class3="ss" angle="1.8694221618111262" k="358.98720000000003"/>
+    <Angle class1="ho" class2="oh" class3="sy" angle="1.8573793899723654" k="369.86560000000003"/>
+    <Angle class1="br" class2="os" class3="br" angle="1.9308577514813265" k="544.7568"/>
+    <Angle class1="c1" class2="os" class3="c1" angle="2.0074777056438777" k="563.1664"/>
+    <Angle class1="c1" class2="os" class3="c3" angle="1.9790288388363704" k="542.2464"/>
+    <Angle class1="c2" class2="os" class3="c2" angle="1.9746655157063844" k="550.6144"/>
+    <Angle class1="c2" class2="os" class3="c3" angle="2.0174260823802457" k="530.5312"/>
+    <Angle class1="c2" class2="os" class3="ca" angle="2.0629791758572975" k="537.2256000000001"/>
+    <Angle class1="c2" class2="os" class3="n2" angle="2.0617574453809016" k="543.9200000000001"/>
+    <Angle class1="c2" class2="os" class3="na" angle="1.812524428196111" k="570.6976000000001"/>
+    <Angle class1="c2" class2="os" class3="os" angle="1.7936748722745723" k="571.5344"/>
+    <Angle class1="c2" class2="os" class3="p5" angle="2.2055725757452342" k="642.6624"/>
+    <Angle class1="c2" class2="os" class3="ss" angle="1.8872245201814684" k="527.184"/>
+    <Angle class1="c3" class2="os" class3="c3" angle="1.9631463426432219" k="524.6736000000001"/>
+    <Angle class1="c3" class2="os" class3="ca" angle="2.058790385652511" k="523.0"/>
+    <Angle class1="c3" class2="os" class3="cc" angle="2.0484929430657446" k="525.5104"/>
+    <Angle class1="c3" class2="os" class3="cd" angle="2.0484929430657446" k="525.5104"/>
+    <Angle class1="c3" class2="os" class3="ce" angle="2.0261527286402172" k="527.184"/>
+    <Angle class1="c3" class2="os" class3="cf" angle="2.0261527286402172" k="527.184"/>
+    <Angle class1="c3" class2="os" class3="cl" angle="1.9285888234537343" k="471.1184"/>
+    <Angle class1="c3" class2="os" class3="cy" angle="1.9261453625009421" k="531.368"/>
+    <Angle class1="c3" class2="os" class3="i" angle="1.9844393595175527" k="459.4032"/>
+    <Angle class1="c3" class2="os" class3="n1" angle="1.9809487010135638" k="556.472"/>
+    <Angle class1="c3" class2="os" class3="n2" angle="1.9064231419534063" k="551.4512000000001"/>
+    <Angle class1="c3" class2="os" class3="n3" angle="1.9168951174653721" k="542.2464"/>
+    <Angle class1="c3" class2="os" class3="n4" angle="1.9285888234537343" k="543.9200000000001"/>
+    <Angle class1="c3" class2="os" class3="n" angle="1.9142771235873808" k="548.9408"/>
+    <Angle class1="c3" class2="os" class3="na" angle="1.936966403863307" k="538.8992000000001"/>
+    <Angle class1="c3" class2="os" class3="nc" angle="1.9675096657732076" k="542.2464"/>
+    <Angle class1="c3" class2="os" class3="nd" angle="1.9675096657732076" k="542.2464"/>
+    <Angle class1="c3" class2="os" class3="nh" angle="1.9161969857645744" k="547.2672000000001"/>
+    <Angle class1="c3" class2="os" class3="no" angle="1.987755485096342" k="536.3888"/>
+    <Angle class1="c3" class2="os" class3="o" angle="1.7976891295541593" k="550.6144"/>
+    <Angle class1="c3" class2="os" class3="oh" angle="1.8868754543310697" k="546.4304"/>
+    <Angle class1="c3" class2="os" class3="os" angle="1.8739600178663118" k="546.4304"/>
+    <Angle class1="c3" class2="os" class3="p2" angle="2.015331687277852" k="672.7872000000001"/>
+    <Angle class1="c3" class2="os" class3="p3" angle="2.050936404018537" k="640.152"/>
+    <Angle class1="c3" class2="os" class3="p4" angle="2.0504128052429382" k="650.1936000000001"/>
+    <Angle class1="c3" class2="os" class3="p5" angle="2.086366587834022" k="650.1936000000001"/>
+    <Angle class1="c3" class2="os" class3="py" angle="2.0868901866096197" k="649.3568"/>
+    <Angle class1="c3" class2="os" class3="s4" angle="1.9758872461827806" k="511.2848"/>
+    <Angle class1="c3" class2="os" class3="s6" angle="2.0223130042858295" k="520.4896"/>
+    <Angle class1="c3" class2="os" class3="s" angle="1.9120081955597878" k="496.2224"/>
+    <Angle class1="c3" class2="os" class3="sh" angle="1.9690804621000024" k="517.1424"/>
+    <Angle class1="c3" class2="os" class3="ss" angle="1.9898498801987352" k="507.10080000000005"/>
+    <Angle class1="ca" class2="os" class3="ca" angle="2.0924752402160016" k="531.368"/>
+    <Angle class1="ca" class2="os" class3="cc" angle="1.9736183181551878" k="548.104"/>
+    <Angle class1="ca" class2="os" class3="cd" angle="1.9736183181551878" k="548.104"/>
+    <Angle class1="ca" class2="os" class3="n3" angle="1.9580848878124382" k="548.104"/>
+    <Angle class1="ca" class2="os" class3="na" angle="1.889144382358662" k="556.472"/>
+    <Angle class1="ca" class2="os" class3="nc" angle="1.907993938280201" k="563.1664"/>
+    <Angle class1="ca" class2="os" class3="nd" angle="1.907993938280201" k="563.1664"/>
+    <Angle class1="ca" class2="os" class3="p5" angle="2.149896572606615" k="650.1936000000001"/>
+    <Angle class1="ca" class2="os" class3="s6" angle="2.045176817486955" k="524.6736000000001"/>
+    <Angle class1="c" class2="os" class3="c2" angle="2.0633282417076964" k="538.8992000000001"/>
+    <Angle class1="c" class2="os" class3="c3" angle="2.0242328664630236" k="529.6944"/>
+    <Angle class1="c" class2="os" class3="c" angle="2.105565209605959" k="533.8783999999999"/>
+    <Angle class1="c" class2="os" class3="ca" angle="2.11446638879113" k="530.5312"/>
+    <Angle class1="c" class2="os" class3="cc" angle="2.087762851235617" k="535.552"/>
+    <Angle class1="cc" class2="os" class3="cc" angle="1.8626153777283485" k="566.5136"/>
+    <Angle class1="cc" class2="os" class3="cd" angle="2.0713567562668707" k="537.2256000000001"/>
+    <Angle class1="c" class2="os" class3="cd" angle="2.087762851235617" k="535.552"/>
+    <Angle class1="cc" class2="os" class3="na" angle="1.9488346427768681" k="549.7776"/>
+    <Angle class1="cc" class2="os" class3="nc" angle="1.8914133103862552" k="567.3504"/>
+    <Angle class1="cc" class2="os" class3="os" angle="1.8931586396382494" k="556.472"/>
+    <Angle class1="cc" class2="os" class3="ss" angle="2.087239252460019" k="501.2432"/>
+    <Angle class1="c" class2="os" class3="cy" angle="1.9659388694464126" k="539.736"/>
+    <Angle class1="cd" class2="os" class3="cd" angle="1.8626153777283485" k="566.5136"/>
+    <Angle class1="cd" class2="os" class3="na" angle="1.9488346427768681" k="549.7776"/>
+    <Angle class1="cd" class2="os" class3="nd" angle="1.8914133103862552" k="567.3504"/>
+    <Angle class1="cd" class2="os" class3="os" angle="1.8931586396382494" k="556.472"/>
+    <Angle class1="cd" class2="os" class3="ss" angle="2.087239252460019" k="501.2432"/>
+    <Angle class1="cl" class2="os" class3="cl" angle="1.9331266795089195" k="437.64639999999997"/>
+    <Angle class1="c" class2="os" class3="n2" angle="1.9568631573360424" k="558.1456000000001"/>
+    <Angle class1="c" class2="os" class3="n" angle="1.9589575524384353" k="556.472"/>
+    <Angle class1="c" class2="os" class3="oh" angle="1.9285888234537343" k="553.9616000000001"/>
+    <Angle class1="c" class2="os" class3="os" angle="1.9233528356977512" k="552.288"/>
+    <Angle class1="c" class2="os" class3="p5" angle="2.131570615460675" k="654.3776"/>
+    <Angle class1="c" class2="os" class3="sy" angle="1.9807741680883646" k="516.3056"/>
+    <Angle class1="cx" class2="os" class3="cx" angle="1.0782644118820968" k="705.4224"/>
+    <Angle class1="cx" class2="os" class3="n" angle="1.0470230182713982" k="740.568"/>
+    <Angle class1="cx" class2="os" class3="os" angle="1.8746581495671093" k="551.4512000000001"/>
+    <Angle class1="cy" class2="os" class3="cy" angle="1.603259450881991" k="577.392"/>
+    <Angle class1="f" class2="os" class3="f" angle="1.8029251173101424" k="534.7152"/>
+    <Angle class1="f" class2="os" class3="os" angle="1.911135530933791" k="535.552"/>
+    <Angle class1="i" class2="os" class3="i" angle="2.018822345781841" k="486.18080000000003"/>
+    <Angle class1="n1" class2="os" class3="n1" angle="2.0558233259241208" k="588.2704"/>
+    <Angle class1="n2" class2="os" class3="n2" angle="1.8645352399055422" k="577.392"/>
+    <Angle class1="n2" class2="os" class3="s6" angle="1.9425514574696885" k="548.104"/>
+    <Angle class1="n3" class2="os" class3="n3" angle="1.8305013194916528" k="566.5136"/>
+    <Angle class1="n4" class2="os" class3="n4" angle="2.0015435861870974" k="549.7776"/>
+    <Angle class1="na" class2="os" class3="na" angle="1.9127063272605858" k="553.1247999999999"/>
+    <Angle class1="na" class2="os" class3="ss" angle="1.8210765415308834" k="542.2464"/>
+    <Angle class1="nc" class2="os" class3="nc" angle="1.9678587316236067" k="562.3296"/>
+    <Angle class1="nc" class2="os" class3="ss" angle="1.9367918709381073" k="529.6944"/>
+    <Angle class1="nd" class2="os" class3="nd" angle="1.9678587316236067" k="562.3296"/>
+    <Angle class1="nd" class2="os" class3="ss" angle="1.9367918709381073" k="529.6944"/>
+    <Angle class1="nh" class2="os" class3="nh" angle="1.8900170469846596" k="567.3504"/>
+    <Angle class1="n" class2="os" class3="n" angle="1.8903661128350582" k="570.6976000000001"/>
+    <Angle class1="no" class2="os" class3="no" angle="1.952325301280857" k="556.472"/>
+    <Angle class1="n" class2="os" class3="s6" angle="1.9832176290411565" k="541.4096000000001"/>
+    <Angle class1="o" class2="os" class3="o" angle="2.0015435861870974" k="525.5104"/>
+    <Angle class1="p2" class2="os" class3="p2" angle="2.094744168243594" k="866.9248"/>
+    <Angle class1="p2" class2="os" class3="p5" angle="1.8825121312010837" k="902.0704000000001"/>
+    <Angle class1="p3" class2="os" class3="p3" angle="2.1156881192675265" k="810.0224000000001"/>
+    <Angle class1="p3" class2="os" class3="py" angle="1.8427186242556128" k="882.8240000000001"/>
+    <Angle class1="p5" class2="os" class3="p5" angle="2.2034781806428407" k="823.4112000000001"/>
+    <Angle class1="s4" class2="os" class3="s4" angle="1.94831104400127" k="521.3264"/>
+    <Angle class1="s6" class2="os" class3="s6" angle="2.0781635403496477" k="527.184"/>
+    <Angle class1="sh" class2="os" class3="sh" angle="2.076069145247255" k="511.2848"/>
+    <Angle class1="s" class2="os" class3="s" angle="2.0608847807549044" k="476.976"/>
+    <Angle class1="ss" class2="os" class3="ss" angle="2.018298747006243" k="508.7744"/>
+    <Angle class1="br" class2="p2" class3="br" angle="1.8954275676658416" k="340.5776"/>
+    <Angle class1="br" class2="p2" class3="c2" angle="1.785820890640598" k="329.6992"/>
+    <Angle class1="br" class2="p2" class3="n2" angle="1.8034487160857409" k="338.0672"/>
+    <Angle class1="br" class2="p2" class3="o" angle="1.9350465416861131" k="329.6992"/>
+    <Angle class1="br" class2="p2" class3="p2" angle="2.0151571543526527" k="420.07360000000006"/>
+    <Angle class1="br" class2="p2" class3="s" angle="1.928937889304133" k="339.74080000000004"/>
+    <Angle class1="c1" class2="p2" class3="c1" angle="1.7285740911751841" k="328.02560000000005"/>
+    <Angle class1="c1" class2="p2" class3="c2" angle="1.7678439993450565" k="333.0464"/>
+    <Angle class1="c1" class2="p2" class3="n2" angle="1.776570645605028" k="346.4352"/>
+    <Angle class1="c1" class2="p2" class3="o" angle="1.8783233409962974" k="345.59839999999997"/>
+    <Angle class1="c1" class2="p2" class3="p2" angle="1.7373007374351557" k="446.01439999999997"/>
+    <Angle class1="c1" class2="p2" class3="s" angle="1.848303677861995" k="343.088"/>
+    <Angle class1="c2" class2="p2" class3="c2" angle="1.8238690683340744" k="338.904"/>
+    <Angle class1="c2" class2="p2" class3="c3" angle="1.7784905077822217" k="323.00480000000005"/>
+    <Angle class1="c2" class2="p2" class3="ca" angle="1.7793631724082188" k="324.6784"/>
+    <Angle class1="c2" class2="p2" class3="cl" angle="1.7928022076485752" k="297.9008"/>
+    <Angle class1="c2" class2="p2" class3="f" angle="1.8058921770385328" k="348.10880000000003"/>
+    <Angle class1="c2" class2="p2" class3="hp" angle="1.6962855000132888" k="251.87680000000003"/>
+    <Angle class1="c2" class2="p2" class3="i" angle="1.7791886394830196" k="283.6752"/>
+    <Angle class1="c2" class2="p2" class3="n2" angle="1.7432348568919362" k="361.49760000000003"/>
+    <Angle class1="c2" class2="p2" class3="n3" angle="1.7767451785302275" k="351.456"/>
+    <Angle class1="c2" class2="p2" class3="n4" angle="1.714960523009628" k="327.1888"/>
+    <Angle class1="c2" class2="p2" class3="n" angle="1.8025760514597438" k="342.2512"/>
+    <Angle class1="c2" class2="p2" class3="na" angle="1.8149678891489032" k="338.904"/>
+    <Angle class1="c2" class2="p2" class3="nh" angle="1.8355627743224365" k="344.76160000000004"/>
+    <Angle class1="c2" class2="p2" class3="no" angle="1.7098990681788446" k="350.6192"/>
+    <Angle class1="c2" class2="p2" class3="o" angle="2.0099211665966696" k="347.272"/>
+    <Angle class1="c2" class2="p2" class3="oh" angle="1.7957692673769656" k="355.64"/>
+    <Angle class1="c2" class2="p2" class3="os" angle="1.7823302321366095" k="363.1712"/>
+    <Angle class1="c2" class2="p2" class3="p2" angle="1.7376498032855545" k="457.72960000000006"/>
+    <Angle class1="c2" class2="p2" class3="p3" angle="1.7325883484547708" k="402.5008"/>
+    <Angle class1="c2" class2="p2" class3="p4" angle="1.691922176883303" k="403.33760000000007"/>
+    <Angle class1="c2" class2="p2" class3="p5" angle="1.7036158828716652" k="401.664"/>
+    <Angle class1="c2" class2="p2" class3="s4" angle="1.6606807832726045" k="320.4944"/>
+    <Angle class1="c2" class2="p2" class3="s6" angle="1.6669639685797841" k="321.3312"/>
+    <Angle class1="c2" class2="p2" class3="s" angle="1.8418459596296162" k="353.12960000000004"/>
+    <Angle class1="c2" class2="p2" class3="sh" angle="1.771334657849045" k="336.39360000000005"/>
+    <Angle class1="c2" class2="p2" class3="ss" angle="1.776919711455427" k="336.39360000000005"/>
+    <Angle class1="c3" class2="p2" class3="c3" angle="1.733111947230369" k="312.9632"/>
+    <Angle class1="c3" class2="p2" class3="n2" angle="1.759640951860683" k="337.2304"/>
+    <Angle class1="c3" class2="p2" class3="o" angle="1.8626153777283485" k="335.5568"/>
+    <Angle class1="c3" class2="p2" class3="os" angle="1.7687166639710536" k="340.5776"/>
+    <Angle class1="c3" class2="p2" class3="p2" angle="1.7537068324039025" k="433.4624"/>
+    <Angle class1="c3" class2="p2" class3="s" angle="1.8444639535076075" k="334.72"/>
+    <Angle class1="ca" class2="p2" class3="ca" angle="1.7400932642383464" k="314.63680000000005"/>
+    <Angle class1="ca" class2="p2" class3="n2" angle="1.759640951860683" k="338.904"/>
+    <Angle class1="ca" class2="p2" class3="n" angle="1.5702727280192983" k="348.9456"/>
+    <Angle class1="ca" class2="p2" class3="na" angle="1.5570082257041413" k="348.9456"/>
+    <Angle class1="ca" class2="p2" class3="o" angle="1.8654079045315393" k="337.2304"/>
+    <Angle class1="ca" class2="p2" class3="s" angle="1.88373386167748" k="333.0464"/>
+    <Angle class1="c" class2="p2" class3="c2" angle="1.6982053621904827" k="325.5152"/>
+    <Angle class1="c" class2="p2" class3="c" angle="1.5725416560468908" k="320.4944"/>
+    <Angle class1="ce" class2="p2" class3="o" angle="1.8751817483427078" k="339.74080000000004"/>
+    <Angle class1="ce" class2="p2" class3="s" angle="1.8420204925548154" k="338.904"/>
+    <Angle class1="cf" class2="p2" class3="o" angle="1.8751817483427078" k="339.74080000000004"/>
+    <Angle class1="cf" class2="p2" class3="s" angle="1.8420204925548154" k="338.904"/>
+    <Angle class1="cl" class2="p2" class3="cl" angle="1.8971728969178363" k="267.776"/>
+    <Angle class1="cl" class2="p2" class3="n2" angle="1.8043213807117375" k="307.10560000000004"/>
+    <Angle class1="cl" class2="p2" class3="o" angle="1.92981055393013" k="301.248"/>
+    <Angle class1="cl" class2="p2" class3="p2" angle="1.7996089917313531" k="399.99039999999997"/>
+    <Angle class1="cl" class2="p2" class3="s" angle="1.9217820393709562" k="306.2688"/>
+    <Angle class1="f" class2="p2" class3="f" angle="1.8692476288859268" k="353.12960000000004"/>
+    <Angle class1="f" class2="p2" class3="n2" angle="1.807637506290527" k="364.8448"/>
+    <Angle class1="f" class2="p2" class3="o" angle="1.930508685630928" k="366.5184"/>
+    <Angle class1="f" class2="p2" class3="p2" angle="1.8060667099637322" k="456.05600000000004"/>
+    <Angle class1="f" class2="p2" class3="s" angle="2.002067184962695" k="343.9248"/>
+    <Angle class1="hp" class2="p2" class3="hp" angle="1.7236871692696" k="190.7904"/>
+    <Angle class1="hp" class2="p2" class3="n1" angle="1.661204382048203" k="260.2448"/>
+    <Angle class1="hp" class2="p2" class3="n2" angle="1.6674875673553824" k="268.61280000000005"/>
+    <Angle class1="hp" class2="p2" class3="ne" angle="1.7470745812463238" k="266.93919999999997"/>
+    <Angle class1="hp" class2="p2" class3="nf" angle="1.7470745812463238" k="266.93919999999997"/>
+    <Angle class1="hp" class2="p2" class3="o" angle="1.8427186242556128" k="267.776"/>
+    <Angle class1="hp" class2="p2" class3="p2" angle="1.7781414419318227" k="319.65760000000006"/>
+    <Angle class1="hp" class2="p2" class3="p4" angle="1.6495106760598408" k="273.63360000000006"/>
+    <Angle class1="hp" class2="p2" class3="p5" angle="1.5545647647513492" k="282.00160000000005"/>
+    <Angle class1="hp" class2="p2" class3="pe" angle="1.6973326975644856" k="314.63680000000005"/>
+    <Angle class1="hp" class2="p2" class3="pf" angle="1.6973326975644856" k="314.63680000000005"/>
+    <Angle class1="hp" class2="p2" class3="s4" angle="1.570621793869697" k="220.07840000000002"/>
+    <Angle class1="hp" class2="p2" class3="s" angle="1.7893115491445863" k="253.55040000000002"/>
+    <Angle class1="hp" class2="p2" class3="s6" angle="1.5381586697826024" k="223.4256"/>
+    <Angle class1="i" class2="p2" class3="i" angle="1.8179349488772936" k="299.57439999999997"/>
+    <Angle class1="i" class2="p2" class3="n2" angle="1.7762215797546292" k="289.5328"/>
+    <Angle class1="i" class2="p2" class3="o" angle="1.9113100638589904" k="278.6544"/>
+    <Angle class1="i" class2="p2" class3="p2" angle="1.7912314113217804" k="386.6016"/>
+    <Angle class1="i" class2="p2" class3="s" angle="1.9303341527057285" k="294.5536"/>
+    <Angle class1="n1" class2="p2" class3="n1" angle="1.504822881069511" k="389.112"/>
+    <Angle class1="n2" class2="p2" class3="n2" angle="1.710422666954443" k="381.5808"/>
+    <Angle class1="n2" class2="p2" class3="n3" angle="1.7526596348527057" k="369.02880000000005"/>
+    <Angle class1="n2" class2="p2" class3="n4" angle="1.6304865872131027" k="347.272"/>
+    <Angle class1="n2" class2="p2" class3="na" angle="1.7807594358098144" k="356.4768"/>
+    <Angle class1="n2" class2="p2" class3="nh" angle="1.7779669090066235" k="365.68160000000006"/>
+    <Angle class1="n2" class2="p2" class3="no" angle="1.7125170620568362" k="364.8448"/>
+    <Angle class1="n2" class2="p2" class3="o" angle="2.0130627592502597" k="364.00800000000004"/>
+    <Angle class1="n2" class2="p2" class3="oh" angle="1.9149752552881782" k="359.824"/>
+    <Angle class1="n2" class2="p2" class3="os" angle="1.7852972918649999" k="379.9072"/>
+    <Angle class1="n2" class2="p2" class3="p3" angle="1.7367771386595574" k="414.216"/>
+    <Angle class1="n2" class2="p2" class3="p4" angle="1.7755234480538313" k="405.848"/>
+    <Angle class1="n2" class2="p2" class3="p5" angle="1.635024443268288" k="422.584"/>
+    <Angle class1="n2" class2="p2" class3="s4" angle="1.7074556072260527" k="325.5152"/>
+    <Angle class1="n2" class2="p2" class3="s6" angle="1.7128661279072352" k="326.35200000000003"/>
+    <Angle class1="n2" class2="p2" class3="s" angle="1.9711748572023957" k="355.64"/>
+    <Angle class1="n2" class2="p2" class3="sh" angle="1.759640951860683" k="349.7824"/>
+    <Angle class1="n2" class2="p2" class3="ss" angle="1.7760470468294298" k="348.10880000000003"/>
+    <Angle class1="n3" class2="p2" class3="n3" angle="1.8552849948699721" k="352.2928"/>
+    <Angle class1="n3" class2="p2" class3="o" angle="1.8645352399055422" k="369.86560000000003"/>
+    <Angle class1="n3" class2="p2" class3="p2" angle="1.7554521616558967" k="466.9344"/>
+    <Angle class1="n3" class2="p2" class3="s" angle="1.8456856839840035" k="361.49760000000003"/>
+    <Angle class1="n4" class2="p2" class3="n4" angle="1.5498523757709646" k="331.37280000000004"/>
+    <Angle class1="n4" class2="p2" class3="o" angle="1.7690657298214525" k="340.5776"/>
+    <Angle class1="n4" class2="p2" class3="p2" angle="1.6847663269501263" k="440.9936"/>
+    <Angle class1="n4" class2="p2" class3="s" angle="1.832246648743647" k="335.5568"/>
+    <Angle class1="na" class2="p2" class3="na" angle="1.8517943363659837" k="336.39360000000005"/>
+    <Angle class1="na" class2="p2" class3="o" angle="1.8755308141931064" k="357.31360000000006"/>
+    <Angle class1="na" class2="p2" class3="s" angle="1.8875735860318674" k="349.7824"/>
+    <Angle class1="ne" class2="p2" class3="o" angle="1.879894137323092" k="382.41760000000005"/>
+    <Angle class1="ne" class2="p2" class3="s" angle="1.8413223608540177" k="370.7024"/>
+    <Angle class1="nf" class2="p2" class3="o" angle="1.879894137323092" k="382.41760000000005"/>
+    <Angle class1="nf" class2="p2" class3="s" angle="1.8413223608540177" k="370.7024"/>
+    <Angle class1="nh" class2="p2" class3="nh" angle="1.8151424220741028" k="353.96639999999996"/>
+    <Angle class1="nh" class2="p2" class3="o" angle="1.8868754543310697" k="366.5184"/>
+    <Angle class1="nh" class2="p2" class3="p2" angle="1.880243203173491" k="450.1984"/>
+    <Angle class1="nh" class2="p2" class3="s" angle="1.913229926036184" k="353.96639999999996"/>
+    <Angle class1="n" class2="p2" class3="n2" angle="1.7252579655963947" k="364.00800000000004"/>
+    <Angle class1="n" class2="p2" class3="o" angle="1.8339919779956413" k="364.00800000000004"/>
+    <Angle class1="no" class2="p2" class3="no" angle="1.7139133254584316" k="352.2928"/>
+    <Angle class1="no" class2="p2" class3="o" angle="1.8303267865664534" k="363.1712"/>
+    <Angle class1="no" class2="p2" class3="p2" angle="1.8949039688902436" k="441.8304"/>
+    <Angle class1="no" class2="p2" class3="s" angle="1.903456082225016" k="349.7824"/>
+    <Angle class1="n" class2="p2" class3="p2" angle="1.7823302321366095" k="456.05600000000004"/>
+    <Angle class1="n" class2="p2" class3="s" angle="1.96070288169043" k="344.76160000000004"/>
+    <Angle class1="oh" class2="p2" class3="oh" angle="1.7470745812463238" k="376.56"/>
+    <Angle class1="oh" class2="p2" class3="p2" angle="1.881813999500286" k="457.72960000000006"/>
+    <Angle class1="oh" class2="p2" class3="s" angle="1.9154988540637765" k="359.824"/>
+    <Angle class1="o" class2="p2" class3="o" angle="2.0936969706923976" k="371.5392"/>
+    <Angle class1="o" class2="p2" class3="oh" angle="1.9278906917529361" k="370.7024"/>
+    <Angle class1="o" class2="p2" class3="os" angle="1.89909275909503" k="381.5808"/>
+    <Angle class1="o" class2="p2" class3="p2" angle="1.9936896045531227" k="456.8928"/>
+    <Angle class1="o" class2="p2" class3="p3" angle="1.86209177895275" k="405.848"/>
+    <Angle class1="o" class2="p2" class3="p4" angle="1.8216001403064819" k="405.01120000000003"/>
+    <Angle class1="o" class2="p2" class3="p5" angle="1.8236945354088747" k="405.01120000000003"/>
+    <Angle class1="o" class2="p2" class3="pe" angle="2.5474825762109234" k="390.78560000000004"/>
+    <Angle class1="o" class2="p2" class3="pf" angle="2.5474825762109234" k="390.78560000000004"/>
+    <Angle class1="o" class2="p2" class3="s4" angle="1.8603464497007558" k="315.47360000000003"/>
+    <Angle class1="o" class2="p2" class3="s6" angle="1.8332938462948438" k="318.8208"/>
+    <Angle class1="o" class2="p2" class3="s" angle="2.0493656076917417" k="358.1504"/>
+    <Angle class1="o" class2="p2" class3="sh" angle="1.912880860185785" k="341.4144"/>
+    <Angle class1="os" class2="p2" class3="os" angle="1.715658654710426" k="393.296"/>
+    <Angle class1="os" class2="p2" class3="p2" angle="1.7708110590734467" k="477.81280000000004"/>
+    <Angle class1="o" class2="p2" class3="ss" angle="1.912880860185785" k="342.2512"/>
+    <Angle class1="os" class2="p2" class3="s" angle="1.8931586396382494" k="367.3552"/>
+    <Angle class1="p2" class2="p2" class3="n2" angle="1.699950691442477" k="481.9968"/>
+    <Angle class1="p2" class2="p2" class3="p3" angle="1.7755234480538313" k="536.3888"/>
+    <Angle class1="p2" class2="p2" class3="p4" angle="1.7798867711838173" k="530.5312"/>
+    <Angle class1="p2" class2="p2" class3="p5" angle="1.7336355460059676" k="537.2256000000001"/>
+    <Angle class1="p2" class2="p2" class3="s4" angle="1.6708036929341716" k="430.952"/>
+    <Angle class1="p2" class2="p2" class3="s6" angle="1.6746434172885591" k="431.78880000000004"/>
+    <Angle class1="p2" class2="p2" class3="s" angle="1.9422023916192899" k="456.05600000000004"/>
+    <Angle class1="p2" class2="p2" class3="sh" angle="1.988628149722339" k="425.0944"/>
+    <Angle class1="p3" class2="p2" class3="p3" angle="1.7627825445142729" k="501.2432"/>
+    <Angle class1="p3" class2="p2" class3="s" angle="1.9771089766591763" k="402.5008"/>
+    <Angle class1="p4" class2="p2" class3="s" angle="1.813222559896909" k="416.7264"/>
+    <Angle class1="p5" class2="p2" class3="p5" angle="1.5603243512829308" k="525.5104"/>
+    <Angle class1="p5" class2="p2" class3="s" angle="1.7664477359434607" k="421.7472"/>
+    <Angle class1="pe" class2="p2" class3="s" angle="1.8561576594959692" k="456.05600000000004"/>
+    <Angle class1="pf" class2="p2" class3="s" angle="1.8561576594959692" k="456.05600000000004"/>
+    <Angle class1="s4" class2="p2" class3="s4" angle="1.4887658519511628" k="334.72"/>
+    <Angle class1="s6" class2="p2" class3="s6" angle="1.7139133254584316" k="312.9632"/>
+    <Angle class1="sh" class2="p2" class3="sh" angle="1.7191493132144144" k="345.59839999999997"/>
+    <Angle class1="s" class2="p2" class3="s" angle="1.8605209826259552" k="369.86560000000003"/>
+    <Angle class1="s" class2="p2" class3="s4" angle="1.8376571694248296" k="325.5152"/>
+    <Angle class1="s" class2="p2" class3="s6" angle="1.8662805691575366" k="323.8416"/>
+    <Angle class1="s" class2="p2" class3="sh" angle="1.9326030807333212" k="341.4144"/>
+    <Angle class1="s" class2="p2" class3="ss" angle="1.992118808226328" k="337.2304"/>
+    <Angle class1="ss" class2="p2" class3="ss" angle="1.7086773377024485" k="348.10880000000003"/>
+    <Angle class1="br" class2="p3" class3="br" angle="1.807113907514929" k="345.59839999999997"/>
+    <Angle class1="br" class2="p3" class3="hp" angle="1.681799267221736" k="225.0992"/>
+    <Angle class1="c1" class2="p3" class3="c1" angle="1.7540558982543013" k="322.168"/>
+    <Angle class1="c1" class2="p3" class3="f" angle="1.6912240451825054" k="340.5776"/>
+    <Angle class1="c1" class2="p3" class3="hp" angle="1.7046630804228615" k="235.1408"/>
+    <Angle class1="c2" class2="p3" class3="c2" angle="1.7762215797546292" k="312.1264"/>
+    <Angle class1="c2" class2="p3" class3="hp" angle="1.7078046730764513" k="230.95680000000002"/>
+    <Angle class1="c3" class2="p3" class3="c3" angle="1.7339846118563662" k="312.1264"/>
+    <Angle class1="c3" class2="p3" class3="ca" angle="1.7791886394830196" k="310.4528"/>
+    <Angle class1="c3" class2="p3" class3="cl" angle="1.7434093898171357" k="297.9008"/>
+    <Angle class1="c3" class2="p3" class3="f" angle="1.7069320084504542" k="330.536"/>
+    <Angle class1="c3" class2="p3" class3="hp" angle="1.7013469548440725" k="228.4464"/>
+    <Angle class1="c3" class2="p3" class3="n2" angle="1.6851153928005251" k="332.2096"/>
+    <Angle class1="c3" class2="p3" class3="n3" angle="1.7699383944474496" k="327.1888"/>
+    <Angle class1="c3" class2="p3" class3="n4" angle="1.691922176883303" k="321.3312"/>
+    <Angle class1="c3" class2="p3" class3="n" angle="1.7762215797546292" k="323.00480000000005"/>
+    <Angle class1="c3" class2="p3" class3="na" angle="1.74829631172272" k="326.35200000000003"/>
+    <Angle class1="c3" class2="p3" class3="nh" angle="1.8238690683340744" k="322.168"/>
+    <Angle class1="c3" class2="p3" class3="no" angle="1.6926203085841007" k="324.6784"/>
+    <Angle class1="c3" class2="p3" class3="o" angle="1.9490091757020678" k="327.1888"/>
+    <Angle class1="c3" class2="p3" class3="oh" angle="1.714087858383631" k="338.0672"/>
+    <Angle class1="c3" class2="p3" class3="os" angle="1.737126204509956" k="336.39360000000005"/>
+    <Angle class1="c3" class2="p3" class3="p3" angle="1.7432348568919362" k="383.2544"/>
+    <Angle class1="c3" class2="p3" class3="p5" angle="1.7610372152622786" k="380.744"/>
+    <Angle class1="c3" class2="p3" class3="s4" angle="1.7257815643719931" k="316.3104"/>
+    <Angle class1="c3" class2="p3" class3="s6" angle="1.7659241371678627" k="313.8"/>
+    <Angle class1="c3" class2="p3" class3="sh" angle="1.7228145046436025" k="312.1264"/>
+    <Angle class1="c3" class2="p3" class3="ss" angle="1.7343336777067653" k="312.9632"/>
+    <Angle class1="ca" class2="p3" class3="ca" angle="1.7428857910415376" k="317.1472"/>
+    <Angle class1="ca" class2="p3" class3="hp" angle="1.7016960206944711" k="231.7936"/>
+    <Angle class1="c" class2="p3" class3="c3" angle="1.6940165719856963" k="313.8"/>
+    <Angle class1="c" class2="p3" class3="c" angle="1.7610372152622786" k="305.432"/>
+    <Angle class1="c" class2="p3" class3="hp" angle="1.6851153928005251" k="226.77280000000002"/>
+    <Angle class1="cl" class2="p3" class3="cl" angle="1.7945475369005695" k="283.6752"/>
+    <Angle class1="cl" class2="p3" class3="f" angle="1.7313666179783749" k="309.616"/>
+    <Angle class1="cl" class2="p3" class3="hp" angle="1.6807520696705391" k="215.0576"/>
+    <Angle class1="c" class2="p3" class3="os" angle="1.4193017477217886" k="369.02880000000005"/>
+    <Angle class1="cx" class2="p3" class3="hp" angle="1.6615534478986016" k="230.12"/>
+    <Angle class1="f" class2="p3" class3="f" angle="1.699950691442477" k="360.66080000000005"/>
+    <Angle class1="f" class2="p3" class3="hp" angle="1.682671931847733" k="255.22400000000002"/>
+    <Angle class1="f" class2="p3" class3="n3" angle="1.7558012275062955" k="350.6192"/>
+    <Angle class1="f" class2="p3" class3="os" angle="1.7318902167539734" k="361.49760000000003"/>
+    <Angle class1="f" class2="p3" class3="p3" angle="1.6964600329384885" k="394.13280000000003"/>
+    <Angle class1="hp" class2="p3" class3="hp" angle="1.6619025137490007" k="184.096"/>
+    <Angle class1="hp" class2="p3" class3="i" angle="1.6788322074933455" k="195.81119999999999"/>
+    <Angle class1="hp" class2="p3" class3="n1" angle="1.6228071385043277" k="261.0816"/>
+    <Angle class1="hp" class2="p3" class3="n2" angle="1.7153095888600272" k="243.5088"/>
+    <Angle class1="hp" class2="p3" class3="n3" angle="1.6486380114338435" k="251.87680000000003"/>
+    <Angle class1="hp" class2="p3" class3="n4" angle="1.6268213957839146" k="236.8144"/>
+    <Angle class1="hp" class2="p3" class3="n" angle="1.6606807832726045" k="246.85600000000002"/>
+    <Angle class1="hp" class2="p3" class3="na" angle="1.6976817634148842" k="244.3456"/>
+    <Angle class1="hp" class2="p3" class3="nh" angle="1.642354826126664" k="251.87680000000003"/>
+    <Angle class1="hp" class2="p3" class3="no" angle="1.624203401905923" k="240.9984"/>
+    <Angle class1="hp" class2="p3" class3="o" angle="1.7631316103646715" k="267.776"/>
+    <Angle class1="hp" class2="p3" class3="oh" angle="1.6746434172885591" k="256.8976"/>
+    <Angle class1="hp" class2="p3" class3="os" angle="1.6990780268164798" k="255.22400000000002"/>
+    <Angle class1="hp" class2="p3" class3="p2" angle="1.72979582165158" k="271.1232"/>
+    <Angle class1="hp" class2="p3" class3="p3" angle="1.6671385015049833" k="268.61280000000005"/>
+    <Angle class1="hp" class2="p3" class3="p4" angle="1.6746434172885591" k="267.776"/>
+    <Angle class1="hp" class2="p3" class3="p5" angle="1.6674875673553824" k="268.61280000000005"/>
+    <Angle class1="hp" class2="p3" class3="s4" angle="1.666614902729385" k="225.0992"/>
+    <Angle class1="hp" class2="p3" class3="s6" angle="1.6222835397287292" k="229.2832"/>
+    <Angle class1="hp" class2="p3" class3="sh" angle="1.6442746883038577" k="221.752"/>
+    <Angle class1="hp" class2="p3" class3="ss" angle="1.651256005311835" k="222.58880000000002"/>
+    <Angle class1="i" class2="p3" class3="i" angle="1.8369590377240317" k="306.2688"/>
+    <Angle class1="n1" class2="p3" class3="n1" angle="1.5784757755036718" k="384.0912"/>
+    <Angle class1="n2" class2="p3" class3="n2" angle="1.8057176441133331" k="338.0672"/>
+    <Angle class1="n3" class2="p3" class3="n3" angle="1.986184688769547" k="328.8624"/>
+    <Angle class1="n3" class2="p3" class3="o" angle="1.8692476288859268" k="359.824"/>
+    <Angle class1="n3" class2="p3" class3="oh" angle="1.7167058522616223" k="360.66080000000005"/>
+    <Angle class1="n4" class2="p3" class3="n4" angle="1.7545794970298996" k="322.168"/>
+    <Angle class1="na" class2="p3" class3="na" angle="1.853888731468377" k="333.8832"/>
+    <Angle class1="nh" class2="p3" class3="nh" angle="1.904328746851013" k="335.5568"/>
+    <Angle class1="n" class2="p3" class3="n" angle="1.8252653317356697" k="334.72"/>
+    <Angle class1="n" class2="p3" class3="o" angle="1.8324211816688465" k="358.1504"/>
+    <Angle class1="no" class2="p3" class3="no" angle="1.7161822534860243" k="331.37280000000004"/>
+    <Angle class1="oh" class2="p3" class3="oh" angle="1.8235200024836755" k="358.1504"/>
+    <Angle class1="o" class2="p3" class3="o" angle="2.132443280086672" k="366.5184"/>
+    <Angle class1="o" class2="p3" class3="p3" angle="2.03749736877818" k="377.39680000000004"/>
+    <Angle class1="o" class2="p3" class3="p5" angle="1.8783233409962974" k="393.296"/>
+    <Angle class1="o" class2="p3" class3="s4" angle="1.9320794819577227" k="323.00480000000005"/>
+    <Angle class1="o" class2="p3" class3="s6" angle="1.8615681801771518" k="330.536"/>
+    <Angle class1="os" class2="p3" class3="os" angle="1.7411404617895434" k="366.5184"/>
+    <Angle class1="p2" class2="p3" class3="p2" angle="1.8078120392157264" k="494.5488"/>
+    <Angle class1="p3" class2="p3" class3="p3" angle="1.8380062352752284" k="476.976"/>
+    <Angle class1="p4" class2="p3" class3="p4" angle="1.7294467558011812" k="491.20160000000004"/>
+    <Angle class1="p5" class2="p3" class3="p5" angle="1.7296212887263802" k="492.03839999999997"/>
+    <Angle class1="s4" class2="p3" class3="s4" angle="1.714960523009628" k="327.1888"/>
+    <Angle class1="s6" class2="p3" class3="s6" angle="1.7065829426000556" k="329.6992"/>
+    <Angle class1="sh" class2="p3" class3="sh" angle="1.8776252092954997" k="306.2688"/>
+    <Angle class1="s" class2="p3" class3="s" angle="2.2919663737189535" k="285.34880000000004"/>
+    <Angle class1="ss" class2="p3" class3="ss" angle="1.9065976748786053" k="305.432"/>
+    <Angle class1="br" class2="p4" class3="br" angle="1.9270180271269393" k="343.9248"/>
+    <Angle class1="br" class2="p4" class3="o" angle="2.178170906488923" k="316.3104"/>
+    <Angle class1="c2" class2="p4" class3="c2" angle="1.8188076135032907" k="310.4528"/>
+    <Angle class1="c2" class2="p4" class3="hp" angle="1.736602605734358" k="231.7936"/>
+    <Angle class1="c2" class2="p4" class3="o" angle="1.9825194973403588" k="329.6992"/>
+    <Angle class1="c3" class2="p4" class3="c3" angle="1.7898351479201848" k="310.4528"/>
+    <Angle class1="c3" class2="p4" class3="n2" angle="1.8006561892825497" k="326.35200000000003"/>
+    <Angle class1="c3" class2="p4" class3="n3" angle="1.7866935552665952" k="329.6992"/>
+    <Angle class1="c3" class2="p4" class3="n4" angle="1.7378243362107537" k="313.8"/>
+    <Angle class1="c3" class2="p4" class3="n" angle="1.8022269856093447" k="325.5152"/>
+    <Angle class1="c3" class2="p4" class3="na" angle="2.0537289308217277" k="316.3104"/>
+    <Angle class1="c3" class2="p4" class3="nh" angle="1.7940239381249714" k="328.8624"/>
+    <Angle class1="c3" class2="p4" class3="no" angle="1.7418385934903406" k="319.65760000000006"/>
+    <Angle class1="c3" class2="p4" class3="o" angle="2.018822345781841" k="324.6784"/>
+    <Angle class1="c3" class2="p4" class3="oh" angle="1.7201965107656112" k="342.2512"/>
+    <Angle class1="c3" class2="p4" class3="os" angle="1.7105971998796425" k="343.9248"/>
+    <Angle class1="c3" class2="p4" class3="p2" angle="1.9071212736542038" k="371.5392"/>
+    <Angle class1="c3" class2="p4" class3="p3" angle="1.8069393745897293" k="376.56"/>
+    <Angle class1="c3" class2="p4" class3="p4" angle="1.7823302321366095" k="402.5008"/>
+    <Angle class1="c3" class2="p4" class3="p5" angle="1.8177604159520941" k="373.2128"/>
+    <Angle class1="c3" class2="p4" class3="sh" angle="1.74829631172272" k="312.9632"/>
+    <Angle class1="c3" class2="p4" class3="ss" angle="1.7660986700930619" k="312.1264"/>
+    <Angle class1="ca" class2="p4" class3="ca" angle="1.880941334874289" k="307.94239999999996"/>
+    <Angle class1="ca" class2="p4" class3="o" angle="1.9484855769264695" k="334.72"/>
+    <Angle class1="cl" class2="p4" class3="cl" angle="1.8065903087393307" k="282.8384"/>
+    <Angle class1="cl" class2="p4" class3="o" angle="2.0338321773489922" k="301.248"/>
+    <Angle class1="hp" class2="p4" class3="hp" angle="1.7315411509035743" k="189.1168"/>
+    <Angle class1="hp" class2="p4" class3="n1" angle="1.7437584556675347" k="252.7136"/>
+    <Angle class1="hp" class2="p4" class3="o" angle="1.9085175370557992" k="262.7552"/>
+    <Angle class1="hp" class2="p4" class3="p3" angle="1.7271778277735883" k="262.7552"/>
+    <Angle class1="hp" class2="p4" class3="s" angle="1.9240509673985489" k="203.34240000000003"/>
+    <Angle class1="i" class2="p4" class3="i" angle="1.9760617791079798" k="322.168"/>
+    <Angle class1="i" class2="p4" class3="o" angle="1.9237019015481498" k="315.47360000000003"/>
+    <Angle class1="n1" class2="p4" class3="n1" angle="1.7559757604314947" k="359.824"/>
+    <Angle class1="n1" class2="p4" class3="o" angle="1.9999727898603024" k="355.64"/>
+    <Angle class1="n2" class2="p4" class3="n2" angle="1.7896606149949854" k="347.272"/>
+    <Angle class1="n2" class2="p4" class3="o" angle="2.0992820242987795" k="341.4144"/>
+    <Angle class1="n3" class2="p4" class3="o" angle="1.976934443733977" k="355.64"/>
+    <Angle class1="n4" class2="p4" class3="o" angle="1.8781488080710982" k="331.37280000000004"/>
+    <Angle class1="na" class2="p4" class3="o" angle="1.9303341527057285" k="377.39680000000004"/>
+    <Angle class1="nh" class2="p4" class3="nh" angle="1.6632987771505958" k="364.00800000000004"/>
+    <Angle class1="nh" class2="p4" class3="o" angle="2.02213847136063" k="350.6192"/>
+    <Angle class1="n" class2="p4" class3="o" angle="2.059313984428109" k="343.088"/>
+    <Angle class1="no" class2="p4" class3="o" angle="2.001718119112297" k="329.6992"/>
+    <Angle class1="oh" class2="p4" class3="oh" angle="1.6704546270837726" k="382.41760000000005"/>
+    <Angle class1="o" class2="p4" class3="o" angle="2.0458749491877533" k="376.56"/>
+    <Angle class1="o" class2="p4" class3="oh" angle="2.0488420089161434" k="358.98720000000003"/>
+    <Angle class1="o" class2="p4" class3="os" angle="2.036275638301784" k="360.66080000000005"/>
+    <Angle class1="o" class2="p4" class3="p2" angle="2.1179570472951186" k="375.7232"/>
+    <Angle class1="o" class2="p4" class3="p3" angle="1.9896753472735356" k="381.5808"/>
+    <Angle class1="o" class2="p4" class3="p4" angle="2.032086848096998" k="408.3584"/>
+    <Angle class1="o" class2="p4" class3="p5" angle="1.9156733869889764" k="384.928"/>
+    <Angle class1="o" class2="p4" class3="s4" angle="1.9580848878124382" k="299.57439999999997"/>
+    <Angle class1="o" class2="p4" class3="s6" angle="1.987755485096342" k="294.5536"/>
+    <Angle class1="o" class2="p4" class3="s" angle="1.9683823303992047" k="312.1264"/>
+    <Angle class1="o" class2="p4" class3="sh" angle="2.061059313680104" k="309.616"/>
+    <Angle class1="os" class2="p4" class3="os" angle="1.75126337145111" k="374.04960000000005"/>
+    <Angle class1="o" class2="p4" class3="ss" angle="2.0270253932662143" k="313.8"/>
+    <Angle class1="p2" class2="p4" class3="p2" angle="1.9322540148829221" k="472.79200000000003"/>
+    <Angle class1="p3" class2="p4" class3="p3" angle="2.00677957394308" k="456.05600000000004"/>
+    <Angle class1="p4" class2="p4" class3="p4" angle="1.8741345507915108" k="513.7952"/>
+    <Angle class1="p5" class2="p4" class3="p5" angle="1.8811158677994881" k="466.9344"/>
+    <Angle class1="s4" class2="p4" class3="s4" angle="1.6797048721193426" k="306.2688"/>
+    <Angle class1="s6" class2="p4" class3="s6" angle="1.7865190223413956" k="294.5536"/>
+    <Angle class1="sh" class2="p4" class3="sh" angle="1.724559833895597" k="322.168"/>
+    <Angle class1="s" class2="p4" class3="s" angle="1.8552849948699721" k="305.432"/>
+    <Angle class1="ss" class2="p4" class3="ss" angle="1.8222982720072793" k="314.63680000000005"/>
+    <Angle class1="br" class2="p5" class3="br" angle="1.8043213807117375" k="351.456"/>
+    <Angle class1="br" class2="p5" class3="o" angle="2.0010199874114987" k="326.35200000000003"/>
+    <Angle class1="br" class2="p5" class3="oh" angle="1.7962928661525641" k="342.2512"/>
+    <Angle class1="c1" class2="p5" class3="c1" angle="1.7957692673769656" k="324.6784"/>
+    <Angle class1="c1" class2="p5" class3="o" angle="2.0205676750338353" k="337.2304"/>
+    <Angle class1="c1" class2="p5" class3="oh" angle="1.7940239381249714" k="347.272"/>
+    <Angle class1="c2" class2="p5" class3="c2" angle="1.8598228509251575" k="300.4112"/>
+    <Angle class1="c2" class2="p5" class3="o" angle="1.9114845967841896" k="331.37280000000004"/>
+    <Angle class1="c2" class2="p5" class3="oh" angle="1.7748253163530336" k="336.39360000000005"/>
+    <Angle class1="c2" class2="p5" class3="os" angle="1.6950637695368929" k="343.9248"/>
+    <Angle class1="c3" class2="p5" class3="c3" angle="1.8500490071139892" k="305.432"/>
+    <Angle class1="c3" class2="p5" class3="hp" angle="1.8022269856093447" k="223.4256"/>
+    <Angle class1="c3" class2="p5" class3="n3" angle="1.8221237390820801" k="328.8624"/>
+    <Angle class1="c3" class2="p5" class3="o" angle="1.9634954084936207" k="329.6992"/>
+    <Angle class1="c3" class2="p5" class3="oh" angle="1.7922786088729767" k="337.2304"/>
+    <Angle class1="c3" class2="p5" class3="os" angle="1.758768287234686" k="340.5776"/>
+    <Angle class1="c3" class2="p5" class3="p4" angle="1.854761396094374" k="369.86560000000003"/>
+    <Angle class1="c3" class2="p5" class3="s" angle="1.9966566642815131" k="309.616"/>
+    <Angle class1="c3" class2="p5" class3="ss" angle="1.8490018095627925" k="303.7584"/>
+    <Angle class1="ca" class2="p5" class3="ca" angle="1.8832102629018814" k="309.616"/>
+    <Angle class1="ca" class2="p5" class3="o" angle="1.9893262814231367" k="333.8832"/>
+    <Angle class1="ca" class2="p5" class3="oh" angle="1.7762215797546292" k="343.9248"/>
+    <Angle class1="ca" class2="p5" class3="os" angle="1.8107790989441168" k="340.5776"/>
+    <Angle class1="c" class2="p5" class3="c" angle="1.8179349488772936" k="301.248"/>
+    <Angle class1="cl" class2="p5" class3="cl" angle="1.8099064343181197" k="282.8384"/>
+    <Angle class1="cl" class2="p5" class3="o" angle="1.9661134023716125" k="307.10560000000004"/>
+    <Angle class1="cl" class2="p5" class3="oh" angle="1.7879152857429912" k="317.1472"/>
+    <Angle class1="c" class2="p5" class3="o" angle="1.8692476288859268" k="332.2096"/>
+    <Angle class1="c" class2="p5" class3="oh" angle="1.7823302321366095" k="333.0464"/>
+    <Angle class1="f" class2="p5" class3="f" angle="1.6095426361891707" k="368.192"/>
+    <Angle class1="f" class2="p5" class3="o" angle="1.9559904927100449" k="359.824"/>
+    <Angle class1="f" class2="p5" class3="oh" angle="1.7798867711838173" k="363.1712"/>
+    <Angle class1="f" class2="p5" class3="os" angle="1.7849482260146008" k="362.3344"/>
+    <Angle class1="f" class2="p5" class3="s" angle="2.049016541841343" k="317.1472"/>
+    <Angle class1="hp" class2="p5" class3="hp" angle="1.7549285628802984" k="178.2384"/>
+    <Angle class1="hp" class2="p5" class3="n1" angle="1.7683675981206546" k="259.408"/>
+    <Angle class1="hp" class2="p5" class3="o" angle="2.0085249031950743" k="252.7136"/>
+    <Angle class1="hp" class2="p5" class3="oh" angle="1.7727309212506404" k="256.06080000000003"/>
+    <Angle class1="hp" class2="p5" class3="s" angle="2.080432468377241" k="215.89440000000002"/>
+    <Angle class1="i" class2="p5" class3="i" angle="1.870469359362323" k="300.4112"/>
+    <Angle class1="i" class2="p5" class3="o" angle="2.0233602018370265" k="276.144"/>
+    <Angle class1="i" class2="p5" class3="oh" angle="1.7847736930894014" k="296.2272"/>
+    <Angle class1="n1" class2="p5" class3="n1" angle="1.7723818554002415" k="383.2544"/>
+    <Angle class1="n1" class2="p5" class3="o" angle="1.9858356229191483" k="373.2128"/>
+    <Angle class1="n2" class2="p5" class3="n2" angle="1.8559831265707702" k="368.192"/>
+    <Angle class1="n2" class2="p5" class3="o" angle="1.9814722997891623" k="369.86560000000003"/>
+    <Angle class1="n2" class2="p5" class3="oh" angle="1.7872171540421935" k="374.8864"/>
+    <Angle class1="n3" class2="p5" class3="n3" angle="1.8041468477865386" k="357.31360000000006"/>
+    <Angle class1="n3" class2="p5" class3="nh" angle="1.8123498952709118" k="356.4768"/>
+    <Angle class1="n3" class2="p5" class3="o" angle="2.0008454544862997" k="358.98720000000003"/>
+    <Angle class1="n3" class2="p5" class3="oh" angle="1.8324211816688465" k="362.3344"/>
+    <Angle class1="n3" class2="p5" class3="os" angle="1.7842500943138029" k="367.3552"/>
+    <Angle class1="n3" class2="p5" class3="s" angle="2.0343557761245905" k="325.5152"/>
+    <Angle class1="n4" class2="p5" class3="n4" angle="1.7837264955382048" k="328.02560000000005"/>
+    <Angle class1="n4" class2="p5" class3="o" angle="1.916022452839375" k="343.9248"/>
+    <Angle class1="n4" class2="p5" class3="oh" angle="1.7188002473640156" k="353.96639999999996"/>
+    <Angle class1="n4" class2="p5" class3="os" angle="1.6502088077606385" k="361.49760000000003"/>
+    <Angle class1="na" class2="p5" class3="na" angle="1.8949039688902436" k="339.74080000000004"/>
+    <Angle class1="na" class2="p5" class3="o" angle="1.979726970537168" k="353.96639999999996"/>
+    <Angle class1="na" class2="p5" class3="oh" angle="1.781457567510612" k="362.3344"/>
+    <Angle class1="na" class2="p5" class3="os" angle="1.798736327105356" k="359.824"/>
+    <Angle class1="nh" class2="p5" class3="nh" angle="1.7367771386595574" k="364.00800000000004"/>
+    <Angle class1="nh" class2="p5" class3="o" angle="2.0046851788406865" k="358.1504"/>
+    <Angle class1="nh" class2="p5" class3="oh" angle="1.7961183332273645" k="365.68160000000006"/>
+    <Angle class1="nh" class2="p5" class3="os" angle="1.8360863730980346" k="361.49760000000003"/>
+    <Angle class1="n" class2="p5" class3="n3" angle="1.8205529427552853" k="350.6192"/>
+    <Angle class1="n" class2="p5" class3="n" angle="1.7992599258809543" k="348.10880000000003"/>
+    <Angle class1="n" class2="p5" class3="o" angle="1.9579103548872387" k="355.64"/>
+    <Angle class1="n" class2="p5" class3="oh" angle="1.7879152857429912" k="360.66080000000005"/>
+    <Angle class1="no" class2="p5" class3="no" angle="1.6699310283081745" k="338.0672"/>
+    <Angle class1="no" class2="p5" class3="o" angle="1.9678587316236067" k="338.904"/>
+    <Angle class1="no" class2="p5" class3="oh" angle="1.7688911968962526" k="348.10880000000003"/>
+    <Angle class1="no" class2="p5" class3="os" angle="1.7749998492782333" k="348.10880000000003"/>
+    <Angle class1="n" class2="p5" class3="os" angle="1.7537068324039025" k="364.8448"/>
+    <Angle class1="oh" class2="p5" class3="oh" angle="1.7922786088729767" k="374.8864"/>
+    <Angle class1="oh" class2="p5" class3="os" angle="1.7791886394830196" k="376.56"/>
+    <Angle class1="oh" class2="p5" class3="p2" angle="1.8069393745897293" k="404.1744"/>
+    <Angle class1="oh" class2="p5" class3="p3" angle="1.8121753623457124" k="398.3168"/>
+    <Angle class1="oh" class2="p5" class3="p4" angle="1.776570645605028" k="398.3168"/>
+    <Angle class1="oh" class2="p5" class3="p5" angle="1.753183233628304" k="430.952"/>
+    <Angle class1="oh" class2="p5" class3="s4" angle="1.8018779197589456" k="338.0672"/>
+    <Angle class1="oh" class2="p5" class3="s6" angle="1.7711601249238458" k="340.5776"/>
+    <Angle class1="oh" class2="p5" class3="s" angle="1.9425514574696885" k="338.904"/>
+    <Angle class1="oh" class2="p5" class3="sh" angle="1.7699383944474496" k="335.5568"/>
+    <Angle class1="oh" class2="p5" class3="ss" angle="1.8167132184008978" k="326.35200000000003"/>
+    <Angle class1="o" class2="p5" class3="o" angle="2.0210912738094335" k="383.2544"/>
+    <Angle class1="o" class2="p5" class3="oh" angle="2.0107938312226667" k="367.3552"/>
+    <Angle class1="o" class2="p5" class3="os" angle="2.0151571543526527" k="367.3552"/>
+    <Angle class1="o" class2="p5" class3="p2" angle="2.0001473227855016" k="386.6016"/>
+    <Angle class1="o" class2="p5" class3="p3" angle="2.0155062202030516" k="379.9072"/>
+    <Angle class1="o" class2="p5" class3="p4" angle="2.001194520336698" k="377.39680000000004"/>
+    <Angle class1="o" class2="p5" class3="p5" angle="1.9799015034623675" k="410.8688"/>
+    <Angle class1="o" class2="p5" class3="s4" angle="1.9238764344733494" k="331.37280000000004"/>
+    <Angle class1="o" class2="p5" class3="s6" angle="1.9504054391036632" k="328.8624"/>
+    <Angle class1="o" class2="p5" class3="s" angle="2.0409880272821685" k="336.39360000000005"/>
+    <Angle class1="o" class2="p5" class3="sh" angle="1.9994491910847039" k="318.8208"/>
+    <Angle class1="os" class2="p5" class3="os" angle="1.7774433102310252" k="376.56"/>
+    <Angle class1="os" class2="p5" class3="p3" angle="1.8093828355425214" k="398.3168"/>
+    <Angle class1="os" class2="p5" class3="p5" angle="1.8235200024836755" k="422.584"/>
+    <Angle class1="os" class2="p5" class3="s4" angle="1.7893115491445863" k="338.904"/>
+    <Angle class1="os" class2="p5" class3="s6" angle="1.7783159748570225" k="339.74080000000004"/>
+    <Angle class1="o" class2="p5" class3="ss" angle="1.9956094667303164" k="314.63680000000005"/>
+    <Angle class1="os" class2="p5" class3="s" angle="2.044304152860958" k="330.536"/>
+    <Angle class1="os" class2="p5" class3="sh" angle="1.7811085016602133" k="333.8832"/>
+    <Angle class1="os" class2="p5" class3="ss" angle="1.7886134174437889" k="328.8624"/>
+    <Angle class1="p2" class2="p5" class3="p2" angle="1.8699457605867247" k="480.3232"/>
+    <Angle class1="p3" class2="p5" class3="p3" angle="1.836609971873633" k="476.976"/>
+    <Angle class1="p4" class2="p5" class3="p4" angle="1.7736035858766377" k="480.3232"/>
+    <Angle class1="p5" class2="p5" class3="p5" angle="1.9673351328480082" k="497.05920000000003"/>
+    <Angle class1="s6" class2="p5" class3="s6" angle="1.835737307247636" k="323.00480000000005"/>
+    <Angle class1="sh" class2="p5" class3="sh" angle="1.824916265885271" k="317.98400000000004"/>
+    <Angle class1="sh" class2="p5" class3="ss" angle="1.8697712276615253" k="311.28960000000006"/>
+    <Angle class1="s" class2="p5" class3="s" angle="1.9919442753011283" k="327.1888"/>
+    <Angle class1="ss" class2="p5" class3="ss" angle="1.9130553931109846" k="305.432"/>
+    <Angle class1="cd" class2="pc" class3="n" angle="1.584758960810851" k="358.1504"/>
+    <Angle class1="cd" class2="pc" class3="na" angle="1.5739379194484864" k="359.824"/>
+    <Angle class1="cc" class2="pd" class3="n" angle="1.584758960810851" k="358.1504"/>
+    <Angle class1="cc" class2="pd" class3="na" angle="1.5739379194484864" k="359.824"/>
+    <Angle class1="c2" class2="pe" class3="ca" angle="1.7704619932230479" k="325.5152"/>
+    <Angle class1="c2" class2="pe" class3="ce" angle="1.797863662479359" k="323.8416"/>
+    <Angle class1="c2" class2="pe" class3="cg" angle="1.8156660208497009" k="342.2512"/>
+    <Angle class1="c2" class2="pe" class3="n2" angle="1.643052957827462" k="376.56"/>
+    <Angle class1="c2" class2="pe" class3="ne" angle="1.7226399717184033" k="350.6192"/>
+    <Angle class1="c2" class2="pe" class3="o" angle="2.0099211665966696" k="343.9248"/>
+    <Angle class1="c2" class2="pe" class3="p2" angle="1.881813999500286" k="426.76800000000003"/>
+    <Angle class1="c2" class2="pe" class3="pe" angle="1.7975145966289598" k="403.33760000000007"/>
+    <Angle class1="c2" class2="pe" class3="px" angle="1.6994270926668789" k="427.6048"/>
+    <Angle class1="c2" class2="pe" class3="py" angle="1.687907919603716" k="425.9312"/>
+    <Angle class1="c2" class2="pe" class3="s" angle="1.9401079965168966" k="343.9248"/>
+    <Angle class1="c2" class2="pe" class3="sx" angle="1.6599826515718068" k="322.168"/>
+    <Angle class1="c2" class2="pe" class3="sy" angle="1.6678366332057812" k="316.3104"/>
+    <Angle class1="ca" class2="pe" class3="n2" angle="1.7807594358098144" k="343.088"/>
+    <Angle class1="ca" class2="pe" class3="o" angle="1.8654079045315393" k="338.0672"/>
+    <Angle class1="ca" class2="pe" class3="p2" angle="1.759117353085085" k="426.76800000000003"/>
+    <Angle class1="ca" class2="pe" class3="pf" angle="1.7400932642383464" k="405.01120000000003"/>
+    <Angle class1="ca" class2="pe" class3="s" angle="1.88373386167748" k="335.5568"/>
+    <Angle class1="c" class2="pe" class3="c2" angle="1.6982053621904827" k="323.00480000000005"/>
+    <Angle class1="ce" class2="pe" class3="n2" angle="1.7549285628802984" k="347.272"/>
+    <Angle class1="ce" class2="pe" class3="o" angle="1.8751817483427078" k="338.904"/>
+    <Angle class1="ce" class2="pe" class3="p2" angle="1.7376498032855545" k="430.1152"/>
+    <Angle class1="ce" class2="pe" class3="s" angle="1.8420204925548154" k="339.74080000000004"/>
+    <Angle class1="cg" class2="pe" class3="n2" angle="1.776570645605028" k="370.7024"/>
+    <Angle class1="cg" class2="pe" class3="o" angle="1.8783233409962974" k="364.8448"/>
+    <Angle class1="cg" class2="pe" class3="p2" angle="1.8270106609876642" k="439.32"/>
+    <Angle class1="cg" class2="pe" class3="s" angle="1.8954275676658416" k="353.96639999999996"/>
+    <Angle class1="n2" class2="pe" class3="n2" angle="1.8873990531066678" k="379.0704"/>
+    <Angle class1="n2" class2="pe" class3="ne" angle="1.8640116411299437" k="358.98720000000003"/>
+    <Angle class1="n2" class2="pe" class3="o" angle="2.013935423876257" k="370.7024"/>
+    <Angle class1="n2" class2="pe" class3="p2" angle="1.9477874452256716" k="442.6672"/>
+    <Angle class1="n2" class2="pe" class3="pe" angle="1.9093902016817967" k="407.52160000000003"/>
+    <Angle class1="n2" class2="pe" class3="px" angle="1.9250981649497454" k="420.9104"/>
+    <Angle class1="n2" class2="pe" class3="py" angle="1.635024443268288" k="452.70880000000005"/>
+    <Angle class1="n2" class2="pe" class3="s" angle="2.004336112990288" k="358.98720000000003"/>
+    <Angle class1="n2" class2="pe" class3="sx" angle="1.7074556072260527" k="329.6992"/>
+    <Angle class1="n2" class2="pe" class3="sy" angle="1.7128661279072352" k="323.00480000000005"/>
+    <Angle class1="ne" class2="pe" class3="o" angle="1.9240509673985489" k="356.4768"/>
+    <Angle class1="ne" class2="pe" class3="p2" angle="1.8235200024836755" k="441.8304"/>
+    <Angle class1="ne" class2="pe" class3="s" angle="1.9057250102526084" k="353.12960000000004"/>
+    <Angle class1="o" class2="pe" class3="o" angle="2.0936969706923976" k="368.192"/>
+    <Angle class1="o" class2="pe" class3="p2" angle="1.9936896045531227" k="440.9936"/>
+    <Angle class1="o" class2="pe" class3="pe" angle="2.5474825762109234" k="355.64"/>
+    <Angle class1="o" class2="pe" class3="px" angle="1.8216001403064819" k="435.9728"/>
+    <Angle class1="o" class2="pe" class3="py" angle="1.8236945354088747" k="431.78880000000004"/>
+    <Angle class1="o" class2="pe" class3="s" angle="2.0493656076917417" k="358.98720000000003"/>
+    <Angle class1="o" class2="pe" class3="sx" angle="1.8603464497007558" k="317.98400000000004"/>
+    <Angle class1="o" class2="pe" class3="sy" angle="1.8332938462948438" k="314.63680000000005"/>
+    <Angle class1="p2" class2="pe" class3="pe" angle="1.714611457159229" k="548.9408"/>
+    <Angle class1="p2" class2="pe" class3="px" angle="1.8898425140594601" k="536.3888"/>
+    <Angle class1="p2" class2="pe" class3="py" angle="1.9350465416861131" k="527.184"/>
+    <Angle class1="p2" class2="pe" class3="s" angle="1.9422023916192899" k="446.8512"/>
+    <Angle class1="p2" class2="pe" class3="sx" angle="1.6708036929341716" k="429.2784"/>
+    <Angle class1="p2" class2="pe" class3="sy" angle="1.6746434172885591" k="422.584"/>
+    <Angle class1="pe" class2="pe" class3="s" angle="1.8833847958270808" k="421.7472"/>
+    <Angle class1="px" class2="pe" class3="s" angle="1.8783233409962974" k="435.136"/>
+    <Angle class1="py" class2="pe" class3="s" angle="1.8976964956934346" k="430.1152"/>
+    <Angle class1="s" class2="pe" class3="s" angle="3.114365517258682" k="287.8592"/>
+    <Angle class1="s" class2="pe" class3="sx" angle="1.8905406457602576" k="323.8416"/>
+    <Angle class1="s" class2="pe" class3="sy" angle="1.8662805691575366" k="321.3312"/>
+    <Angle class1="c2" class2="pf" class3="ca" angle="1.7704619932230479" k="325.5152"/>
+    <Angle class1="c2" class2="pf" class3="cf" angle="1.797863662479359" k="323.8416"/>
+    <Angle class1="c2" class2="pf" class3="ch" angle="1.8156660208497009" k="342.2512"/>
+    <Angle class1="c2" class2="pf" class3="n2" angle="1.643052957827462" k="376.56"/>
+    <Angle class1="c2" class2="pf" class3="nf" angle="1.7226399717184033" k="350.6192"/>
+    <Angle class1="c2" class2="pf" class3="o" angle="2.0099211665966696" k="343.9248"/>
+    <Angle class1="c2" class2="pf" class3="p2" angle="1.881813999500286" k="426.76800000000003"/>
+    <Angle class1="c2" class2="pf" class3="pf" angle="1.7975145966289598" k="403.33760000000007"/>
+    <Angle class1="c2" class2="pf" class3="px" angle="1.6994270926668789" k="427.6048"/>
+    <Angle class1="c2" class2="pf" class3="py" angle="1.687907919603716" k="425.9312"/>
+    <Angle class1="c2" class2="pf" class3="s" angle="1.9401079965168966" k="343.9248"/>
+    <Angle class1="c2" class2="pf" class3="sx" angle="1.6599826515718068" k="322.168"/>
+    <Angle class1="c2" class2="pf" class3="sy" angle="1.6678366332057812" k="316.3104"/>
+    <Angle class1="ca" class2="pf" class3="n2" angle="1.7807594358098144" k="343.088"/>
+    <Angle class1="ca" class2="pf" class3="o" angle="1.8654079045315393" k="338.0672"/>
+    <Angle class1="ca" class2="pf" class3="p2" angle="1.759117353085085" k="426.76800000000003"/>
+    <Angle class1="ca" class2="pf" class3="pe" angle="1.7400932642383464" k="405.01120000000003"/>
+    <Angle class1="ca" class2="pf" class3="s" angle="1.88373386167748" k="335.5568"/>
+    <Angle class1="c" class2="pf" class3="c2" angle="1.6982053621904827" k="323.00480000000005"/>
+    <Angle class1="cf" class2="pf" class3="n2" angle="1.7549285628802984" k="347.272"/>
+    <Angle class1="cf" class2="pf" class3="o" angle="1.8751817483427078" k="338.904"/>
+    <Angle class1="cf" class2="pf" class3="p2" angle="1.7376498032855545" k="430.1152"/>
+    <Angle class1="cf" class2="pf" class3="s" angle="1.8420204925548154" k="339.74080000000004"/>
+    <Angle class1="ch" class2="pf" class3="n2" angle="1.776570645605028" k="370.7024"/>
+    <Angle class1="ch" class2="pf" class3="o" angle="1.8783233409962974" k="364.8448"/>
+    <Angle class1="ch" class2="pf" class3="p2" angle="1.8270106609876642" k="439.32"/>
+    <Angle class1="ch" class2="pf" class3="s" angle="1.8954275676658416" k="353.96639999999996"/>
+    <Angle class1="n2" class2="pf" class3="n2" angle="1.8873990531066678" k="379.0704"/>
+    <Angle class1="n2" class2="pf" class3="nf" angle="1.8640116411299437" k="358.98720000000003"/>
+    <Angle class1="n2" class2="pf" class3="o" angle="2.013935423876257" k="370.7024"/>
+    <Angle class1="n2" class2="pf" class3="p2" angle="1.9477874452256716" k="442.6672"/>
+    <Angle class1="n2" class2="pf" class3="pf" angle="1.9093902016817967" k="407.52160000000003"/>
+    <Angle class1="n2" class2="pf" class3="px" angle="1.9250981649497454" k="420.9104"/>
+    <Angle class1="n2" class2="pf" class3="py" angle="1.635024443268288" k="452.70880000000005"/>
+    <Angle class1="n2" class2="pf" class3="s" angle="2.004336112990288" k="358.98720000000003"/>
+    <Angle class1="n2" class2="pf" class3="sx" angle="1.7074556072260527" k="329.6992"/>
+    <Angle class1="n2" class2="pf" class3="sy" angle="1.7128661279072352" k="323.00480000000005"/>
+    <Angle class1="nf" class2="pf" class3="o" angle="1.9240509673985489" k="356.4768"/>
+    <Angle class1="nf" class2="pf" class3="p2" angle="1.8235200024836755" k="441.8304"/>
+    <Angle class1="nf" class2="pf" class3="s" angle="1.9057250102526084" k="353.12960000000004"/>
+    <Angle class1="o" class2="pf" class3="o" angle="2.0936969706923976" k="368.192"/>
+    <Angle class1="o" class2="pf" class3="p2" angle="1.9936896045531227" k="440.9936"/>
+    <Angle class1="o" class2="pf" class3="pf" angle="2.5474825762109234" k="355.64"/>
+    <Angle class1="o" class2="pf" class3="px" angle="1.8216001403064819" k="435.9728"/>
+    <Angle class1="o" class2="pf" class3="py" angle="1.8236945354088747" k="431.78880000000004"/>
+    <Angle class1="o" class2="pf" class3="s" angle="2.0493656076917417" k="358.98720000000003"/>
+    <Angle class1="o" class2="pf" class3="sx" angle="1.8603464497007558" k="317.98400000000004"/>
+    <Angle class1="o" class2="pf" class3="sy" angle="1.8332938462948438" k="314.63680000000005"/>
+    <Angle class1="p2" class2="pf" class3="pf" angle="1.714611457159229" k="548.9408"/>
+    <Angle class1="p2" class2="pf" class3="px" angle="1.8898425140594601" k="536.3888"/>
+    <Angle class1="p2" class2="pf" class3="py" angle="1.9350465416861131" k="527.184"/>
+    <Angle class1="p2" class2="pf" class3="s" angle="1.9422023916192899" k="446.8512"/>
+    <Angle class1="p2" class2="pf" class3="sx" angle="1.6708036929341716" k="429.2784"/>
+    <Angle class1="p2" class2="pf" class3="sy" angle="1.6746434172885591" k="422.584"/>
+    <Angle class1="pf" class2="pf" class3="s" angle="1.8833847958270808" k="421.7472"/>
+    <Angle class1="px" class2="pf" class3="s" angle="1.8783233409962974" k="435.136"/>
+    <Angle class1="py" class2="pf" class3="s" angle="1.8976964956934346" k="430.1152"/>
+    <Angle class1="s" class2="pf" class3="s" angle="3.114365517258682" k="287.8592"/>
+    <Angle class1="s" class2="pf" class3="sx" angle="1.8905406457602576" k="323.8416"/>
+    <Angle class1="s" class2="pf" class3="sy" angle="1.8662805691575366" k="321.3312"/>
+    <Angle class1="c3" class2="px" class3="ca" angle="1.8289305231648578" k="308.7792"/>
+    <Angle class1="c3" class2="px" class3="ce" angle="1.830152253641254" k="309.616"/>
+    <Angle class1="c3" class2="px" class3="cf" angle="1.830152253641254" k="309.616"/>
+    <Angle class1="c3" class2="px" class3="ne" angle="1.7882643515933898" k="330.536"/>
+    <Angle class1="c3" class2="px" class3="nf" angle="1.7882643515933898" k="330.536"/>
+    <Angle class1="c3" class2="px" class3="o" angle="1.9860101558443477" k="328.8624"/>
+    <Angle class1="c3" class2="px" class3="pe" angle="1.8453366181336046" k="399.99039999999997"/>
+    <Angle class1="c3" class2="px" class3="pf" angle="1.8453366181336046" k="399.99039999999997"/>
+    <Angle class1="c3" class2="px" class3="py" angle="1.7996089917313531" k="380.744"/>
+    <Angle class1="c3" class2="px" class3="sx" angle="1.737475270360355" k="301.248"/>
+    <Angle class1="c3" class2="px" class3="sy" angle="1.804844979487336" k="295.3904"/>
+    <Angle class1="ca" class2="px" class3="ca" angle="1.8177604159520941" k="310.4528"/>
+    <Angle class1="ca" class2="px" class3="o" angle="1.876228945893904" k="338.904"/>
+    <Angle class1="c" class2="px" class3="c3" angle="1.775348915128632" k="307.10560000000004"/>
+    <Angle class1="ce" class2="px" class3="ce" angle="1.8188076135032907" k="310.4528"/>
+    <Angle class1="ce" class2="px" class3="o" angle="1.9860101558443477" k="329.6992"/>
+    <Angle class1="cf" class2="px" class3="cf" angle="1.8188076135032907" k="310.4528"/>
+    <Angle class1="cf" class2="px" class3="o" angle="1.9860101558443477" k="329.6992"/>
+    <Angle class1="c" class2="px" class3="o" angle="1.997878394757909" k="317.98400000000004"/>
+    <Angle class1="ne" class2="px" class3="ne" angle="1.8015288539085468" k="350.6192"/>
+    <Angle class1="ne" class2="px" class3="o" angle="1.9919442753011283" k="353.12960000000004"/>
+    <Angle class1="nf" class2="px" class3="nf" angle="1.8015288539085468" k="350.6192"/>
+    <Angle class1="nf" class2="px" class3="o" angle="1.9919442753011283" k="353.12960000000004"/>
+    <Angle class1="o" class2="px" class3="pe" angle="2.033308578573394" k="413.3792"/>
+    <Angle class1="o" class2="px" class3="pf" angle="2.033308578573394" k="413.3792"/>
+    <Angle class1="o" class2="px" class3="py" angle="1.9931660057775245" k="384.0912"/>
+    <Angle class1="o" class2="px" class3="sx" angle="1.9689059291748032" k="299.57439999999997"/>
+    <Angle class1="o" class2="px" class3="sy" angle="1.981646832714362" k="297.9008"/>
+    <Angle class1="pe" class2="px" class3="pe" angle="1.9322540148829221" k="513.7952"/>
+    <Angle class1="pf" class2="px" class3="pf" angle="1.9322540148829221" k="513.7952"/>
+    <Angle class1="py" class2="px" class3="py" angle="1.8811158677994881" k="474.46560000000005"/>
+    <Angle class1="sx" class2="px" class3="sx" angle="1.6797048721193426" k="307.94239999999996"/>
+    <Angle class1="sy" class2="px" class3="sy" angle="1.7865190223413956" k="297.064"/>
+    <Angle class1="c3" class2="py" class3="n4" angle="1.8121753623457124" k="310.4528"/>
+    <Angle class1="c3" class2="py" class3="na" angle="1.865582437456739" k="321.3312"/>
+    <Angle class1="c3" class2="py" class3="o" angle="2.0364501712269836" k="323.8416"/>
+    <Angle class1="c3" class2="py" class3="oh" angle="1.7481217787975203" k="341.4144"/>
+    <Angle class1="c3" class2="py" class3="os" angle="1.8394024986768238" k="333.0464"/>
+    <Angle class1="c3" class2="py" class3="px" angle="1.854761396094374" k="374.04960000000005"/>
+    <Angle class1="c3" class2="py" class3="py" angle="1.9168951174653721" k="369.86560000000003"/>
+    <Angle class1="c3" class2="py" class3="sx" angle="1.8563321924211689" k="289.5328"/>
+    <Angle class1="ca" class2="py" class3="ca" angle="1.8771016105199012" k="307.10560000000004"/>
+    <Angle class1="ca" class2="py" class3="o" angle="1.995434933805117" k="330.536"/>
+    <Angle class1="ca" class2="py" class3="oh" angle="1.795420201526567" k="339.74080000000004"/>
+    <Angle class1="ca" class2="py" class3="os" angle="1.7690657298214525" k="342.2512"/>
+    <Angle class1="c" class2="py" class3="c3" angle="1.9261453625009421" k="297.064"/>
+    <Angle class1="c" class2="py" class3="c" angle="1.8186330805780915" k="302.9216"/>
+    <Angle class1="ce" class2="py" class3="ce" angle="1.8594737850747587" k="309.616"/>
+    <Angle class1="ce" class2="py" class3="o" angle="1.9903734789743337" k="332.2096"/>
+    <Angle class1="ce" class2="py" class3="oh" angle="1.8285814573144588" k="338.0672"/>
+    <Angle class1="ce" class2="py" class3="os" angle="1.8305013194916528" k="337.2304"/>
+    <Angle class1="cf" class2="py" class3="cf" angle="1.8594737850747587" k="309.616"/>
+    <Angle class1="cf" class2="py" class3="o" angle="1.9903734789743337" k="332.2096"/>
+    <Angle class1="cf" class2="py" class3="oh" angle="1.8285814573144588" k="338.0672"/>
+    <Angle class1="cf" class2="py" class3="os" angle="1.8305013194916528" k="337.2304"/>
+    <Angle class1="c" class2="py" class3="o" angle="1.9896753472735356" k="323.8416"/>
+    <Angle class1="c" class2="py" class3="oh" angle="1.8015288539085468" k="333.0464"/>
+    <Angle class1="c" class2="py" class3="os" angle="1.745503784919529" k="338.0672"/>
+    <Angle class1="n3" class2="py" class3="ne" angle="1.8982200944690328" k="352.2928"/>
+    <Angle class1="n4" class2="py" class3="o" angle="2.017251549455046" k="324.6784"/>
+    <Angle class1="n4" class2="py" class3="py" angle="0.9616764178488756" k="528.8576"/>
+    <Angle class1="na" class2="py" class3="o" angle="2.1362830044410592" k="341.4144"/>
+    <Angle class1="na" class2="py" class3="py" angle="0.8880235234147149" k="566.5136"/>
+    <Angle class1="ne" class2="py" class3="ne" angle="2.062804642932098" k="347.272"/>
+    <Angle class1="ne" class2="py" class3="o" angle="1.9758872461827806" k="369.86560000000003"/>
+    <Angle class1="ne" class2="py" class3="oh" angle="1.827359726838063" k="369.86560000000003"/>
+    <Angle class1="ne" class2="py" class3="os" angle="1.8900170469846596" k="364.00800000000004"/>
+    <Angle class1="nf" class2="py" class3="nf" angle="2.062804642932098" k="347.272"/>
+    <Angle class1="nf" class2="py" class3="o" angle="1.9758872461827806" k="369.86560000000003"/>
+    <Angle class1="nf" class2="py" class3="oh" angle="1.827359726838063" k="369.86560000000003"/>
+    <Angle class1="nf" class2="py" class3="os" angle="1.8900170469846596" k="364.00800000000004"/>
+    <Angle class1="oh" class2="py" class3="oh" angle="1.7746507834278342" k="376.56"/>
+    <Angle class1="oh" class2="py" class3="pe" angle="1.829803187790855" k="426.76800000000003"/>
+    <Angle class1="oh" class2="py" class3="pf" angle="1.829803187790855" k="426.76800000000003"/>
+    <Angle class1="oh" class2="py" class3="px" angle="1.8203784098300857" k="399.15360000000004"/>
+    <Angle class1="oh" class2="py" class3="py" angle="1.753183233628304" k="409.1952"/>
+    <Angle class1="oh" class2="py" class3="sx" angle="1.761735346963076" k="312.9632"/>
+    <Angle class1="oh" class2="py" class3="sy" angle="1.7709855919986461" k="322.168"/>
+    <Angle class1="o" class2="py" class3="oh" angle="2.021614872585032" k="366.5184"/>
+    <Angle class1="o" class2="py" class3="os" angle="2.0244073993882226" k="365.68160000000006"/>
+    <Angle class1="o" class2="py" class3="pe" angle="1.9994491910847039" k="414.216"/>
+    <Angle class1="o" class2="py" class3="pf" angle="1.9994491910847039" k="414.216"/>
+    <Angle class1="o" class2="py" class3="px" angle="1.9437731879460847" k="389.112"/>
+    <Angle class1="o" class2="py" class3="py" angle="2.101900018176771" k="376.56"/>
+    <Angle class1="os" class2="py" class3="os" angle="1.7770942443806264" k="375.7232"/>
+    <Angle class1="os" class2="py" class3="py" angle="1.8254398646608694" k="400.8272"/>
+    <Angle class1="os" class2="py" class3="sx" angle="1.8126989611213105" k="308.7792"/>
+    <Angle class1="os" class2="py" class3="sy" angle="1.7823302321366095" k="321.3312"/>
+    <Angle class1="o" class2="py" class3="sx" angle="2.069262361164477" k="290.36960000000005"/>
+    <Angle class1="o" class2="py" class3="sy" angle="1.9497073074028652" k="309.616"/>
+    <Angle class1="pe" class2="py" class3="pe" angle="1.8699457605867247" k="517.1424"/>
+    <Angle class1="pf" class2="py" class3="pf" angle="1.8699457605867247" k="517.1424"/>
+    <Angle class1="py" class2="py" class3="py" angle="1.9669860669976096" k="466.9344"/>
+    <Angle class1="py" class2="py" class3="sx" angle="1.0740756216773104" k="490.36480000000006"/>
+    <Angle class1="sy" class2="py" class3="sy" angle="1.8355627743224365" k="302.08480000000003"/>
+    <Angle class1="c1" class2="s2" class3="o" angle="2.046398547963351" k="550.6144"/>
+    <Angle class1="c2" class2="s2" class3="n2" angle="1.9345229429105149" k="569.024"/>
+    <Angle class1="c2" class2="s2" class3="o" angle="2.001892652037496" k="553.9616000000001"/>
+    <Angle class1="cl" class2="s2" class3="n1" angle="2.054252529597326" k="446.8512"/>
+    <Angle class1="f" class2="s2" class3="n1" angle="2.0402898955813713" k="553.9616000000001"/>
+    <Angle class1="n1" class2="s2" class3="o" angle="1.8929841067130497" k="610.864"/>
+    <Angle class1="n2" class2="s2" class3="o" angle="2.1153390534171272" k="563.1664"/>
+    <Angle class1="o" class2="s2" class3="o" angle="2.0275489920418126" k="569.024"/>
+    <Angle class1="o" class2="s2" class3="s" angle="2.0647245051092917" k="533.8783999999999"/>
+    <Angle class1="s" class2="s2" class3="s" angle="2.007826771494277" k="531.368"/>
+    <Angle class1="br" class2="s4" class3="br" angle="1.7107717328048417" k="540.5728"/>
+    <Angle class1="br" class2="s4" class3="c3" angle="1.6228071385043277" k="518.816"/>
+    <Angle class1="br" class2="s4" class3="o" angle="1.9559904927100449" k="495.38560000000007"/>
+    <Angle class1="c1" class2="s4" class3="c1" angle="1.632755515240695" k="546.4304"/>
+    <Angle class1="c1" class2="s4" class3="o" angle="1.9261453625009421" k="551.4512000000001"/>
+    <Angle class1="c2" class2="s4" class3="c2" angle="1.7852972918649999" k="518.816"/>
+    <Angle class1="c2" class2="s4" class3="c3" angle="1.657190124768616" k="527.184"/>
+    <Angle class1="c2" class2="s4" class3="o" angle="1.8690730959607273" k="556.472"/>
+    <Angle class1="c3" class2="s4" class3="c3" angle="1.6776104770169495" k="514.6320000000001"/>
+    <Angle class1="c3" class2="s4" class3="ca" angle="1.6580627893946132" k="523.8368"/>
+    <Angle class1="c3" class2="s4" class3="f" angle="1.6004669240788003" k="550.6144"/>
+    <Angle class1="c3" class2="s4" class3="hs" angle="1.5812683023068625" k="384.928"/>
+    <Angle class1="c3" class2="s4" class3="i" angle="1.5800465718304666" k="442.6672"/>
+    <Angle class1="c3" class2="s4" class3="n2" angle="1.5810937693816631" k="573.208"/>
+    <Angle class1="c3" class2="s4" class3="n3" angle="1.6715018246349693" k="538.8992000000001"/>
+    <Angle class1="c3" class2="s4" class3="n" angle="1.6767378123909522" k="536.3888"/>
+    <Angle class1="c3" class2="s4" class3="n4" angle="1.6139059593191567" k="516.3056"/>
+    <Angle class1="c3" class2="s4" class3="na" angle="1.6243779348311225" k="541.4096000000001"/>
+    <Angle class1="c3" class2="s4" class3="nh" angle="1.6943656378360952" k="535.552"/>
+    <Angle class1="c3" class2="s4" class3="no" angle="1.5625932793105233" k="520.4896"/>
+    <Angle class1="c3" class2="s4" class3="o" angle="1.8624408448031489" k="542.2464"/>
+    <Angle class1="c3" class2="s4" class3="oh" angle="1.5756832487004806" k="566.5136"/>
+    <Angle class1="c3" class2="s4" class3="os" angle="1.571843524346093" k="567.3504"/>
+    <Angle class1="c3" class2="s4" class3="p2" angle="1.647067215107049" k="637.6416"/>
+    <Angle class1="c3" class2="s4" class3="p3" angle="1.6849408598753257" k="651.8672"/>
+    <Angle class1="c3" class2="s4" class3="p4" angle="1.699950691442477" k="615.048"/>
+    <Angle class1="c3" class2="s4" class3="p5" angle="1.7310175521279763" k="652.7040000000001"/>
+    <Angle class1="c3" class2="s4" class3="s4" angle="1.562069680534925" k="535.552"/>
+    <Angle class1="c3" class2="s4" class3="s" angle="1.722989037568802" k="510.44800000000004"/>
+    <Angle class1="c3" class2="s4" class3="s6" angle="1.7013469548440725" k="513.7952"/>
+    <Angle class1="c3" class2="s4" class3="sh" angle="1.6521286699378321" k="506.264"/>
+    <Angle class1="c3" class2="s4" class3="ss" angle="1.6634733100757955" k="505.4272"/>
+    <Angle class1="ca" class2="s4" class3="ca" angle="1.661727980823801" k="529.6944"/>
+    <Angle class1="ca" class2="s4" class3="o" angle="1.8610445814015537" k="551.4512000000001"/>
+    <Angle class1="c" class2="s4" class3="c3" angle="1.659284519871009" k="512.1216000000001"/>
+    <Angle class1="c" class2="s4" class3="c" angle="1.5154693895066762" k="529.6944"/>
+    <Angle class1="cl" class2="s4" class3="cl" angle="1.7048376133480614" k="451.03520000000003"/>
+    <Angle class1="cl" class2="s4" class3="o" angle="1.8908897116106567" k="486.18080000000003"/>
+    <Angle class1="c" class2="s4" class3="o" angle="1.8530160668423798" k="534.7152"/>
+    <Angle class1="cx" class2="s4" class3="cx" angle="0.8517206749732327" k="725.5056000000001"/>
+    <Angle class1="cx" class2="s4" class3="o" angle="1.8940313042642465" k="526.3472"/>
+    <Angle class1="f" class2="s4" class3="f" angle="1.6180947495239428" k="585.76"/>
+    <Angle class1="f" class2="s4" class3="o" angle="1.8641861740551433" k="585.76"/>
+    <Angle class1="f" class2="s4" class3="s" angle="1.876228945893904" k="500.4064"/>
+    <Angle class1="hs" class2="s4" class3="hs" angle="1.5184364492350666" k="316.3104"/>
+    <Angle class1="hs" class2="s4" class3="n1" angle="1.5796975059800675" k="428.44160000000005"/>
+    <Angle class1="hs" class2="s4" class3="o" angle="1.924574566174147" k="415.05280000000005"/>
+    <Angle class1="i" class2="s4" class3="i" angle="1.6980308292652833" k="456.05600000000004"/>
+    <Angle class1="i" class2="s4" class3="o" angle="1.9881045509467405" k="396.6432"/>
+    <Angle class1="n1" class2="s4" class3="n1" angle="1.6409585627250687" k="605.8432"/>
+    <Angle class1="n1" class2="s4" class3="o" angle="1.9214329735205575" k="586.5968"/>
+    <Angle class1="n2" class2="s4" class3="n2" angle="1.573763386523287" k="634.2944"/>
+    <Angle class1="n2" class2="s4" class3="o" angle="1.8774506763703" k="602.496"/>
+    <Angle class1="n3" class2="s4" class3="n3" angle="1.591565744893629" k="579.0656"/>
+    <Angle class1="n3" class2="s4" class3="o" angle="1.9273670929773383" k="562.3296"/>
+    <Angle class1="n4" class2="s4" class3="n4" angle="1.651256005311835" k="505.4272"/>
+    <Angle class1="n4" class2="s4" class3="o" angle="1.8310249182672511" k="528.0208"/>
+    <Angle class1="na" class2="s4" class3="na" angle="1.7994344588061535" k="532.2048"/>
+    <Angle class1="na" class2="s4" class3="o" angle="1.9154988540637765" k="555.6352"/>
+    <Angle class1="nh" class2="s4" class3="nh" angle="1.6098917020395693" k="577.392"/>
+    <Angle class1="nh" class2="s4" class3="o" angle="1.876927077594702" k="571.5344"/>
+    <Angle class1="n" class2="s4" class3="n" angle="1.593485607070823" k="574.0448"/>
+    <Angle class1="n" class2="s4" class3="o" angle="1.8751817483427078" k="567.3504"/>
+    <Angle class1="no" class2="s4" class3="no" angle="1.455604596163271" k="531.368"/>
+    <Angle class1="no" class2="s4" class3="o" angle="1.8078120392157264" k="526.3472"/>
+    <Angle class1="oh" class2="s4" class3="oh" angle="1.75126337145111" k="577.392"/>
+    <Angle class1="o" class2="s4" class3="o" angle="1.9915952094507294" k="610.0272000000001"/>
+    <Angle class1="o" class2="s4" class3="oh" angle="1.9216075064457567" k="579.9024"/>
+    <Angle class1="o" class2="s4" class3="os" angle="1.8887953165082634" k="585.76"/>
+    <Angle class1="o" class2="s4" class3="p2" angle="1.8634880423543456" k="637.6416"/>
+    <Angle class1="o" class2="s4" class3="p3" angle="1.8589501862991602" k="666.9296"/>
+    <Angle class1="o" class2="s4" class3="p4" angle="1.803972314861339" k="630.9472000000001"/>
+    <Angle class1="o" class2="s4" class3="p5" angle="1.6920967098085025" k="713.7904"/>
+    <Angle class1="o" class2="s4" class3="s4" angle="1.8247417329600717" k="533.8783999999999"/>
+    <Angle class1="o" class2="s4" class3="s" angle="1.9586084865880367" k="516.3056"/>
+    <Angle class1="o" class2="s4" class3="s6" angle="1.7948966027509685" k="538.0624"/>
+    <Angle class1="o" class2="s4" class3="sh" angle="1.8764034788191037" k="506.264"/>
+    <Angle class1="os" class2="s4" class3="os" angle="1.6418312273510658" k="597.4752000000001"/>
+    <Angle class1="o" class2="s4" class3="ss" angle="1.9109609980085913" k="502.08000000000004"/>
+    <Angle class1="p2" class2="s4" class3="p2" angle="1.616523953197148" k="821.7376"/>
+    <Angle class1="p3" class2="s4" class3="p3" angle="1.6704546270837726" k="848.5152"/>
+    <Angle class1="p5" class2="s4" class3="p5" angle="1.6381660359218775" k="876.1296000000001"/>
+    <Angle class1="s4" class2="s4" class3="s4" angle="1.573763386523287" k="547.2672000000001"/>
+    <Angle class1="s4" class2="s4" class3="s6" angle="1.573763386523287" k="547.2672000000001"/>
+    <Angle class1="s6" class2="s4" class3="s6" angle="1.632231916465097" k="537.2256000000001"/>
+    <Angle class1="sh" class2="s4" class3="sh" angle="1.793500339349373" k="492.03839999999997"/>
+    <Angle class1="sh" class2="s4" class3="ss" angle="1.7914059442469796" k="492.8752"/>
+    <Angle class1="s" class2="s4" class3="s" angle="1.8863518555554712" k="501.2432"/>
+    <Angle class1="ss" class2="s4" class3="ss" angle="1.6662658368789862" k="510.44800000000004"/>
+    <Angle class1="br" class2="s6" class3="br" angle="1.7727309212506404" k="561.4928"/>
+    <Angle class1="br" class2="s6" class3="c3" angle="1.7277014265491866" k="527.184"/>
+    <Angle class1="br" class2="s6" class3="f" angle="1.7558012275062955" k="526.3472"/>
+    <Angle class1="br" class2="s6" class3="o" angle="1.8776252092954997" k="534.7152"/>
+    <Angle class1="c1" class2="s6" class3="c1" angle="1.74515471906913" k="536.3888"/>
+    <Angle class1="c1" class2="s6" class3="o" angle="1.884606526303477" k="569.024"/>
+    <Angle class1="c2" class2="s6" class3="c2" angle="1.7933258064241737" k="517.9792"/>
+    <Angle class1="c2" class2="s6" class3="c3" angle="1.8160150867000997" k="507.10080000000005"/>
+    <Angle class1="c2" class2="s6" class3="o" angle="1.8601719167755564" k="563.1664"/>
+    <Angle class1="c3" class2="s6" class3="c3" angle="1.8121753623457124" k="501.2432"/>
+    <Angle class1="c3" class2="s6" class3="ca" angle="1.8006561892825497" k="508.7744"/>
+    <Angle class1="c3" class2="s6" class3="cy" angle="1.6538739991898268" k="518.816"/>
+    <Angle class1="c3" class2="s6" class3="f" angle="1.673770752662562" k="539.736"/>
+    <Angle class1="c3" class2="s6" class3="hs" angle="1.7561502933566946" k="369.86560000000003"/>
+    <Angle class1="c3" class2="s6" class3="i" angle="1.7058848108992575" k="425.9312"/>
+    <Angle class1="c3" class2="s6" class3="n2" angle="1.9631463426432219" k="524.6736000000001"/>
+    <Angle class1="c3" class2="s6" class3="n3" angle="1.7797122382586177" k="537.2256000000001"/>
+    <Angle class1="c3" class2="s6" class3="n" angle="1.8053685782629345" k="527.184"/>
+    <Angle class1="c3" class2="s6" class3="n4" angle="1.7348572764823638" k="509.6112"/>
+    <Angle class1="c3" class2="s6" class3="na" angle="1.79437300397537" k="528.0208"/>
+    <Angle class1="c3" class2="s6" class3="nh" angle="1.8207274756804843" k="527.184"/>
+    <Angle class1="c3" class2="s6" class3="no" angle="1.7378243362107537" k="499.56960000000004"/>
+    <Angle class1="c3" class2="s6" class3="o" angle="1.8956021005910413" k="547.2672000000001"/>
+    <Angle class1="c3" class2="s6" class3="oh" angle="1.723338103419201" k="553.9616000000001"/>
+    <Angle class1="c3" class2="s6" class3="os" angle="1.6828464647729324" k="561.4928"/>
+    <Angle class1="c3" class2="s6" class3="p2" angle="1.8582520545983625" k="604.1696000000001"/>
+    <Angle class1="c3" class2="s6" class3="p3" angle="1.804670446562137" k="634.2944"/>
+    <Angle class1="c3" class2="s6" class3="p4" angle="1.8172368171764959" k="592.4544"/>
+    <Angle class1="c3" class2="s6" class3="p5" angle="1.8057176441133331" k="641.8256"/>
+    <Angle class1="c3" class2="s6" class3="s4" angle="1.7121679962064371" k="513.7952"/>
+    <Angle class1="c3" class2="s6" class3="s" angle="1.8238690683340744" k="504.5904"/>
+    <Angle class1="c3" class2="s6" class3="s6" angle="1.7793631724082188" k="503.75360000000006"/>
+    <Angle class1="c3" class2="s6" class3="sh" angle="1.7774433102310252" k="499.56960000000004"/>
+    <Angle class1="c3" class2="s6" class3="ss" angle="1.7884388845185892" k="497.05920000000003"/>
+    <Angle class1="ca" class2="s6" class3="ca" angle="1.7990853929557549" k="514.6320000000001"/>
+    <Angle class1="ca" class2="s6" class3="o" angle="1.8167132184008978" k="568.1872000000001"/>
+    <Angle class1="c" class2="s6" class3="c3" angle="1.7669713347190592" k="498.73280000000005"/>
+    <Angle class1="c" class2="s6" class3="c" angle="1.7421876593407395" k="494.5488"/>
+    <Angle class1="cc" class2="s6" class3="o" angle="1.8109536318693162" k="558.1456000000001"/>
+    <Angle class1="cl" class2="s6" class3="cl" angle="1.7671458676442584" k="442.6672"/>
+    <Angle class1="cl" class2="s6" class3="f" angle="1.7278759594743864" k="481.16"/>
+    <Angle class1="cl" class2="s6" class3="o" angle="1.876578011744303" k="489.528"/>
+    <Angle class1="c" class2="s6" class3="o" angle="1.8844319933782776" k="533.8783999999999"/>
+    <Angle class1="c" class2="s6" class3="os" angle="1.7823302321366095" k="533.8783999999999"/>
+    <Angle class1="cx" class2="s6" class3="cx" angle="0.9546951008408984" k="721.3216000000001"/>
+    <Angle class1="cy" class2="s6" class3="o" angle="1.9310322844065262" k="532.2048"/>
+    <Angle class1="f" class2="s6" class3="f" angle="1.5657348719641129" k="587.4336000000001"/>
+    <Angle class1="f" class2="s6" class3="o" angle="1.8594737850747587" k="589.9440000000001"/>
+    <Angle class1="hs" class2="s6" class3="hs" angle="1.728225025324785" k="299.57439999999997"/>
+    <Angle class1="hs" class2="s6" class3="n1" angle="1.6976817634148842" k="457.72960000000006"/>
+    <Angle class1="hs" class2="s6" class3="o" angle="1.8793705385474944" k="430.952"/>
+    <Angle class1="i" class2="s6" class3="i" angle="1.732239282604372" k="451.03520000000003"/>
+    <Angle class1="i" class2="s6" class3="o" angle="1.8992672920202291" k="402.5008"/>
+    <Angle class1="n1" class2="s6" class3="n1" angle="1.6671385015049833" k="700.4016"/>
+    <Angle class1="n1" class2="s6" class3="o" angle="1.876578011744303" k="655.2144"/>
+    <Angle class1="n2" class2="s6" class3="n2" angle="1.7210691753916083" k="628.4368"/>
+    <Angle class1="n2" class2="s6" class3="o" angle="2.0786871391252464" k="592.4544"/>
+    <Angle class1="n2" class2="s6" class3="oh" angle="1.8668041679331349" k="590.7808"/>
+    <Angle class1="n2" class2="s6" class3="os" angle="1.8020524526841453" k="603.3328"/>
+    <Angle class1="n3" class2="s6" class3="n3" angle="1.718102115663218" k="584.0864"/>
+    <Angle class1="n3" class2="s6" class3="o" angle="1.8750072154175084" k="595.8016"/>
+    <Angle class1="n3" class2="s6" class3="os" angle="1.7393951325375487" k="592.4544"/>
+    <Angle class1="n4" class2="s6" class3="n4" angle="1.7776178431562244" k="502.08000000000004"/>
+    <Angle class1="n4" class2="s6" class3="o" angle="1.7962928661525641" k="549.7776"/>
+    <Angle class1="na" class2="s6" class3="na" angle="1.7111207986552408" k="568.1872000000001"/>
+    <Angle class1="na" class2="s6" class3="o" angle="1.8469074144603996" k="588.2704"/>
+    <Angle class1="nh" class2="s6" class3="nh" angle="1.650383340685838" k="587.4336000000001"/>
+    <Angle class1="nh" class2="s6" class3="o" angle="1.8711674910631204" k="590.7808"/>
+    <Angle class1="n" class2="s6" class3="n" angle="1.8179349488772936" k="552.288"/>
+    <Angle class1="n" class2="s6" class3="o" angle="1.8678513654843312" k="585.76"/>
+    <Angle class1="no" class2="s6" class3="no" angle="1.5992451936024041" k="512.1216000000001"/>
+    <Angle class1="no" class2="s6" class3="o" angle="1.8750072154175084" k="523.8368"/>
+    <Angle class1="n" class2="s6" class3="os" angle="1.7318902167539734" k="584.9232000000001"/>
+    <Angle class1="oh" class2="s6" class3="oh" angle="1.75126337145111" k="599.1487999999999"/>
+    <Angle class1="oh" class2="s6" class3="os" angle="1.6896532488557103" k="611.7008"/>
+    <Angle class1="oh" class2="s6" class3="p2" angle="1.9141025906621811" k="625.9264"/>
+    <Angle class1="o" class2="s6" class3="o" angle="2.0952677670191924" k="615.8847999999999"/>
+    <Angle class1="o" class2="s6" class3="oh" angle="1.885828256779873" k="606.6800000000001"/>
+    <Angle class1="o" class2="s6" class3="os" angle="1.8947294359650442" k="608.3536"/>
+    <Angle class1="o" class2="s6" class3="p2" angle="1.8606955155511546" k="640.9888"/>
+    <Angle class1="o" class2="s6" class3="p3" angle="1.8687240301103285" k="670.2768"/>
+    <Angle class1="o" class2="s6" class3="p4" angle="1.844289420582408" k="619.232"/>
+    <Angle class1="o" class2="s6" class3="p5" angle="1.861219114326753" k="682.8288"/>
+    <Angle class1="o" class2="s6" class3="s4" angle="1.8823375982758843" k="527.184"/>
+    <Angle class1="o" class2="s6" class3="s" angle="1.924923632024546" k="531.368"/>
+    <Angle class1="o" class2="s6" class3="s6" angle="1.8512707375903852" k="531.368"/>
+    <Angle class1="o" class2="s6" class3="sh" angle="1.8641861740551433" k="523.0"/>
+    <Angle class1="os" class2="s6" class3="os" angle="1.7226399717184033" k="608.3536"/>
+    <Angle class1="o" class2="s6" class3="ss" angle="1.8750072154175084" k="518.816"/>
+    <Angle class1="p3" class2="s6" class3="p3" angle="1.9228292369221527" k="794.1232000000001"/>
+    <Angle class1="p5" class2="s6" class3="p5" angle="1.8236945354088747" k="830.1056000000001"/>
+    <Angle class1="s4" class2="s6" class3="s4" angle="1.7800613041090168" k="514.6320000000001"/>
+    <Angle class1="s4" class2="s6" class3="s6" angle="1.573763386523287" k="547.2672000000001"/>
+    <Angle class1="s6" class2="s6" class3="s6" angle="1.802750584384943" k="511.2848"/>
+    <Angle class1="sh" class2="s6" class3="sh" angle="1.857553922897565" k="497.05920000000003"/>
+    <Angle class1="sh" class2="s6" class3="ss" angle="1.7914059442469796" k="505.4272"/>
+    <Angle class1="s" class2="s6" class3="s" angle="1.9083430041306" k="507.10080000000005"/>
+    <Angle class1="ss" class2="s6" class3="ss" angle="1.7770942443806264" k="506.264"/>
+    <Angle class1="br" class2="sh" class3="hs" angle="1.6692328966073768" k="364.8448"/>
+    <Angle class1="c1" class2="sh" class3="hs" angle="1.6753415489893566" k="402.5008"/>
+    <Angle class1="c2" class2="sh" class3="hs" angle="1.6893041830053117" k="382.41760000000005"/>
+    <Angle class1="c3" class2="sh" class3="hs" angle="1.6824973989225336" k="372.37600000000003"/>
+    <Angle class1="ca" class2="sh" class3="hs" angle="1.6667894356545847" k="384.928"/>
+    <Angle class1="cc" class2="sh" class3="hs" angle="1.6582373223198124" k="388.2752"/>
+    <Angle class1="c" class2="sh" class3="hs" angle="1.6488125443590431" k="384.0912"/>
+    <Angle class1="f" class2="sh" class3="hs" angle="1.684242728174528" k="401.664"/>
+    <Angle class1="hs" class2="sh" class3="hs" angle="1.6231562043547263" k="312.1264"/>
+    <Angle class1="hs" class2="sh" class3="i" angle="1.6831955306233315" k="311.28960000000006"/>
+    <Angle class1="hs" class2="sh" class3="n1" angle="1.6320573835398977" k="431.78880000000004"/>
+    <Angle class1="hs" class2="sh" class3="n2" angle="1.6723744892609664" k="402.5008"/>
+    <Angle class1="hs" class2="sh" class3="n" angle="1.6683602319813795" k="404.1744"/>
+    <Angle class1="hs" class2="sh" class3="n3" angle="1.6751670160641576" k="401.664"/>
+    <Angle class1="hs" class2="sh" class3="n4" angle="1.625425132382319" k="394.13280000000003"/>
+    <Angle class1="hs" class2="sh" class3="na" angle="1.6996016255920778" k="401.664"/>
+    <Angle class1="hs" class2="sh" class3="nh" angle="1.7647024066914665" k="396.6432"/>
+    <Angle class1="hs" class2="sh" class3="no" angle="1.6219344738783303" k="395.8064"/>
+    <Angle class1="hs" class2="sh" class3="o" angle="1.9064231419534063" k="402.5008"/>
+    <Angle class1="hs" class2="sh" class3="oh" angle="1.7215927741672068" k="407.52160000000003"/>
+    <Angle class1="hs" class2="sh" class3="os" angle="1.7130406608324344" k="412.5424"/>
+    <Angle class1="hs" class2="sh" class3="p2" angle="1.7299703545767793" k="472.79200000000003"/>
+    <Angle class1="hs" class2="sh" class3="p3" angle="1.6721999563357672" k="444.3408"/>
+    <Angle class1="hs" class2="sh" class3="p4" angle="1.6444492212290571" k="451.872"/>
+    <Angle class1="hs" class2="sh" class3="p5" angle="1.6496852089850402" k="458.5664"/>
+    <Angle class1="hs" class2="sh" class3="s" angle="1.795420201526567" k="343.088"/>
+    <Angle class1="hs" class2="sh" class3="s4" angle="1.6084954386379742" k="352.2928"/>
+    <Angle class1="hs" class2="sh" class3="s6" angle="1.6376424371462794" k="358.98720000000003"/>
+    <Angle class1="hs" class2="sh" class3="sh" angle="1.7290976899507822" k="358.1504"/>
+    <Angle class1="hs" class2="sh" class3="ss" angle="1.7308430192027764" k="356.4768"/>
+    <Angle class1="br" class2="ss" class3="br" angle="1.7962928661525641" k="560.6560000000001"/>
+    <Angle class1="br" class2="ss" class3="c3" angle="1.7283995582499845" k="526.3472"/>
+    <Angle class1="c1" class2="ss" class3="c1" angle="1.715658654710426" k="551.4512000000001"/>
+    <Angle class1="c1" class2="ss" class3="c3" angle="1.777792376081424" k="517.1424"/>
+    <Angle class1="c2" class2="ss" class3="c2" angle="1.7376498032855545" k="533.0416"/>
+    <Angle class1="c2" class2="ss" class3="c3" angle="1.7517869702267086" k="514.6320000000001"/>
+    <Angle class1="c2" class2="ss" class3="cy" angle="1.557706357404939" k="543.9200000000001"/>
+    <Angle class1="c2" class2="ss" class3="n2" angle="1.8633135094291462" k="539.736"/>
+    <Angle class1="c2" class2="ss" class3="na" angle="1.7542304311795005" k="543.9200000000001"/>
+    <Angle class1="c2" class2="ss" class3="os" angle="1.5666075365901102" k="584.0864"/>
+    <Angle class1="c2" class2="ss" class3="ss" angle="1.6102407678899684" k="538.0624"/>
+    <Angle class1="c3" class2="ss" class3="c3" angle="1.7320647496791726" k="503.75360000000006"/>
+    <Angle class1="c3" class2="ss" class3="ca" angle="1.7819811662862104" k="504.5904"/>
+    <Angle class1="c3" class2="ss" class3="cc" angle="1.7564993592070932" k="511.2848"/>
+    <Angle class1="c3" class2="ss" class3="cd" angle="1.7564993592070932" k="511.2848"/>
+    <Angle class1="c3" class2="ss" class3="cl" angle="1.7348572764823638" k="470.2816"/>
+    <Angle class1="c3" class2="ss" class3="cy" angle="1.6447982870794562" k="515.4688"/>
+    <Angle class1="c3" class2="ss" class3="f" angle="1.701521487769272" k="527.184"/>
+    <Angle class1="c3" class2="ss" class3="i" angle="1.7453292519943295" k="468.608"/>
+    <Angle class1="c3" class2="ss" class3="n1" angle="1.718102115663218" k="548.104"/>
+    <Angle class1="c3" class2="ss" class3="n2" angle="1.6769123453161519" k="549.7776"/>
+    <Angle class1="c3" class2="ss" class3="n3" angle="1.7249088997459958" k="533.0416"/>
+    <Angle class1="c3" class2="ss" class3="n" angle="1.7505652397503124" k="528.8576"/>
+    <Angle class1="c3" class2="ss" class3="n4" angle="1.7067574755252548" k="523.8368"/>
+    <Angle class1="c3" class2="ss" class3="na" angle="1.6858135245013228" k="538.0624"/>
+    <Angle class1="c3" class2="ss" class3="nh" angle="1.7563248262818936" k="530.5312"/>
+    <Angle class1="c3" class2="ss" class3="no" angle="1.7212437083168077" k="519.6528000000001"/>
+    <Angle class1="c3" class2="ss" class3="o" angle="1.8673277667087331" k="538.8992000000001"/>
+    <Angle class1="c3" class2="ss" class3="oh" angle="1.7153095888600272" k="542.2464"/>
+    <Angle class1="c3" class2="ss" class3="os" angle="1.714087858383631" k="540.5728"/>
+    <Angle class1="c3" class2="ss" class3="p2" angle="1.7175785168876194" k="668.6032000000001"/>
+    <Angle class1="c3" class2="ss" class3="p3" angle="1.7226399717184033" k="635.9680000000001"/>
+    <Angle class1="c3" class2="ss" class3="p4" angle="1.7132151937576339" k="641.8256"/>
+    <Angle class1="c3" class2="ss" class3="p5" angle="1.746376449545526" k="632.6208"/>
+    <Angle class1="c3" class2="ss" class3="s4" angle="1.6819738001469353" k="501.2432"/>
+    <Angle class1="c3" class2="ss" class3="s" angle="1.7784905077822217" k="499.56960000000004"/>
+    <Angle class1="c3" class2="ss" class3="s6" angle="1.6887805842297132" k="508.7744"/>
+    <Angle class1="c3" class2="ss" class3="sh" angle="1.7790141065578202" k="502.9168"/>
+    <Angle class1="c3" class2="ss" class3="ss" angle="1.8044959136369374" k="498.73280000000005"/>
+    <Angle class1="ca" class2="ss" class3="ca" angle="1.7249088997459958" k="522.1632"/>
+    <Angle class1="ca" class2="ss" class3="cc" angle="1.5615460817593265" k="552.288"/>
+    <Angle class1="ca" class2="ss" class3="cd" angle="1.5615460817593265" k="552.288"/>
+    <Angle class1="ca" class2="ss" class3="cl" angle="1.76365520914027" k="471.9552"/>
+    <Angle class1="ca" class2="ss" class3="n" angle="1.5880750863896405" k="565.6768"/>
+    <Angle class1="ca" class2="ss" class3="na" angle="1.733461013080768" k="540.5728"/>
+    <Angle class1="ca" class2="ss" class3="nc" angle="1.6538739991898268" k="568.1872000000001"/>
+    <Angle class1="ca" class2="ss" class3="nd" angle="1.6538739991898268" k="568.1872000000001"/>
+    <Angle class1="ca" class2="ss" class3="ss" angle="1.8348646426216384" k="500.4064"/>
+    <Angle class1="c" class2="ss" class3="c2" angle="1.6132078276183588" k="543.0832"/>
+    <Angle class1="c" class2="ss" class3="c3" angle="1.7306684862775772" k="509.6112"/>
+    <Angle class1="c" class2="ss" class3="c" angle="1.7697638615222502" k="509.6112"/>
+    <Angle class1="c" class2="ss" class3="cc" angle="1.656142927217419" k="533.0416"/>
+    <Angle class1="cc" class2="ss" class3="cc" angle="1.574985116999683" k="553.9616000000001"/>
+    <Angle class1="cc" class2="ss" class3="cd" angle="1.5840608291100535" k="552.288"/>
+    <Angle class1="cc" class2="ss" class3="n" angle="1.6332791140162934" k="561.4928"/>
+    <Angle class1="cc" class2="ss" class3="na" angle="1.7336355460059676" k="543.9200000000001"/>
+    <Angle class1="cc" class2="ss" class3="nc" angle="1.6269959287091138" k="577.392"/>
+    <Angle class1="cc" class2="ss" class3="os" angle="1.724559833895597" k="553.1247999999999"/>
+    <Angle class1="cc" class2="ss" class3="ss" angle="1.637118838370681" k="531.368"/>
+    <Angle class1="cd" class2="ss" class3="cd" angle="1.574985116999683" k="553.9616000000001"/>
+    <Angle class1="cd" class2="ss" class3="n" angle="1.6332791140162934" k="561.4928"/>
+    <Angle class1="cd" class2="ss" class3="na" angle="1.7336355460059676" k="543.9200000000001"/>
+    <Angle class1="cd" class2="ss" class3="nd" angle="1.6269959287091138" k="577.392"/>
+    <Angle class1="cd" class2="ss" class3="os" angle="1.724559833895597" k="553.1247999999999"/>
+    <Angle class1="cd" class2="ss" class3="ss" angle="1.637118838370681" k="531.368"/>
+    <Angle class1="cl" class2="ss" class3="cl" angle="1.8041468477865386" k="438.4832"/>
+    <Angle class1="cx" class2="ss" class3="cx" angle="0.8429940287132611" k="725.5056000000001"/>
+    <Angle class1="f" class2="ss" class3="f" angle="1.715658654710426" k="553.9616000000001"/>
+    <Angle class1="f" class2="ss" class3="ss" angle="1.890191579909859" k="496.2224"/>
+    <Angle class1="i" class2="ss" class3="i" angle="1.8551104619447731" k="486.18080000000003"/>
+    <Angle class1="n1" class2="ss" class3="n1" angle="1.6922712427337019" k="611.7008"/>
+    <Angle class1="n2" class2="ss" class3="n2" angle="1.688606051304514" k="594.9648"/>
+    <Angle class1="n3" class2="ss" class3="n3" angle="1.786169956490997" k="555.6352"/>
+    <Angle class1="n4" class2="ss" class3="n4" angle="1.7660986700930619" k="531.368"/>
+    <Angle class1="na" class2="ss" class3="na" angle="1.79437300397537" k="551.4512000000001"/>
+    <Angle class1="nc" class2="ss" class3="nc" angle="1.7102481340292435" k="602.496"/>
+    <Angle class1="nd" class2="ss" class3="nd" angle="1.7102481340292435" k="602.496"/>
+    <Angle class1="nh" class2="ss" class3="nh" angle="1.8830357299766822" k="545.5936"/>
+    <Angle class1="n" class2="ss" class3="n" angle="1.7994344588061535" k="553.1247999999999"/>
+    <Angle class1="no" class2="ss" class3="no" angle="1.857553922897565" k="513.7952"/>
+    <Angle class1="oh" class2="ss" class3="oh" angle="1.8195057452040886" k="569.024"/>
+    <Angle class1="o" class2="ss" class3="o" angle="2.0821777976292353" k="595.8016"/>
+    <Angle class1="o" class2="ss" class3="p5" angle="1.857204857047166" k="658.5616"/>
+    <Angle class1="o" class2="ss" class3="s6" angle="1.8394024986768238" k="523.0"/>
+    <Angle class1="os" class2="ss" class3="os" angle="1.7975145966289598" k="567.3504"/>
+    <Angle class1="o" class2="ss" class3="ss" angle="1.9669860669976096" k="515.4688"/>
+    <Angle class1="p2" class2="ss" class3="p2" angle="1.7369516715847566" k="882.8240000000001"/>
+    <Angle class1="p3" class2="ss" class3="p3" angle="1.7744762505026348" k="810.0224000000001"/>
+    <Angle class1="p5" class2="ss" class3="p5" angle="1.5248941674674459" k="875.2927999999999"/>
+    <Angle class1="s4" class2="ss" class3="s4" angle="1.6769123453161519" k="509.6112"/>
+    <Angle class1="s4" class2="ss" class3="s6" angle="1.767320400569458" k="501.2432"/>
+    <Angle class1="s6" class2="ss" class3="s6" angle="1.776919711455427" k="506.264"/>
+    <Angle class1="sh" class2="ss" class3="sh" angle="1.876927077594702" k="504.5904"/>
+    <Angle class1="sh" class2="ss" class3="ss" angle="1.8592992521495593" k="506.264"/>
+    <Angle class1="s" class2="ss" class3="s" angle="2.007826771494277" k="482.83360000000005"/>
+    <Angle class1="ss" class2="ss" class3="ss" angle="1.88373386167748" k="502.08000000000004"/>
+    <Angle class1="c3" class2="sx" class3="ca" angle="1.68668618912732" k="512.1216000000001"/>
+    <Angle class1="c3" class2="sx" class3="cc" angle="1.661204382048203" k="517.9792"/>
+    <Angle class1="c3" class2="sx" class3="ce" angle="1.6631242442253968" k="517.1424"/>
+    <Angle class1="c3" class2="sx" class3="cf" angle="1.6631242442253968" k="517.1424"/>
+    <Angle class1="c3" class2="sx" class3="ne" angle="1.571843524346093" k="542.2464"/>
+    <Angle class1="c3" class2="sx" class3="nf" angle="1.571843524346093" k="542.2464"/>
+    <Angle class1="c3" class2="sx" class3="o" angle="1.876578011744303" k="536.3888"/>
+    <Angle class1="c3" class2="sx" class3="pe" angle="1.6461945504810513" k="640.9888"/>
+    <Angle class1="c3" class2="sx" class3="pf" angle="1.6461945504810513" k="640.9888"/>
+    <Angle class1="c3" class2="sx" class3="px" angle="1.6835445964737301" k="618.3952"/>
+    <Angle class1="c3" class2="sx" class3="py" angle="1.669756495382975" k="617.5584"/>
+    <Angle class1="c3" class2="sx" class3="sx" angle="1.596452666799213" k="476.976"/>
+    <Angle class1="c3" class2="sx" class3="sy" angle="1.6662658368789862" k="489.528"/>
+    <Angle class1="ca" class2="sx" class3="ca" angle="1.6711527587845703" k="517.1424"/>
+    <Angle class1="ca" class2="sx" class3="o" angle="1.8701202935119243" k="541.4096000000001"/>
+    <Angle class1="c" class2="sx" class3="c3" angle="1.6180947495239428" k="514.6320000000001"/>
+    <Angle class1="c" class2="sx" class3="c" angle="1.5158184553570753" k="525.5104"/>
+    <Angle class1="cc" class2="sx" class3="o" angle="1.829279589015257" k="550.6144"/>
+    <Angle class1="ce" class2="sx" class3="ce" angle="1.6573646576938152" k="521.3264"/>
+    <Angle class1="ce" class2="sx" class3="o" angle="1.888969849433463" k="539.736"/>
+    <Angle class1="cf" class2="sx" class3="cf" angle="1.6573646576938152" k="521.3264"/>
+    <Angle class1="cf" class2="sx" class3="o" angle="1.888969849433463" k="539.736"/>
+    <Angle class1="c" class2="sx" class3="o" angle="1.8530160668423798" k="530.5312"/>
+    <Angle class1="ne" class2="sx" class3="ne" angle="1.857902988747964" k="511.2848"/>
+    <Angle class1="ne" class2="sx" class3="o" angle="1.9165460516149735" k="544.7568"/>
+    <Angle class1="nf" class2="sx" class3="nf" angle="1.857902988747964" k="511.2848"/>
+    <Angle class1="nf" class2="sx" class3="o" angle="1.9165460516149735" k="544.7568"/>
+    <Angle class1="o" class2="sx" class3="pe" angle="1.857553922897565" k="644.336"/>
+    <Angle class1="o" class2="sx" class3="pf" angle="1.857553922897565" k="644.336"/>
+    <Angle class1="o" class2="sx" class3="px" angle="1.8285814573144588" k="629.2736000000001"/>
+    <Angle class1="o" class2="sx" class3="py" angle="1.9046778127014117" k="611.7008"/>
+    <Angle class1="o" class2="sx" class3="sx" angle="1.826487062212066" k="466.09760000000006"/>
+    <Angle class1="o" class2="sx" class3="sy" angle="1.804844979487336" k="497.05920000000003"/>
+    <Angle class1="pe" class2="sx" class3="pe" angle="1.616523953197148" k="830.1056000000001"/>
+    <Angle class1="pf" class2="sx" class3="pf" angle="1.616523953197148" k="830.1056000000001"/>
+    <Angle class1="py" class2="sx" class3="py" angle="1.2082914411556744" k="921.3168"/>
+    <Angle class1="sx" class2="sx" class3="sx" angle="1.4817845349431857" k="490.36480000000006"/>
+    <Angle class1="sy" class2="sx" class3="sy" angle="1.632231916465097" k="495.38560000000007"/>
+    <Angle class1="c3" class2="sy" class3="ca" angle="1.8139206915977066" k="502.9168"/>
+    <Angle class1="c3" class2="sy" class3="cc" angle="1.7793631724082188" k="508.7744"/>
+    <Angle class1="c3" class2="sy" class3="ce" angle="1.8069393745897293" k="504.5904"/>
+    <Angle class1="c3" class2="sy" class3="cf" angle="1.8069393745897293" k="504.5904"/>
+    <Angle class1="c3" class2="sy" class3="ne" angle="1.7835519626130052" k="536.3888"/>
+    <Angle class1="c3" class2="sy" class3="nf" angle="1.7835519626130052" k="536.3888"/>
+    <Angle class1="c3" class2="sy" class3="o" angle="1.8823375982758843" k="547.2672000000001"/>
+    <Angle class1="c3" class2="sy" class3="pe" angle="1.8505726058895877" k="598.312"/>
+    <Angle class1="c3" class2="sy" class3="pf" angle="1.8505726058895877" k="598.312"/>
+    <Angle class1="c3" class2="sy" class3="px" angle="1.808510170916524" k="598.312"/>
+    <Angle class1="c3" class2="sy" class3="py" angle="1.8044959136369374" k="612.5376"/>
+    <Angle class1="c3" class2="sy" class3="sx" angle="1.8263125292868665" k="469.44480000000004"/>
+    <Angle class1="c3" class2="sy" class3="sy" angle="1.7589428201598853" k="478.6496"/>
+    <Angle class1="ca" class2="sy" class3="ca" angle="1.8228218707828776" k="504.5904"/>
+    <Angle class1="ca" class2="sy" class3="cc" angle="1.834166510920841" k="503.75360000000006"/>
+    <Angle class1="ca" class2="sy" class3="n3" angle="1.7879152857429912" k="535.552"/>
+    <Angle class1="ca" class2="sy" class3="n" angle="1.839053432826425" k="525.5104"/>
+    <Angle class1="ca" class2="sy" class3="ne" angle="1.797863662479359" k="537.2256000000001"/>
+    <Angle class1="ca" class2="sy" class3="nh" angle="1.8413223608540177" k="525.5104"/>
+    <Angle class1="ca" class2="sy" class3="o" angle="1.891064244535856" k="550.6144"/>
+    <Angle class1="ca" class2="sy" class3="oh" angle="1.7680185322702555" k="548.104"/>
+    <Angle class1="ca" class2="sy" class3="os" angle="1.6228071385043277" k="564.84"/>
+    <Angle class1="c" class2="sy" class3="c3" angle="1.7671458676442584" k="499.56960000000004"/>
+    <Angle class1="c" class2="sy" class3="c" angle="1.7420131264155405" k="495.38560000000007"/>
+    <Angle class1="cc" class2="sy" class3="n3" angle="1.789486082069786" k="536.3888"/>
+    <Angle class1="cc" class2="sy" class3="o" angle="1.8830357299766822" k="553.1247999999999"/>
+    <Angle class1="cd" class2="sy" class3="n3" angle="1.789486082069786" k="536.3888"/>
+    <Angle class1="cd" class2="sy" class3="nh" angle="1.6964600329384885" k="548.104"/>
+    <Angle class1="cd" class2="sy" class3="o" angle="1.8830357299766822" k="553.1247999999999"/>
+    <Angle class1="ce" class2="sy" class3="ce" angle="1.7938494051997718" k="509.6112"/>
+    <Angle class1="ce" class2="sy" class3="o" angle="1.8915878433114541" k="550.6144"/>
+    <Angle class1="cf" class2="sy" class3="cf" angle="1.7938494051997718" k="509.6112"/>
+    <Angle class1="cf" class2="sy" class3="o" angle="1.8915878433114541" k="550.6144"/>
+    <Angle class1="c" class2="sy" class3="o" angle="1.8758798800435055" k="535.552"/>
+    <Angle class1="f" class2="sy" class3="o" angle="1.8425440913304136" k="168.19680000000002"/>
+    <Angle class1="n2" class2="sy" class3="o" angle="2.1560052249885953" k="582.4128"/>
+    <Angle class1="n3" class2="sy" class3="ne" angle="1.7790141065578202" k="569.8607999999999"/>
+    <Angle class1="n3" class2="sy" class3="o" angle="1.8697712276615253" k="589.1072"/>
+    <Angle class1="na" class2="sy" class3="na" angle="1.7111207986552408" k="566.5136"/>
+    <Angle class1="nc" class2="sy" class3="nc" angle="1.7111207986552408" k="629.2736000000001"/>
+    <Angle class1="nd" class2="sy" class3="nd" angle="1.7111207986552408" k="629.2736000000001"/>
+    <Angle class1="ne" class2="sy" class3="ne" angle="1.7212437083168077" k="584.0864"/>
+    <Angle class1="ne" class2="sy" class3="o" angle="1.9137535248117823" k="588.2704"/>
+    <Angle class1="nf" class2="sy" class3="nf" angle="1.7212437083168077" k="584.0864"/>
+    <Angle class1="nf" class2="sy" class3="o" angle="1.9137535248117823" k="588.2704"/>
+    <Angle class1="nh" class2="sy" class3="o" angle="1.8540632643935762" k="587.4336000000001"/>
+    <Angle class1="n" class2="sy" class3="o" angle="1.876927077594702" k="583.2496000000001"/>
+    <Angle class1="o" class2="sy" class3="o" angle="2.1190042448463156" k="606.6800000000001"/>
+    <Angle class1="o" class2="sy" class3="oh" angle="1.8619172460275508" k="605.0064"/>
+    <Angle class1="o" class2="sy" class3="os" angle="1.876578011744303" k="590.7808"/>
+    <Angle class1="o" class2="sy" class3="pe" angle="1.8657569703819383" k="630.9472000000001"/>
+    <Angle class1="o" class2="sy" class3="pf" angle="1.8657569703819383" k="630.9472000000001"/>
+    <Angle class1="o" class2="sy" class3="px" angle="1.8530160668423798" k="623.416"/>
+    <Angle class1="o" class2="sy" class3="py" angle="1.8617427131023514" k="640.152"/>
+    <Angle class1="o" class2="sy" class3="sx" angle="1.8558085936455706" k="490.36480000000006"/>
+    <Angle class1="o" class2="sy" class3="sy" angle="1.8533651326927785" k="492.03839999999997"/>
+    <Angle class1="py" class2="sy" class3="py" angle="1.8236945354088747" k="776.5504"/>
+    <Angle class1="sx" class2="sy" class3="sx" angle="1.7800613041090168" k="474.46560000000005"/>
+    <Angle class1="sy" class2="sy" class3="sy" angle="1.802750584384943" k="472.79200000000003"/>
+    <Angle class1="c2" class2="c1" class3="cf" angle="3.125012025695847" k="487.0176"/>
+    <Angle class1="c3" class2="c1" class3="ch" angle="3.114190984333482" k="467.7712"/>
+    <Angle class1="nf" class2="c1" class3="s" angle="3.06863789085643" k="488.6912"/>
+    <Angle class1="br" class2="c2" class3="cf" angle="2.1210986399487086" k="526.3472"/>
+    <Angle class1="cd" class2="c2" class3="h4" angle="2.091777108515204" k="412.5424"/>
+    <Angle class1="cd" class2="c2" class3="nh" angle="2.1488493750554185" k="574.0448"/>
+    <Angle class1="cd" class2="c2" class3="o" angle="2.157052422539792" k="609.1904"/>
+    <Angle class1="cf" class2="c2" class3="cl" angle="2.1549580274373983" k="484.5072"/>
+    <Angle class1="cf" class2="c2" class3="h4" angle="2.1347122081142644" k="410.8688"/>
+    <Angle class1="cf" class2="c2" class3="na" angle="2.167175332201359" k="570.6976000000001"/>
+    <Angle class1="cf" class2="c2" class3="nh" angle="2.106786940082355" k="582.4128"/>
+    <Angle class1="cf" class2="c2" class3="no" angle="2.0882864500112155" k="570.6976000000001"/>
+    <Angle class1="cf" class2="c2" class3="o" angle="2.1532126981854045" k="613.3744"/>
+    <Angle class1="cf" class2="c2" class3="oh" angle="2.149023907980618" k="590.7808"/>
+    <Angle class1="cf" class2="c2" class3="os" angle="2.1432643214490366" k="586.5968"/>
+    <Angle class1="h4" class2="c2" class3="nf" angle="2.085842989058423" k="439.32"/>
+    <Angle class1="h5" class2="c2" class3="nf" angle="2.091777108515204" k="438.4832"/>
+    <Angle class1="nf" class2="c2" class3="os" angle="2.0727530196684656" k="623.416"/>
+    <Angle class1="nf" class2="c2" class3="ss" angle="2.1032962815783667" k="545.5936"/>
+    <Angle class1="n" class2="c2" class3="nf" angle="2.1875956844496924" k="593.2912000000001"/>
+    <Angle class1="ca" class2="c3" class3="cf" angle="1.958433953662837" k="532.2048"/>
+    <Angle class1="cd" class2="c3" class3="cx" angle="1.9617500792416265" k="533.0416"/>
+    <Angle class1="c" class2="c3" class3="cf" angle="1.9528489000564555" k="531.368"/>
+    <Angle class1="cd" class2="c3" class3="hx" angle="1.9374900026389053" k="394.13280000000003"/>
+    <Angle class1="cd" class2="c3" class3="n2" angle="1.925272697874945" k="561.4928"/>
+    <Angle class1="cd" class2="c3" class3="n4" angle="2.017251549455046" k="540.5728"/>
+    <Angle class1="cd" class2="c3" class3="na" angle="1.974840048631584" k="554.7984"/>
+    <Angle class1="cd" class2="c3" class3="p5" angle="2.028596189593009" k="635.9680000000001"/>
+    <Angle class1="cf" class2="c3" class3="cf" angle="1.9455185171980791" k="533.8783999999999"/>
+    <Angle class1="cf" class2="c3" class3="n" angle="1.9237019015481498" k="558.9824"/>
+    <Angle class1="cf" class2="c3" class3="oh" angle="1.940631595292495" k="566.5136"/>
+    <Angle class1="cf" class2="c3" class3="os" angle="1.911135530933791" k="569.8607999999999"/>
+    <Angle class1="cf" class2="c3" class3="ss" angle="1.9324285478081218" k="513.7952"/>
+    <Angle class1="cd" class2="ca" class3="cq" angle="2.1694442602289516" k="535.552"/>
+    <Angle class1="cf" class2="ca" class3="na" angle="2.0929988389916" k="557.3088"/>
+    <Angle class1="ch" class2="ca" class3="cq" angle="2.1210986399487086" k="545.5936"/>
+    <Angle class1="cl" class2="ca" class3="cq" angle="2.101201886475973" k="481.9968"/>
+    <Angle class1="cq" class2="ca" class3="f" angle="2.0842721927316283" k="558.9824"/>
+    <Angle class1="cq" class2="ca" class3="h4" angle="2.0959658987199905" k="400.8272"/>
+    <Angle class1="cq" class2="ca" class3="na" angle="1.898743693244631" k="601.6592"/>
+    <Angle class1="cq" class2="ca" class3="nb" angle="2.1568778896145924" k="573.208"/>
+    <Angle class1="cq" class2="ca" class3="nh" angle="2.121622238724307" k="568.1872000000001"/>
+    <Angle class1="cq" class2="ca" class3="oh" angle="2.109230401035147" k="577.392"/>
+    <Angle class1="cq" class2="ca" class3="ss" angle="1.9402825294420962" k="534.7152"/>
+    <Angle class1="ca" class2="c" class3="nf" angle="2.002067184962695" k="565.6768"/>
+    <Angle class1="br" class2="cd" class3="c" angle="2.0294688542190062" k="533.8783999999999"/>
+    <Angle class1="br" class2="cd" class3="cd" angle="2.1650809370989657" k="518.816"/>
+    <Angle class1="br" class2="cd" class3="cc" angle="2.1682225297525557" k="521.3264"/>
+    <Angle class1="br" class2="cd" class3="na" angle="2.1219713045747057" k="539.736"/>
+    <Angle class1="ca" class2="cd" class3="cf" angle="2.2167426829579977" k="520.4896"/>
+    <Angle class1="ca" class2="cd" class3="nh" angle="2.131570615460675" k="558.9824"/>
+    <Angle class1="cd" class2="c" class3="cf" angle="2.0170770165298464" k="538.8992000000001"/>
+    <Angle class1="cd" class2="cd" class3="f" angle="2.080257935452041" k="555.6352"/>
+    <Angle class1="c" class2="cd" class3="ch" angle="2.0573941222509156" k="543.9200000000001"/>
+    <Angle class1="cd" class2="cd" class3="sy" angle="2.238384765682728" k="495.38560000000007"/>
+    <Angle class1="cc" class2="cd" class3="f" angle="2.115164520491928" k="563.1664"/>
+    <Angle class1="cc" class2="cd" class3="no" angle="2.2460642143915024" k="549.7776"/>
+    <Angle class1="c" class2="cd" class3="f" angle="2.0416861589829667" k="552.288"/>
+    <Angle class1="ch" class2="cd" class3="na" angle="2.139948195870247" k="563.1664"/>
+    <Angle class1="ch" class2="cd" class3="ss" angle="2.107136005932754" k="517.1424"/>
+    <Angle class1="cd" class2="c" class3="h4" angle="2.0041615800650887" k="394.13280000000003"/>
+    <Angle class1="cl" class2="cd" class3="na" angle="2.1139427900155323" k="497.05920000000003"/>
+    <Angle class1="cl" class2="cd" class3="ss" angle="2.091777108515204" k="483.6704"/>
+    <Angle class1="c" class2="cd" class3="nf" angle="2.092300707290802" k="560.6560000000001"/>
+    <Angle class1="cd" class2="c" class3="s" angle="2.2040017794184394" k="519.6528000000001"/>
+    <Angle class1="cd" class2="c" class3="ss" angle="1.9617500792416265" k="522.1632"/>
+    <Angle class1="cx" class2="cd" class3="nc" angle="2.0910789768144062" k="567.3504"/>
+    <Angle class1="cx" class2="cd" class3="os" angle="2.0607102478297046" k="569.8607999999999"/>
+    <Angle class1="cc" class2="c" class3="cx" angle="2.052332667420132" k="529.6944"/>
+    <Angle class1="cc" class2="c" class3="nc" angle="1.9853120241435498" k="574.0448"/>
+    <Angle class1="cf" class2="c" class3="cx" angle="2.057917721026514" k="527.184"/>
+    <Angle class1="cf" class2="c" class3="h4" angle="2.0052087776162852" k="390.78560000000004"/>
+    <Angle class1="cf" class2="c" class3="ss" angle="1.9284142905285344" k="525.5104"/>
+    <Angle class1="na" class2="cd" class3="no" angle="2.1745057150597353" k="571.5344"/>
+    <Angle class1="na" class2="cd" class3="oh" angle="2.0504128052429382" k="610.0272000000001"/>
+    <Angle class1="na" class2="cd" class3="sx" angle="2.0423842906837644" k="528.8576"/>
+    <Angle class1="na" class2="cd" class3="sy" angle="2.102423616952369" k="528.0208"/>
+    <Angle class1="nd" class2="cd" class3="no" angle="2.1245892984526975" k="579.9024"/>
+    <Angle class1="nc" class2="cd" class3="nc" angle="2.2352431730291378" k="601.6592"/>
+    <Angle class1="nc" class2="cd" class3="nf" angle="2.2516492679978843" k="584.9232000000001"/>
+    <Angle class1="nc" class2="cd" class3="no" angle="2.1423916568230394" k="587.4336000000001"/>
+    <Angle class1="nc" class2="cd" class3="sh" angle="2.181137966217314" k="525.5104"/>
+    <Angle class1="nc" class2="cd" class3="sx" angle="2.2294835864975564" k="509.6112"/>
+    <Angle class1="nc" class2="cd" class3="sy" angle="2.1472785787286237" k="526.3472"/>
+    <Angle class1="nf" class2="cd" class3="ss" angle="2.042558823608964" k="542.2464"/>
+    <Angle class1="n" class2="cd" class3="n2" angle="2.0842721927316283" k="612.5376"/>
+    <Angle class1="no" class2="cd" class3="os" angle="2.051634535719334" k="594.9648"/>
+    <Angle class1="no" class2="cd" class3="ss" angle="2.1128955924643353" k="528.8576"/>
+    <Angle class1="ca" class2="cc" class3="cf" angle="2.179916235740918" k="540.5728"/>
+    <Angle class1="ca" class2="cc" class3="na" angle="2.154608961587" k="554.7984"/>
+    <Angle class1="cd" class2="cc" class3="cg" angle="2.1954496660836673" k="543.9200000000001"/>
+    <Angle class1="cd" class2="cc" class3="cy" angle="2.1237166338267004" k="538.0624"/>
+    <Angle class1="cd" class2="cc" class3="nd" angle="2.1610666798193785" k="584.0864"/>
+    <Angle class1="cc" class2="cc" class3="cy" angle="2.1710150565557464" k="523.8368"/>
+    <Angle class1="cf" class2="cc" class3="nc" angle="2.1638592066225697" k="574.8816"/>
+    <Angle class1="c" class2="cc" class3="h4" angle="2.062804642932098" k="389.9488"/>
+    <Angle class1="na" class2="cc" class3="nh" angle="2.04692214673895" k="600.8224"/>
+    <Angle class1="na" class2="cc" class3="ss" angle="1.9453439842728797" k="555.6352"/>
+    <Angle class1="nc" class2="cc" class3="nc" angle="2.193878869756872" k="584.0864"/>
+    <Angle class1="oh" class2="cc" class3="os" angle="1.947961978150871" k="633.4576000000001"/>
+    <Angle class1="c2" class2="cf" class3="cl" angle="2.090206312188409" k="483.6704"/>
+    <Angle class1="c2" class2="cf" class3="h4" angle="2.173807583358937" k="406.68480000000005"/>
+    <Angle class1="c2" class2="cf" class3="n1" angle="2.0635027746328958" k="605.0064"/>
+    <Angle class1="c2" class2="cf" class3="na" angle="2.080257935452041" k="578.2288"/>
+    <Angle class1="c2" class2="cf" class3="oh" angle="2.158972284716986" k="586.5968"/>
+    <Angle class1="c3" class2="cf" class3="ch" angle="2.0458749491877533" k="535.552"/>
+    <Angle class1="c3" class2="cf" class3="ne" angle="2.106263341306757" k="559.8192"/>
+    <Angle class1="c3" class2="cf" class3="nh" angle="2.0867156536844202" k="548.9408"/>
+    <Angle class1="ca" class2="cf" class3="cf" angle="2.086366587834022" k="532.2048"/>
+    <Angle class1="ca" class2="cf" class3="cl" angle="1.9999727898603024" k="484.5072"/>
+    <Angle class1="ca" class2="cf" class3="h4" angle="2.0418606919081657" k="389.9488"/>
+    <Angle class1="ca" class2="cf" class3="nh" angle="2.017251549455046" k="566.5136"/>
+    <Angle class1="ca" class2="cf" class3="os" angle="2.0230111359866276" k="572.3712"/>
+    <Angle class1="ca" class2="cf" class3="ss" angle="2.051110936943736" k="514.6320000000001"/>
+    <Angle class1="c" class2="cf" class3="ca" angle="2.064375439258893" k="530.5312"/>
+    <Angle class1="cd" class2="cf" class3="cc" angle="2.279574536029794" k="528.8576"/>
+    <Angle class1="c" class2="cf" class3="cf" angle="2.11149932906274" k="528.0208"/>
+    <Angle class1="c" class2="cf" class3="ch" angle="2.0668189002116852" k="538.8992000000001"/>
+    <Angle class1="cd" class2="cf" class3="h4" angle="2.0189968787070405" k="396.6432"/>
+    <Angle class1="c" class2="cf" class3="cl" angle="2.015331687277852" k="481.9968"/>
+    <Angle class1="cd" class2="cf" class3="nh" angle="2.0603611819793057" k="565.6768"/>
+    <Angle class1="c" class2="cf" class3="cy" angle="1.543569190463785" k="605.8432"/>
+    <Angle class1="cf" class2="cf" class3="cl" angle="2.0458749491877533" k="481.16"/>
+    <Angle class1="cf" class2="cf" class3="oh" angle="2.0394172309553737" k="578.2288"/>
+    <Angle class1="ce" class2="cf" class3="cy" angle="2.401223984893799" k="504.5904"/>
+    <Angle class1="ce" class2="cf" class3="h4" angle="2.1458823153270283" k="408.3584"/>
+    <Angle class1="ce" class2="cf" class3="n1" angle="2.0933479048419987" k="599.9856000000001"/>
+    <Angle class1="ce" class2="cf" class3="nh" angle="2.1184806460707173" k="579.0656"/>
+    <Angle class1="ch" class2="cf" class3="n2" angle="2.1142918558659307" k="582.4128"/>
+    <Angle class1="c" class2="cf" class3="oh" angle="2.020393142108636" k="574.8816"/>
+    <Angle class1="c" class2="cf" class3="os" angle="2.0013690532618975" k="574.0448"/>
+    <Angle class1="h4" class2="cf" class3="n1" angle="2.035752039526186" k="439.32"/>
+    <Angle class1="h4" class2="cf" class3="nf" angle="2.018473279931442" k="420.9104"/>
+    <Angle class1="n2" class2="cf" class3="os" angle="2.0586158527273115" k="623.416"/>
+    <Angle class1="n2" class2="cf" class3="ss" angle="2.0460494821129527" k="541.4096000000001"/>
+    <Angle class1="nf" class2="cf" class3="nh" angle="1.983392161966356" k="604.1696000000001"/>
+    <Angle class1="ne" class2="cf" class3="nh" angle="2.0816541988536366" k="609.1904"/>
+    <Angle class1="ca" class2="ce" class3="cd" angle="2.2842869250101785" k="523.8368"/>
+    <Angle class1="c" class2="ce" class3="cc" angle="2.056346924699719" k="535.552"/>
+    <Angle class1="c" class2="ce" class3="n2" angle="1.9968311972067123" k="584.9232000000001"/>
+    <Angle class1="h4" class2="ce" class3="nf" angle="2.104168946204364" k="435.9728"/>
+    <Angle class1="c1" class2="ch" class3="cd" angle="3.117332576987072" k="476.976"/>
+    <Angle class1="ch" class2="cg" class3="cg" angle="3.1342622707314174" k="491.20160000000004"/>
+    <Angle class1="n" class2="c" class3="nf" angle="1.924400033248948" k="616.7216000000001"/>
+    <Angle class1="ca" class2="cq" class3="na" angle="2.0856684561332237" k="574.0448"/>
+    <Angle class1="nb" class2="cq" class3="nb" angle="2.1954496660836673" k="596.6384"/>
+    <Angle class1="cd" class2="cx" class3="hc" angle="1.995434933805117" k="393.296"/>
+    <Angle class1="cf" class2="cy" class3="h2" angle="2.049016541841343" k="379.9072"/>
+    <Angle class1="cf" class2="cy" class3="n" angle="1.5348425442038134" k="625.0896"/>
+    <Angle class1="cf" class2="cy" class3="ss" angle="2.103819880353965" k="490.36480000000006"/>
+    <Angle class1="cd" class2="n2" class3="na" angle="1.9065976748786053" k="610.864"/>
+    <Angle class1="cd" class2="n2" class3="nh" angle="2.067691564837682" k="589.9440000000001"/>
+    <Angle class1="c3" class2="n4" class3="cd" angle="1.9380136014145035" k="523.8368"/>
+    <Angle class1="c3" class2="na" class3="cq" angle="2.087762851235617" k="531.368"/>
+    <Angle class1="ca" class2="na" class3="cq" angle="2.109404933960347" k="544.7568"/>
+    <Angle class1="cd" class2="na" class3="cf" angle="2.2097613659500204" k="526.3472"/>
+    <Angle class1="cq" class2="nb" class3="nb" angle="2.1111502632123407" k="578.2288"/>
+    <Angle class1="c" class2="n" class3="cf" angle="2.29301357127015" k="515.4688"/>
+    <Angle class1="ca" class2="nc" class3="nd" angle="1.8908897116106567" k="615.048"/>
+    <Angle class1="c2" class2="nf" class3="ch" angle="2.150769237232612" k="570.6976000000001"/>
+    <Angle class1="c" class2="nf" class3="sy" angle="2.032086848096998" k="533.8783999999999"/>
+    <Angle class1="c3" class2="nh" class3="ce" angle="2.0964894974955888" k="529.6944"/>
+    <Angle class1="cd" class2="nh" class3="n2" angle="2.0959658987199905" k="569.024"/>
+    <Angle class1="cd" class2="nh" class3="sy" angle="2.1383773995434523" k="512.1216000000001"/>
+    <Angle class1="cf" class2="nh" class3="sy" angle="1.9790288388363704" k="531.368"/>
+    <Angle class1="hn" class2="n" class3="nd" angle="2.014459022651855" k="423.42080000000004"/>
+    <Angle class1="cd" class2="no" class3="o" angle="2.0505873381681377" k="586.5968"/>
+    <Angle class1="n3" class2="py" class3="nf" angle="1.8982200944690328" k="352.2928"/>
+    <Angle class1="cd" class2="s6" class3="o" angle="1.8109536318693162" k="558.1456000000001"/>
+    <Angle class1="cd" class2="sh" class3="hs" angle="1.6582373223198124" k="388.2752"/>
+    <Angle class1="c" class2="ss" class3="cd" angle="1.656142927217419" k="533.0416"/>
+    <Angle class1="c3" class2="sx" class3="cd" angle="1.661204382048203" k="517.9792"/>
+    <Angle class1="cd" class2="sx" class3="o" angle="1.829279589015257" k="550.6144"/>
+    <Angle class1="c3" class2="sy" class3="cd" angle="1.7793631724082188" k="508.7744"/>
+    <Angle class1="ca" class2="sy" class3="cd" angle="1.834166510920841" k="503.75360000000006"/>
+    <Angle class1="ca" class2="sy" class3="nf" angle="1.797863662479359" k="537.2256000000001"/>
+    <Angle class1="cc" class2="sy" class3="nh" angle="1.6964600329384885" k="548.104"/>
+    <Angle class1="n3" class2="sy" class3="nf" angle="1.7790141065578202" k="569.8607999999999"/>
+    <Angle class1="cl" class2="py" class3="ne" angle="1.9052014114770102" k="301.248"/>
+    <Angle class1="ce" class2="ce" class3="nh" angle="2.031737782246599" k="569.024"/>
+    <Angle class1="cp" class2="ca" class3="os" angle="2.0404644285065707" k="586.5968"/>
+    <Angle class1="ca" class2="cc" class3="ca" angle="2.145707782401829" k="528.8576"/>
+    <Angle class1="h1" class2="c3" class3="i" angle="1.8130480269717095" k="316.3104"/>
+    <Angle class1="h4" class2="c2" class3="h4" angle="2.0580922539517132" k="317.98400000000004"/>
+    <Angle class1="c" class2="ss" class3="ss" angle="1.7048376133480614" k="517.1424"/>
+    <Angle class1="f" class2="py" class3="ne" angle="1.8954275676658416" k="351.456"/>
+    <Angle class1="ca" class2="nh" class3="ce" angle="2.2294835864975564" k="528.8576"/>
+    <Angle class1="ce" class2="cx" class3="cx" angle="2.0703095587156737" k="520.4896"/>
+    <Angle class1="py" class2="ne" class3="py" angle="2.1190042448463156" k="879.4768"/>
+    <Angle class1="c" class2="cd" class3="ss" angle="2.1287780886574836" k="510.44800000000004"/>
+    <Angle class1="s" class2="p5" class3="ss" angle="2.036275638301784" k="307.94239999999996"/>
+    <Angle class1="cx" class2="c3" class3="nh" angle="1.8126989611213105" k="574.8816"/>
+    <Angle class1="cc" class2="cc" class3="cl" angle="2.094220569467996" k="483.6704"/>
+    <Angle class1="cd" class2="na" class3="cx" angle="2.0313887163962" k="539.736"/>
+    <Angle class1="h1" class2="cy" class3="nh" angle="1.9198621771937625" k="419.2368"/>
+    <Angle class1="h5" class2="c" class3="os" angle="1.9737928510803873" k="435.9728"/>
+    <Angle class1="c2" class2="c3" class3="n4" angle="1.983392161966356" k="543.0832"/>
+    <Angle class1="c2" class2="cx" class3="c3" angle="2.0155062202030516" k="528.0208"/>
+    <Angle class1="c3" class2="c2" class3="cx" angle="2.057219589325716" k="525.5104"/>
+    <Angle class1="br" class2="cx" class3="cx" angle="2.0776399415740503" k="512.9584"/>
+    <Angle class1="cc" class2="cf" class3="ch" angle="2.1340140764134667" k="552.288"/>
+    <Angle class1="c3" class2="c3" class3="sx" angle="1.9285888234537343" k="512.1216000000001"/>
+    <Angle class1="ca" class2="cy" class3="hc" angle="1.9989255923091056" k="384.928"/>
+    <Angle class1="cx" class2="c1" class3="n1" angle="3.1110493916798925" k="492.03839999999997"/>
+    <Angle class1="cl" class2="py" class3="cl" angle="1.7793631724082188" k="279.4912"/>
+    <Angle class1="c2" class2="ce" class3="cx" angle="2.14221712389784" k="538.0624"/>
+    <Angle class1="c3" class2="c" class3="cx" angle="2.02528006401422" k="523.8368"/>
+    <Angle class1="cf" class2="cc" class3="os" angle="2.147976710429421" k="581.576"/>
+    <Angle class1="cd" class2="cd" class3="cl" angle="2.094220569467996" k="483.6704"/>
+    <Angle class1="c3" class2="py" class3="ca" angle="1.8722146886143172" k="305.432"/>
+    <Angle class1="c3" class2="c3" class3="py" angle="1.9472638464500733" k="645.1727999999999"/>
+    <Angle class1="c3" class2="py" class3="s" angle="1.9870573533955442" k="306.2688"/>
+    <Angle class1="ca" class2="c" class3="cx" angle="2.053554397896528" k="526.3472"/>
+    <Angle class1="ce" class2="ce" class3="os" angle="2.0104447653722683" k="579.0656"/>
+    <Angle class1="c3" class2="n4" class3="cx" angle="2.047096679664149" k="509.6112"/>
+    <Angle class1="h4" class2="ce" class3="sy" angle="2.007128639793479" k="353.12960000000004"/>
+    <Angle class1="hx" class2="cy" class3="n4" angle="1.8500490071139892" k="410.03200000000004"/>
+    <Angle class1="cy" class2="no" class3="o" angle="2.039068165104975" k="563.1664"/>
+    <Angle class1="cc" class2="cd" class3="cx" angle="2.1668262663509603" k="535.552"/>
+    <Angle class1="ca" class2="nb" class3="na" angle="2.0731020855188644" k="579.9024"/>
+    <Angle class1="cl" class2="c3" class3="cy" angle="1.9528489000564555" k="512.9584"/>
+    <Angle class1="f" class2="c2" class3="h4" angle="1.9556414268596463" k="425.0944"/>
+    <Angle class1="ca" class2="py" class3="s" angle="2.029992452994605" k="304.5952"/>
+    <Angle class1="cl" class2="c3" class3="cx" angle="1.9331266795089195" k="517.1424"/>
+    <Angle class1="ca" class2="nh" class3="cy" angle="2.1608921468941795" k="525.5104"/>
+    <Angle class1="cy" class2="cy" class3="no" angle="2.0146335555770545" k="528.8576"/>
+    <Angle class1="ce" class2="n1" class3="n1" angle="3.1000538173923284" k="515.4688"/>
+    <Angle class1="cy" class2="cy" class3="hx" angle="2.0231856689118266" k="373.2128"/>
+    <Angle class1="ce" class2="n" class3="hn" angle="1.9867082875451454" k="399.15360000000004"/>
+    <Angle class1="c3" class2="cx" class3="cu" angle="2.110277598586344" k="518.816"/>
+    <Angle class1="cf" class2="cf" class3="ne" angle="2.1081832034839505" k="574.0448"/>
+    <Angle class1="f" class2="p5" class3="na" angle="1.5578808903301387" k="373.2128"/>
+    <Angle class1="ce" class2="no" class3="o" angle="2.0633282417076964" k="173.2176"/>
+    <Angle class1="h4" class2="ce" class3="nh" angle="2.017251549455046" k="422.584"/>
+    <Angle class1="ne" class2="c" class3="s" angle="2.1682225297525557" k="545.5936"/>
+    <Angle class1="ca" class2="os" class3="py" angle="2.1521655006342075" k="648.52"/>
+    <Angle class1="cf" class2="ce" class3="cl" angle="2.1282544898818854" k="479.4864"/>
+    <Angle class1="cy" class2="cy" class3="n4" angle="1.9352210746113125" k="540.5728"/>
+    <Angle class1="na" class2="cc" class3="sh" angle="2.1458823153270283" k="525.5104"/>
+    <Angle class1="nb" class2="na" class3="o" angle="2.0617574453809016" k="620.9056"/>
+    <Angle class1="c" class2="cx" class3="n3" angle="2.031039650545801" k="549.7776"/>
+    <Angle class1="cd" class2="cy" class3="hc" angle="1.8709929581379214" k="399.99039999999997"/>
+    <Angle class1="f" class2="c3" class3="no" angle="1.8807668019490895" k="571.5344"/>
+    <Angle class1="ce" class2="cd" class3="na" angle="2.1804398345165157" k="569.8607999999999"/>
+    <Angle class1="cq" class2="cp" class3="cq" angle="1.8853046580042745" k="564.84"/>
+    <Angle class1="os" class2="py" class3="s" angle="2.0284216566678097" k="326.35200000000003"/>
+    <Angle class1="c" class2="c3" class3="cy" angle="1.9352210746113125" k="530.5312"/>
+    <Angle class1="cy" class2="c2" class3="ha" angle="2.0697859599400754" k="379.0704"/>
+    <Angle class1="cp" class2="cq" class3="cp" angle="1.8853046580042745" k="564.84"/>
+    <Angle class1="cx" class2="cu" class3="cx" angle="1.1028735543352168" k="730.5264"/>
+    <Angle class1="cu" class2="c2" class3="ha" angle="2.120400508247911" k="417.5632"/>
+    <Angle class1="cd" class2="ce" class3="cg" angle="2.1340140764134667" k="552.288"/>
+    <Angle class1="cf" class2="ne" class3="ne" angle="1.9751891144819826" k="584.9232000000001"/>
+    <Angle class1="c3" class2="c2" class3="no" angle="2.0235347347622255" k="548.9408"/>
+    <Angle class1="f" class2="cy" class3="f" angle="1.8947294359650442" k="586.5968"/>
+    <Angle class1="c2" class2="cy" class3="hc" angle="1.9687313962496038" k="388.2752"/>
+    <Angle class1="c3" class2="c2" class3="cy" angle="2.059313984428109" k="520.4896"/>
+    <Angle class1="c" class2="ce" class3="h4" angle="2.0608847807549044" k="386.6016"/>
+    <Angle class1="cf" class2="cc" class3="n" angle="2.1676989309769574" k="571.5344"/>
+    <Angle class1="cd" class2="cc" class3="i" angle="2.169095194378553" k="472.79200000000003"/>
+    <Angle class1="ce" class2="cf" class3="cl" angle="2.1282544898818854" k="479.4864"/>
+    <Angle class1="cl" class2="c3" class3="p5" angle="1.9114845967841896" k="613.3744"/>
+    <Angle class1="c2" class2="c3" class3="no" angle="1.8708184252127218" k="555.6352"/>
+    <Angle class1="ce" class2="nf" class3="nf" angle="1.9751891144819826" k="584.9232000000001"/>
+    <Angle class1="c1" class2="c3" class3="cx" angle="1.960877414615629" k="538.8992000000001"/>
+    <Angle class1="ce" class2="c3" class3="h2" angle="1.9594811512140338" k="388.2752"/>
+    <Angle class1="na" class2="cd" class3="na" angle="1.8605209826259552" k="629.2736000000001"/>
+    <Angle class1="cx" class2="cx" class3="n4" angle="2.0722294208928678" k="533.0416"/>
+    <Angle class1="c1" class2="cx" class3="hc" angle="2.0046851788406865" k="400.8272"/>
+    <Angle class1="cg" class2="ca" class3="nb" angle="2.039766296805773" k="582.4128"/>
+    <Angle class1="ce" class2="c2" class3="f" angle="2.140122728795447" k="566.5136"/>
+    <Angle class1="cp" class2="ca" class3="cq" angle="1.9463911818240762" k="575.7184"/>
+    <Angle class1="cl" class2="py" class3="nf" angle="1.9052014114770102" k="301.248"/>
+    <Angle class1="cy" class2="cy" class3="i" angle="2.1745057150597353" k="455.2192"/>
+    <Angle class1="ca" class2="c3" class3="cy" angle="1.9603538158400309" k="528.8576"/>
+    <Angle class1="ch" class2="cd" class3="nd" angle="2.1472785787286237" k="564.0032000000001"/>
+    <Angle class1="h1" class2="cy" class3="ss" angle="1.9516271695800593" k="344.76160000000004"/>
+    <Angle class1="h5" class2="cc" class3="n2" angle="2.1516419018586093" k="433.4624"/>
+    <Angle class1="cc" class2="na" class3="cy" angle="2.214473754930405" k="520.4896"/>
+    <Angle class1="c" class2="c3" class3="no" angle="1.8673277667087331" k="553.1247999999999"/>
+    <Angle class1="c3" class2="py" class3="c3" angle="1.8451620852084052" k="305.432"/>
+    <Angle class1="hx" class2="c3" class3="n3" angle="1.9500563732532643" k="410.8688"/>
+    <Angle class1="cf" class2="cf" class3="nh" angle="2.031737782246599" k="569.024"/>
+    <Angle class1="c3" class2="n3" class3="py" angle="2.0642009063336935" k="654.3776"/>
+    <Angle class1="h5" class2="c2" class3="os" angle="1.9364428050877087" k="440.9936"/>
+    <Angle class1="cc" class2="c3" class3="ce" angle="1.935395607536512" k="537.2256000000001"/>
+    <Angle class1="n4" class2="c3" class3="p5" angle="1.8516198034407843" k="681.1552"/>
+    <Angle class1="ne" class2="cd" class3="ss" angle="2.199114857512855" k="528.0208"/>
+    <Angle class1="na" class2="cd" class3="ne" angle="2.137504734917455" k="603.3328"/>
+    <Angle class1="cl" class2="c3" class3="h3" angle="1.8790214726970953" k="333.8832"/>
+    <Angle class1="h5" class2="c" class3="s" angle="2.1556561591381964" k="364.8448"/>
+    <Angle class1="cf" class2="ce" class3="ss" angle="2.1109757302871417" k="516.3056"/>
+    <Angle class1="c3" class2="c2" class3="f" angle="1.9771089766591763" k="551.4512000000001"/>
+    <Angle class1="h4" class2="c2" class3="oh" angle="2.000321855710701" k="439.32"/>
+    <Angle class1="ne" class2="ce" class3="nf" angle="2.233323310851944" k="587.4336000000001"/>
+    <Angle class1="cc" class2="n" class3="cd" angle="2.112721059539136" k="545.5936"/>
+    <Angle class1="f" class2="py" class3="f" angle="1.7018705536196708" k="360.66080000000005"/>
+    <Angle class1="n" class2="cc" class3="os" angle="2.077290875723651" k="602.496"/>
+    <Angle class1="cq" class2="cp" class3="nb" angle="2.094569635318395" k="569.8607999999999"/>
+    <Angle class1="c" class2="c" class3="s" angle="2.1172589155943213" k="519.6528000000001"/>
+    <Angle class1="cf" class2="ce" class3="os" angle="2.0984093596727824" k="589.9440000000001"/>
+    <Angle class1="br" class2="ce" class3="c2" angle="2.103470814503566" k="525.5104"/>
+    <Angle class1="cp" class2="nb" class3="na" angle="2.0614083795305027" k="581.576"/>
+    <Angle class1="n" class2="s6" class3="oh" angle="1.6982053621904827" k="589.1072"/>
+    <Angle class1="cd" class2="c3" class3="h2" angle="1.9280652246781358" k="394.9696"/>
+    <Angle class1="nb" class2="ca" class3="sy" angle="2.0198695433330376" k="539.736"/>
+    <Angle class1="na" class2="sy" class3="o" angle="1.8378317023500288" k="587.4336000000001"/>
+    <Angle class1="hx" class2="cx" class3="hx" angle="2.0205676750338353" k="321.3312"/>
+    <Angle class1="cd" class2="cf" class3="ne" angle="2.1361084715158603" k="571.5344"/>
+    <Angle class1="h5" class2="c" class3="oh" angle="1.9109609980085913" k="444.3408"/>
+    <Angle class1="cy" class2="n" class3="cy" angle="1.6502088077606385" k="579.9024"/>
+    <Angle class1="br" class2="c3" class3="no" angle="1.8668041679331349" k="543.9200000000001"/>
+    <Angle class1="ce" class2="s4" class3="ss" angle="1.5472343818929732" k="132.2144"/>
+    <Angle class1="c2" class2="ss" class3="s4" angle="1.6130332946931594" k="519.6528000000001"/>
+    <Angle class1="c3" class2="nh" class3="o" angle="2.051285469868936" k="571.5344"/>
+    <Angle class1="br" class2="cc" class3="ss" angle="2.0954422999443922" k="538.0624"/>
+    <Angle class1="c" class2="ce" class3="ss" angle="1.9762363120331796" k="523.0"/>
+    <Angle class1="c3" class2="n" class3="n3" angle="2.0518090686445336" k="546.4304"/>
+    <Angle class1="h5" class2="ca" class3="na" angle="2.0210912738094335" k="423.42080000000004"/>
+    <Angle class1="n2" class2="nh" class3="oh" angle="2.057568655176115" k="581.576"/>
+    <Angle class1="c2" class2="c3" class3="p5" angle="1.9586084865880367" k="646.8464"/>
+    <Angle class1="c3" class2="cx" class3="nh" angle="1.8654079045315393" k="571.5344"/>
+    <Angle class1="c2" class2="cc" class3="ss" angle="2.2249457304423714" k="508.7744"/>
+    <Angle class1="c" class2="ca" class3="na" angle="2.0561723917745196" k="558.9824"/>
+    <Angle class1="cl" class2="c2" class3="n2" angle="2.1197023765471132" k="503.75360000000006"/>
+    <Angle class1="n2" class2="s4" class3="ne" angle="1.8202038769048863" k="579.9024"/>
+    <Angle class1="nc" class2="c" class3="s" angle="2.172411319957342" k="545.5936"/>
+    <Angle class1="o" class2="sy" class3="ss" angle="1.8777997422206991" k="183.2592"/>
+    <Angle class1="c2" class2="ce" class3="ss" angle="2.1617648115201766" k="510.44800000000004"/>
+    <Angle class1="c3" class2="cx" class3="ca" angle="2.042209757758565" k="523.0"/>
+    <Angle class1="cc" class2="cc" class3="nf" angle="2.1237166338267004" k="579.0656"/>
+    <Angle class1="ca" class2="nd" class3="cd" angle="1.8193312122788892" k="596.6384"/>
+    <Angle class1="cc" class2="n2" class3="oh" angle="1.9765853778835782" k="596.6384"/>
+    <Angle class1="ca" class2="os" class3="sy" angle="2.0596630502785085" k="505.4272"/>
+    <Angle class1="hx" class2="c3" class3="p5" angle="1.8777997422206991" k="447.68800000000005"/>
+    <Angle class1="ca" class2="ce" class3="n" angle="2.0767672769480527" k="552.288"/>
+    <Angle class1="h4" class2="ce" class3="sx" angle="2.0118410287738633" k="346.4352"/>
+    <Angle class1="c3" class2="ce" class3="ne" angle="2.028596189593009" k="555.6352"/>
+    <Angle class1="c1" class2="n1" class3="ce" angle="3.086963848002371" k="502.08000000000004"/>
+    <Angle class1="c3" class2="n2" class3="cd" angle="2.042209757758565" k="551.4512000000001"/>
+    <Angle class1="cc" class2="c3" class3="h2" angle="1.9280652246781358" k="394.9696"/>
+    <Angle class1="ca" class2="ce" class3="cg" angle="2.0327849797977957" k="544.7568"/>
+    <Angle class1="c2" class2="cc" class3="na" angle="2.15146736893341" k="574.8816"/>
+    <Angle class1="ca" class2="c3" class3="s4" angle="1.9114845967841896" k="518.816"/>
+    <Angle class1="n2" class2="cf" class3="nf" angle="2.1064378742319563" k="606.6800000000001"/>
+    <Angle class1="ce" class2="cf" class3="ss" angle="2.1109757302871417" k="516.3056"/>
+    <Angle class1="c3" class2="cx" class3="ss" angle="1.992642407001926" k="506.264"/>
+    <Angle class1="nh" class2="ce" class3="nh" angle="2.089333647562412" k="589.1072"/>
+    <Angle class1="cd" class2="c" class3="ne" angle="1.9586084865880367" k="577.392"/>
+    <Angle class1="na" class2="c3" class3="ss" angle="1.800307123432151" k="549.7776"/>
+    <Angle class1="cf" class2="cf" class3="os" angle="2.0104447653722683" k="579.0656"/>
+    <Angle class1="cx" class2="c3" class3="h2" angle="1.9898498801987352" k="384.0912"/>
+    <Angle class1="cv" class2="ss" class3="cy" angle="1.441991027997715" k="562.3296"/>
+    <Angle class1="ss" class2="cy" class3="ss" angle="1.9191640454929646" k="515.4688"/>
+    <Angle class1="ce" class2="cx" class3="os" angle="2.0457004162625534" k="552.288"/>
+    <Angle class1="nb" class2="ca" class3="ne" angle="2.1190042448463156" k="591.6176"/>
+    <Angle class1="br" class2="ca" class3="nb" angle="2.030690584695402" k="547.2672000000001"/>
+    <Angle class1="c3" class2="nh" class3="os" angle="1.9263198954261416" k="564.84"/>
+    <Angle class1="c2" class2="nh" class3="p5" angle="2.197369528260861" k="650.1936000000001"/>
+    <Angle class1="br" class2="ca" class3="cp" angle="2.1186551789959163" k="520.4896"/>
+    <Angle class1="cc" class2="ce" class3="cc" angle="2.0275489920418126" k="544.7568"/>
+    <Angle class1="c3" class2="nh" class3="s6" angle="2.033134045648194" k="520.4896"/>
+    <Angle class1="cx" class2="c3" class3="na" angle="2.0032889154390916" k="546.4304"/>
+    <Angle class1="ca" class2="os" class3="p3" angle="1.9278906917529361" k="668.6032000000001"/>
+    <Angle class1="ce" class2="cf" class3="sy" angle="2.1500711055318145" k="510.44800000000004"/>
+    <Angle class1="ca" class2="n2" class3="n1" angle="2.0678660977628818" k="615.048"/>
+    <Angle class1="cd" class2="cd" class3="no" angle="2.198242192886858" k="545.5936"/>
+    <Angle class1="na" class2="n2" class3="os" angle="1.8210765415308834" k="618.3952"/>
+    <Angle class1="ce" class2="c3" class3="f" angle="1.925272697874945" k="555.6352"/>
+    <Angle class1="cx" class2="cc" class3="na" angle="2.2202333414619866" k="543.0832"/>
+    <Angle class1="n" class2="n2" class3="na" angle="1.8507471388147871" k="619.232"/>
+    <Angle class1="c3" class2="cf" class3="cc" angle="2.049540140616941" k="543.9200000000001"/>
+    <Angle class1="ca" class2="na" class3="cy" angle="2.2350686401039384" k="517.1424"/>
+    <Angle class1="h1" class2="c3" class3="py" angle="1.9090411358313977" k="444.3408"/>
+    <Angle class1="cy" class2="s6" class3="cy" angle="1.5144221919554797" k="535.552"/>
+    <Angle class1="ce" class2="ce" class3="s4" angle="2.0790362049756452" k="157.31840000000003"/>
+    <Angle class1="c3" class2="p3" class3="cy" angle="1.812524428196111" k="301.248"/>
+    <Angle class1="h2" class2="cx" class3="os" angle="1.9795524376119686" k="425.0944"/>
+    <Angle class1="c" class2="c" class3="ce" angle="2.014808088502254" k="523.8368"/>
+    <Angle class1="ce" class2="cy" class3="h1" angle="2.015680753128251" k="382.41760000000005"/>
+    <Angle class1="cx" class2="c3" class3="ss" angle="1.839926097452422" k="526.3472"/>
+    <Angle class1="cg" class2="ce" class3="ss" angle="2.062804642932098" k="517.1424"/>
+    <Angle class1="br" class2="cy" class3="cy" angle="2.0816541988536366" k="506.264"/>
+    <Angle class1="c" class2="cy" class3="cl" angle="1.9579103548872387" k="512.9584"/>
+    <Angle class1="c" class2="cx" class3="n" angle="2.052332667420132" k="548.9408"/>
+    <Angle class1="br" class2="c3" class3="f" angle="1.913229926036184" k="523.8368"/>
+    <Angle class1="c3" class2="n4" class3="cy" angle="1.9631463426432219" k="516.3056"/>
+    <Angle class1="ce" class2="cv" class3="ss" angle="2.316226450321675" k="506.264"/>
+    <Angle class1="cc" class2="cd" class3="i" angle="2.169095194378553" k="474.46560000000005"/>
+    <Angle class1="c2" class2="ss" class3="ca" angle="1.7938494051997718" k="517.9792"/>
+    <Angle class1="c" class2="cx" class3="ce" angle="2.0392426980301748" k="525.5104"/>
+    <Angle class1="cy" class2="nh" class3="cy" angle="1.6285667250359088" k="581.576"/>
+    <Angle class1="cx" class2="c" class3="h4" angle="2.0137608909510574" k="385.76480000000004"/>
+    <Angle class1="c" class2="n4" class3="c3" angle="1.8982200944690328" k="519.6528000000001"/>
+    <Angle class1="f" class2="cy" class3="py" angle="1.9755381803323815" k="618.3952"/>
+    <Angle class1="n2" class2="c3" class3="ss" angle="1.909215668756597" k="533.8783999999999"/>
+    <Angle class1="c3" class2="ss" class3="cf" angle="1.767669466419857" k="506.264"/>
+    <Angle class1="ce" class2="cy" class3="hc" angle="2.004336112990288" k="384.0912"/>
+    <Angle class1="br" class2="cc" class3="nc" angle="2.028945255443408" k="552.288"/>
+    <Angle class1="h3" class2="c3" class3="n" angle="1.9177677820913692" k="415.05280000000005"/>
+    <Angle class1="ca" class2="ne" class3="cd" angle="2.158448685941387" k="548.9408"/>
+    <Angle class1="cx" class2="n" class3="cy" angle="2.0282471237426103" k="528.0208"/>
+    <Angle class1="cl" class2="c3" class3="s4" angle="1.9545942293084493" k="480.3232"/>
+    <Angle class1="cp" class2="cq" class3="nb" angle="2.094569635318395" k="569.8607999999999"/>
+    <Angle class1="cc" class2="cd" class3="o" angle="2.374694980263485" k="148.9504"/>
+    <Angle class1="hx" class2="cy" class3="hx" angle="1.933824811209717" k="326.35200000000003"/>
+    <Angle class1="cc" class2="na" class3="sy" angle="2.1846286247213023" k="503.75360000000006"/>
+    <Angle class1="h1" class2="cy" class3="na" angle="1.8566812582715677" k="425.9312"/>
+    <Angle class1="h4" class2="cf" class3="sy" angle="2.007128639793479" k="353.12960000000004"/>
+    <Angle class1="c" class2="p5" class3="c3" angle="1.9422023916192899" k="294.5536"/>
+    <Angle class1="ca" class2="c" class3="nc" angle="2.042558823608964" k="560.6560000000001"/>
+    <Angle class1="c3" class2="os" class3="sy" angle="2.008001304419476" k="506.264"/>
+    <Angle class1="cd" class2="ne" class3="sy" angle="2.108008670558751" k="532.2048"/>
+    <Angle class1="cx" class2="ca" class3="nb" angle="2.0402898955813713" k="567.3504"/>
+    <Angle class1="nc" class2="ss" class3="ss" angle="1.7006488231432746" k="544.7568"/>
+    <Angle class1="hp" class2="p5" class3="os" angle="1.7990853929557549" k="254.3872"/>
+    <Angle class1="ca" class2="n" class3="oh" angle="2.017949681155844" k="564.0032000000001"/>
+    <Angle class1="c3" class2="s6" class3="ne" angle="1.888271717732665" k="136.3984"/>
+    <Angle class1="c1" class2="cx" class3="h1" angle="2.0036379812894904" k="400.8272"/>
+    <Angle class1="na" class2="c3" class3="oh" angle="1.8952530347406427" k="599.1487999999999"/>
+    <Angle class1="n" class2="nc" class3="nd" angle="2.092300707290802" k="597.4752000000001"/>
+    <Angle class1="c3" class2="na" class3="nb" angle="1.9746655157063844" k="566.5136"/>
+    <Angle class1="ne" class2="c" class3="os" angle="1.9549432951588488" k="619.232"/>
+    <Angle class1="br" class2="ce" class3="ce" angle="2.010968364147866" k="532.2048"/>
+    <Angle class1="cc" class2="c2" class3="oh" angle="2.010270232447069" k="607.5168"/>
+    <Angle class1="c1" class2="cx" class3="os" angle="2.0177751482306445" k="574.0448"/>
+    <Angle class1="nc" class2="cc" class3="os" angle="2.124414765527498" k="598.312"/>
+    <Angle class1="br" class2="ce" class3="cf" angle="2.1223203704251046" k="523.0"/>
+    <Angle class1="cy" class2="c3" class3="f" angle="1.9456930501232788" k="548.104"/>
+    <Angle class1="h5" class2="ce" class3="ne" angle="1.9835666948915556" k="105.4368"/>
+    <Angle class1="n3" class2="py" class3="n3" angle="1.824916265885271" k="350.6192"/>
+    <Angle class1="br" class2="cc" class3="ca" angle="2.210284964725619" k="512.1216000000001"/>
+    <Angle class1="f" class2="c3" class3="na" angle="1.9270180271269393" k="581.576"/>
+    <Angle class1="cc" class2="c3" class3="s4" angle="1.9547687622336491" k="513.7952"/>
+    <Angle class1="ce" class2="cf" class3="sx" angle="1.971698455977994" k="525.5104"/>
+    <Angle class1="cc" class2="cc" class3="i" angle="2.1954496660836673" k="470.2816"/>
+    <Angle class1="c" class2="cg" class3="ch" angle="3.083822255348781" k="475.3024"/>
+    <Angle class1="ce" class2="c3" class3="hx" angle="1.9352210746113125" k="390.78560000000004"/>
+    <Angle class1="cd" class2="na" class3="cy" angle="2.2076669708476273" k="521.3264"/>
+    <Angle class1="br" class2="c3" class3="c2" angle="1.9402825294420962" k="522.1632"/>
+    <Angle class1="ce" class2="ce" class3="cg" angle="2.0008454544862997" k="553.1247999999999"/>
+    <Angle class1="cl" class2="cd" class3="nd" angle="2.116909849743922" k="497.896"/>
+    <Angle class1="n" class2="ca" class3="na" angle="2.045002284561756" k="592.4544"/>
+    <Angle class1="cx" class2="cd" class3="nd" angle="2.1223203704251046" k="555.6352"/>
+    <Angle class1="cl" class2="p5" class3="os" angle="1.8243926671096726" k="313.8"/>
+    <Angle class1="cx" class2="ss" class3="cy" angle="1.5994197265276036" k="523.8368"/>
+    <Angle class1="cc" class2="cg" class3="ch" angle="3.0902799735811595" k="481.16"/>
+    <Angle class1="cc" class2="sy" class3="oh" angle="1.8172368171764959" k="541.4096000000001"/>
+    <Angle class1="cq" class2="ca" class3="os" angle="2.0404644285065707" k="586.5968"/>
+    <Angle class1="ca" class2="cd" class3="ca" angle="2.145707782401829" k="528.8576"/>
+    <Angle class1="f" class2="py" class3="nf" angle="1.8954275676658416" k="351.456"/>
+    <Angle class1="ca" class2="nh" class3="cf" angle="2.2294835864975564" k="528.8576"/>
+    <Angle class1="cf" class2="cx" class3="cx" angle="2.27468761412421" k="497.05920000000003"/>
+    <Angle class1="py" class2="nf" class3="py" angle="2.1190042448463156" k="879.4768"/>
+    <Angle class1="c" class2="cc" class3="ss" angle="2.1287780886574836" k="510.44800000000004"/>
+    <Angle class1="cc" class2="na" class3="cx" angle="2.12685822648029" k="528.0208"/>
+    <Angle class1="c2" class2="cf" class3="cx" angle="2.227912790170762" k="528.0208"/>
+    <Angle class1="ce" class2="cd" class3="os" angle="2.147976710429421" k="581.576"/>
+    <Angle class1="cd" class2="cc" class3="cx" angle="2.2769565421518023" k="524.6736000000001"/>
+    <Angle class1="cf" class2="n1" class3="n1" angle="3.1000538173923284" k="515.4688"/>
+    <Angle class1="cf" class2="n" class3="hn" angle="1.9867082875451454" k="399.15360000000004"/>
+    <Angle class1="ce" class2="ce" class3="nf" angle="2.1081832034839505" k="574.0448"/>
+    <Angle class1="cf" class2="no" class3="o" angle="2.0633282417076964" k="173.2176"/>
+    <Angle class1="h4" class2="cf" class3="nh" angle="2.017251549455046" k="422.584"/>
+    <Angle class1="nf" class2="c" class3="s" angle="2.1682225297525557" k="545.5936"/>
+    <Angle class1="na" class2="cd" class3="sh" angle="2.1458823153270283" k="525.5104"/>
+    <Angle class1="cc" class2="cy" class3="hc" angle="1.8675022996339325" k="403.33760000000007"/>
+    <Angle class1="cf" class2="cc" class3="na" angle="2.1804398345165157" k="569.8607999999999"/>
+    <Angle class1="c" class2="cf" class3="h4" angle="2.0608847807549044" k="386.6016"/>
+    <Angle class1="ce" class2="cd" class3="n" angle="2.1676989309769574" k="571.5344"/>
+    <Angle class1="cf" class2="c3" class3="h2" angle="1.9594811512140338" k="388.2752"/>
+    <Angle class1="na" class2="cc" class3="na" angle="1.8605209826259552" k="629.2736000000001"/>
+    <Angle class1="ch" class2="ca" class3="nb" angle="2.039766296805773" k="582.4128"/>
+    <Angle class1="cf" class2="c2" class3="f" angle="2.140122728795447" k="566.5136"/>
+    <Angle class1="cg" class2="cc" class3="nc" angle="2.1472785787286237" k="564.0032000000001"/>
+    <Angle class1="h5" class2="cd" class3="n2" angle="2.1516419018586093" k="433.4624"/>
+    <Angle class1="cd" class2="c3" class3="cf" angle="1.935395607536512" k="537.2256000000001"/>
+    <Angle class1="nf" class2="cc" class3="ss" angle="2.199114857512855" k="528.0208"/>
+    <Angle class1="na" class2="cc" class3="nf" angle="2.137504734917455" k="603.3328"/>
+    <Angle class1="nf" class2="cf" class3="ne" angle="2.233323310851944" k="587.4336000000001"/>
+    <Angle class1="n" class2="cd" class3="os" angle="2.077290875723651" k="602.496"/>
+    <Angle class1="ce" class2="cf" class3="os" angle="2.0984093596727824" k="589.9440000000001"/>
+    <Angle class1="br" class2="cf" class3="c2" angle="2.103470814503566" k="525.5104"/>
+    <Angle class1="cq" class2="nb" class3="na" angle="2.0614083795305027" k="581.576"/>
+    <Angle class1="cc" class2="ce" class3="nf" angle="2.1361084715158603" k="571.5344"/>
+    <Angle class1="cf" class2="s4" class3="ss" angle="1.5472343818929732" k="132.2144"/>
+    <Angle class1="br" class2="cd" class3="ss" angle="2.0954422999443922" k="538.0624"/>
+    <Angle class1="c" class2="cf" class3="ss" angle="1.9762363120331796" k="523.0"/>
+    <Angle class1="c2" class2="cd" class3="ss" angle="2.2249457304423714" k="508.7744"/>
+    <Angle class1="n2" class2="s4" class3="nf" angle="1.8202038769048863" k="579.9024"/>
+    <Angle class1="nd" class2="c" class3="s" angle="2.172411319957342" k="545.5936"/>
+    <Angle class1="c2" class2="cf" class3="ss" angle="2.1617648115201766" k="510.44800000000004"/>
+    <Angle class1="cd" class2="cd" class3="ne" angle="2.1237166338267004" k="579.0656"/>
+    <Angle class1="ca" class2="nc" class3="cc" angle="1.8193312122788892" k="596.6384"/>
+    <Angle class1="cd" class2="n2" class3="oh" angle="1.9765853778835782" k="596.6384"/>
+    <Angle class1="ca" class2="cf" class3="n" angle="2.0767672769480527" k="552.288"/>
+    <Angle class1="h4" class2="cf" class3="sx" angle="2.0118410287738633" k="346.4352"/>
+    <Angle class1="c3" class2="cf" class3="nf" angle="2.028596189593009" k="555.6352"/>
+    <Angle class1="c1" class2="n1" class3="cf" angle="3.086963848002371" k="502.08000000000004"/>
+    <Angle class1="c3" class2="n2" class3="cc" angle="2.042209757758565" k="551.4512000000001"/>
+    <Angle class1="ca" class2="cf" class3="ch" angle="2.0327849797977957" k="544.7568"/>
+    <Angle class1="c2" class2="cd" class3="na" angle="2.15146736893341" k="574.8816"/>
+    <Angle class1="n2" class2="ce" class3="ne" angle="2.1064378742319563" k="606.6800000000001"/>
+    <Angle class1="nh" class2="cf" class3="nh" angle="2.089333647562412" k="589.1072"/>
+    <Angle class1="cc" class2="c" class3="nf" angle="1.9586084865880367" k="577.392"/>
+    <Angle class1="cf" class2="cx" class3="os" angle="2.0457004162625534" k="552.288"/>
+    <Angle class1="nb" class2="ca" class3="nf" angle="2.1190042448463156" k="591.6176"/>
+    <Angle class1="br" class2="ca" class3="cq" angle="2.1186551789959163" k="520.4896"/>
+    <Angle class1="cd" class2="cf" class3="cd" angle="2.0275489920418126" k="544.7568"/>
+    <Angle class1="cf" class2="ce" class3="sy" angle="2.1500711055318145" k="510.44800000000004"/>
+    <Angle class1="cc" class2="cc" class3="no" angle="2.198242192886858" k="545.5936"/>
+    <Angle class1="cf" class2="c3" class3="f" angle="1.925272697874945" k="555.6352"/>
+    <Angle class1="cx" class2="cd" class3="na" angle="2.2202333414619866" k="543.0832"/>
+    <Angle class1="c3" class2="ce" class3="cd" angle="2.049540140616941" k="543.9200000000001"/>
+    <Angle class1="cf" class2="cf" class3="s4" angle="2.0790362049756452" k="157.31840000000003"/>
+    <Angle class1="c" class2="c" class3="cf" angle="2.014808088502254" k="523.8368"/>
+    <Angle class1="cf" class2="cy" class3="h1" angle="2.015680753128251" k="383.2544"/>
+    <Angle class1="ch" class2="cf" class3="ss" angle="2.062804642932098" k="517.1424"/>
+    <Angle class1="cf" class2="cv" class3="ss" angle="2.2704988239194233" k="502.08000000000004"/>
+    <Angle class1="c" class2="cx" class3="cf" angle="2.0392426980301748" k="526.3472"/>
+    <Angle class1="c3" class2="ss" class3="ce" angle="1.767669466419857" k="506.264"/>
+    <Angle class1="cf" class2="cy" class3="hc" angle="2.004336112990288" k="384.0912"/>
+    <Angle class1="br" class2="cd" class3="nd" angle="2.028945255443408" k="552.288"/>
+    <Angle class1="ca" class2="nf" class3="cc" angle="2.158448685941387" k="548.9408"/>
+    <Angle class1="cd" class2="cc" class3="o" angle="2.374694980263485" k="148.9504"/>
+    <Angle class1="cd" class2="na" class3="sy" angle="2.1846286247213023" k="503.75360000000006"/>
+    <Angle class1="ca" class2="c" class3="nd" angle="2.042558823608964" k="560.6560000000001"/>
+    <Angle class1="cc" class2="nf" class3="sy" angle="2.108008670558751" k="532.2048"/>
+    <Angle class1="nd" class2="ss" class3="ss" angle="1.7006488231432746" k="544.7568"/>
+    <Angle class1="c3" class2="s6" class3="nf" angle="1.888271717732665" k="136.3984"/>
+    <Angle class1="n" class2="nd" class3="nc" angle="2.092300707290802" k="597.4752000000001"/>
+    <Angle class1="nf" class2="c" class3="os" angle="1.9549432951588488" k="619.232"/>
+    <Angle class1="br" class2="cf" class3="cf" angle="2.010968364147866" k="532.2048"/>
+    <Angle class1="cd" class2="c2" class3="oh" angle="2.010270232447069" k="607.5168"/>
+    <Angle class1="nd" class2="cd" class3="os" angle="2.124414765527498" k="598.312"/>
+    <Angle class1="br" class2="cf" class3="ce" angle="2.1223203704251046" k="523.0"/>
+    <Angle class1="h5" class2="cf" class3="nf" angle="1.9835666948915556" k="105.4368"/>
+    <Angle class1="br" class2="cd" class3="ca" angle="2.210284964725619" k="512.1216000000001"/>
+    <Angle class1="cd" class2="c3" class3="s4" angle="1.9547687622336491" k="513.7952"/>
+    <Angle class1="cf" class2="ce" class3="sx" angle="1.971698455977994" k="525.5104"/>
+    <Angle class1="cd" class2="cd" class3="i" angle="2.1954496660836673" k="471.1184"/>
+    <Angle class1="c" class2="ch" class3="cg" angle="3.083822255348781" k="475.3024"/>
+    <Angle class1="cf" class2="c3" class3="hx" angle="1.9352210746113125" k="390.78560000000004"/>
+    <Angle class1="cf" class2="cf" class3="ch" angle="2.0008454544862997" k="553.1247999999999"/>
+    <Angle class1="cl" class2="cc" class3="nc" angle="2.116909849743922" k="497.896"/>
+    <Angle class1="cx" class2="cc" class3="nc" angle="2.1485003092050197" k="553.9616000000001"/>
+    <Angle class1="cd" class2="ch" class3="cg" angle="3.0902799735811595" k="481.16"/>
+    <Angle class1="cd" class2="sy" class3="oh" angle="1.8172368171764959" k="541.4096000000001"/>
+    <Angle class1="cx" class2="cx" class3="op" angle="1.0314895879286488" k="776.5504"/>
+    <Angle class1="h1" class2="cx" class3="op" angle="2.005906909317083" k="415.05280000000005"/>
+    <Angle class1="c3" class2="cx" class3="op" angle="2.021614872585032" k="551.4512000000001"/>
+    <Angle class1="nj" class2="c" class3="o" angle="2.3223351027036547" k="590.7808"/>
+    <Angle class1="c" class2="nj" class3="cy" angle="1.6409585627250687" k="594.128"/>
+    <Angle class1="h1" class2="cx" class3="np" angle="2.0376719017033795" k="400.8272"/>
+    <Angle class1="cx" class2="op" class3="cx" angle="1.077915346031698" k="705.4224"/>
+    <Angle class1="cy" class2="cy" class3="nj" angle="1.5470598489677738" k="611.7008"/>
+    <Angle class1="cy" class2="c" class3="nj" angle="1.6001178582284015" k="615.8847999999999"/>
+    <Angle class1="h1" class2="cx" class3="nm" angle="2.0315632493213998" k="405.01120000000003"/>
+    <Angle class1="h1" class2="cy" class3="nj" angle="1.947089313524874" k="409.1952"/>
+    <Angle class1="ce" class2="nj" class3="cy" angle="1.9486601098516692" k="540.5728"/>
+    <Angle class1="c" class2="nj" class3="ce" angle="2.29615516392374" k="511.2848"/>
+    <Angle class1="c" class2="ce" class3="nj" angle="2.068738762388879" k="552.288"/>
+    <Angle class1="cx" class2="cx" class3="np" angle="1.0402162341886205" k="760.6512000000001"/>
+    <Angle class1="c3" class2="cy" class3="nj" angle="1.818458547652892" k="569.024"/>
+    <Angle class1="c2" class2="ce" class3="nj" angle="1.9256217637253437" k="599.9856000000001"/>
+    <Angle class1="h2" class2="cy" class3="nj" angle="1.9991001252343052" k="403.33760000000007"/>
+    <Angle class1="cx" class2="cx" class3="nm" angle="1.0318386537790476" k="767.3456000000001"/>
+    <Angle class1="nj" class2="cy" class3="ss" angle="1.835039175546838" k="541.4096000000001"/>
+    <Angle class1="c" class2="cx" class3="op" angle="2.00677957394308" k="557.3088"/>
+    <Angle class1="cx" class2="np" class3="cx" angle="1.0602875205865552" k="723.832"/>
+    <Angle class1="cx" class2="np" class3="p5" angle="2.0851448573576254" k="647.6832"/>
+    <Angle class1="h1" class2="c3" class3="nj" angle="1.8940313042642465" k="420.07360000000006"/>
+    <Angle class1="h1" class2="cy" class3="nq" angle="1.9964821313563135" k="402.5008"/>
+    <Angle class1="c" class2="nj" class3="c3" angle="2.2270401255447645" k="514.6320000000001"/>
+    <Angle class1="c3" class2="nj" class3="cy" angle="2.045176817486955" k="523.0"/>
+    <Angle class1="cx" class2="nm" class3="cx" angle="1.0821041362364843" k="723.832"/>
+    <Angle class1="c3" class2="c3" class3="nj" angle="1.866455102082736" k="564.84"/>
+    <Angle class1="cf" class2="ce" class3="nj" angle="1.8905406457602576" k="605.0064"/>
+    <Angle class1="c" class2="c3" class3="nj" angle="1.9231783027725518" k="559.8192"/>
+    <Angle class1="cc" class2="nm" class3="cx" angle="2.140995393421444" k="521.3264"/>
+    <Angle class1="c3" class2="np" class3="cx" angle="2.0313887163962" k="523.8368"/>
+    <Angle class1="h1" class2="c3" class3="np" angle="1.9193385784181642" k="415.05280000000005"/>
+    <Angle class1="c3" class2="cx" class3="np" angle="2.0223130042858295" k="543.0832"/>
+    <Angle class1="cy" class2="cy" class3="nq" angle="1.5489797111449675" k="610.0272000000001"/>
+    <Angle class1="ca" class2="cy" class3="cy" angle="2.0387190992545765" k="513.7952"/>
+    <Angle class1="ce" class2="c2" class3="cx" angle="2.1373302019922558" k="542.2464"/>
+    <Angle class1="np" class2="p5" class3="o" angle="2.030865117620602" k="351.456"/>
+    <Angle class1="ca" class2="nm" class3="cx" angle="2.15757602131539" k="524.6736000000001"/>
+    <Angle class1="cy" class2="cy" class3="oq" angle="1.5805701706060646" k="611.7008"/>
+    <Angle class1="c2" class2="cx" class3="op" angle="2.0395917638805736" k="556.472"/>
+    <Angle class1="h1" class2="c3" class3="nq" angle="1.8949039688902436" k="419.2368"/>
+    <Angle class1="h1" class2="cy" class3="oq" angle="1.9271925600521387" k="416.7264"/>
+    <Angle class1="c3" class2="cy" class3="oq" angle="1.9638444743440193" k="553.1247999999999"/>
+    <Angle class1="c3" class2="nq" class3="cy" angle="2.070833157491272" k="517.9792"/>
+    <Angle class1="cx" class2="cx" class3="n" angle="2.077290875723651" k="544.7568"/>
+    <Angle class1="np" class2="p5" class3="np" angle="1.7666222688686604" k="353.96639999999996"/>
+    <Angle class1="cd" class2="cc" class3="nm" angle="2.094744168243594" k="572.3712"/>
+    <Angle class1="c" class2="cc" class3="nm" angle="2.101550952326372" k="553.1247999999999"/>
+    <Angle class1="nj" class2="s6" class3="o" angle="1.876578011744303" k="583.2496000000001"/>
+    <Angle class1="ce" class2="cy" class3="nj" angle="1.5339698795778163" k="623.416"/>
+    <Angle class1="ce" class2="c" class3="nj" angle="1.5711453926452954" k="638.4784"/>
+    <Angle class1="h1" class2="cy" class3="nn" angle="1.9879300180215413" k="404.1744"/>
+    <Angle class1="nb" class2="ca" class3="nm" angle="2.0387190992545765" k="609.1904"/>
+    <Angle class1="cd" class2="nm" class3="cx" angle="2.192657139280476" k="522.1632"/>
+    <Angle class1="cy" class2="nq" class3="cy" angle="1.5863297571376462" k="586.5968"/>
+    <Angle class1="cx" class2="np" class3="hn" angle="1.9167205845401725" k="394.13280000000003"/>
+    <Angle class1="c3" class2="c3" class3="np" angle="1.9275416259025373" k="554.7984"/>
+    <Angle class1="cl" class2="p5" class3="nq" angle="1.8500490071139892" k="327.1888"/>
+    <Angle class1="n3" class2="p5" class3="np" angle="1.8057176441133331" k="353.96639999999996"/>
+    <Angle class1="hx" class2="c3" class3="nk" angle="1.8702948264371233" k="410.03200000000004"/>
+    <Angle class1="c3" class2="c3" class3="nq" angle="1.943075056245287" k="553.1247999999999"/>
+    <Angle class1="cy" class2="nq" class3="hn" angle="2.013237292175459" k="382.41760000000005"/>
+    <Angle class1="o" class2="c" class3="oq" angle="2.2343705084031407" k="614.2112000000001"/>
+    <Angle class1="s" class2="p5" class3="sq" angle="2.0340067102741917" k="303.7584"/>
+    <Angle class1="c3" class2="nk" class3="cx" angle="2.047096679664149" k="510.44800000000004"/>
+    <Angle class1="hx" class2="cx" class3="nk" angle="1.9984019935335071" k="399.15360000000004"/>
+    <Angle class1="ca" class2="ca" class3="nn" angle="2.1170843826691215" k="573.208"/>
+    <Angle class1="ca" class2="cx" class3="op" angle="2.0633282417076964" k="551.4512000000001"/>
+    <Angle class1="cy" class2="oq" class3="cy" angle="1.5994197265276036" k="569.8607999999999"/>
+    <Angle class1="ne" class2="py" class3="np" angle="1.8940313042642465" k="351.456"/>
+    <Angle class1="cx" class2="np" class3="py" angle="2.124938364303096" k="642.6624"/>
+    <Angle class1="h1" class2="cx" class3="ni" angle="2.02528006401422" k="398.3168"/>
+    <Angle class1="h2" class2="cy" class3="sq" angle="1.9669860669976096" k="343.9248"/>
+    <Angle class1="c" class2="oq" class3="cy" angle="1.602386786255994" k="585.76"/>
+    <Angle class1="nj" class2="cy" class3="s6" angle="1.7983872612549574" k="546.4304"/>
+    <Angle class1="ce" class2="c3" class3="cx" angle="1.8697712276615253" k="543.0832"/>
+    <Angle class1="cy" class2="c" class3="oq" angle="1.6538739991898268" k="613.3744"/>
+    <Angle class1="ca" class2="ca" class3="nm" angle="2.1104521315115434" k="572.3712"/>
+    <Angle class1="n" class2="p5" class3="np" angle="1.8261379963616668" k="346.4352"/>
+    <Angle class1="cx" class2="cx" class3="ss" angle="2.0432569553097615" k="501.2432"/>
+    <Angle class1="hx" class2="cy" class3="nl" angle="1.959132085363635" k="396.6432"/>
+    <Angle class1="c" class2="ce" class3="cx" angle="2.0383700334041777" k="529.6944"/>
+    <Angle class1="ca" class2="nn" class3="cy" angle="2.2198842756115877" k="513.7952"/>
+    <Angle class1="ce" class2="cf" class3="nj" angle="1.9003144895714261" k="605.0064"/>
+    <Angle class1="cy" class2="cy" class3="nn" angle="1.5449654538653805" k="611.7008"/>
+    <Angle class1="c" class2="cf" class3="nj" angle="2.044129619935759" k="557.3088"/>
+    <Angle class1="cf" class2="nj" class3="cy" angle="1.9315558831821247" k="544.7568"/>
+    <Angle class1="c" class2="nj" class3="cf" angle="2.271895087321018" k="515.4688"/>
+    <Angle class1="np" class2="p5" class3="s" angle="2.0423842906837644" k="323.00480000000005"/>
+    <Angle class1="cy" class2="nj" class3="s6" angle="2.239781029084323" k="488.6912"/>
+    <Angle class1="c" class2="nj" class3="s6" angle="2.2033036477176418" k="500.4064"/>
+    <Angle class1="cx" class2="cx" class3="nj" angle="1.9687313962496038" k="557.3088"/>
+    <Angle class1="cc" class2="cd" class3="nm" angle="2.1577505542405895" k="573.208"/>
+    <Angle class1="c" class2="cd" class3="nm" angle="2.009223034895872" k="573.208"/>
+    <Angle class1="c2" class2="ce" class3="cy" angle="2.3603832803971314" k="509.6112"/>
+    <Angle class1="c3" class2="cy" class3="nq" angle="2.0057323763918835" k="540.5728"/>
+    <Angle class1="nj" class2="cy" class3="os" angle="1.8552849948699721" k="603.3328"/>
+    <Angle class1="ce" class2="cy" class3="cy" angle="1.592787475370025" k="581.576"/>
+    <Angle class1="ce" class2="ce" class3="cx" angle="1.9566886244108426" k="544.7568"/>
+    <Angle class1="c2" class2="nm" class3="cx" angle="2.15757602131539" k="521.3264"/>
+    <Angle class1="cl" class2="p5" class3="nn" angle="1.8519688692911829" k="330.536"/>
+    <Angle class1="c3" class2="p5" class3="sq" angle="1.8779742751458985" k="296.2272"/>
+    <Angle class1="cy" class2="n4" class3="hn" angle="1.888969849433463" k="385.76480000000004"/>
+    <Angle class1="c" class2="cx" class3="np" angle="2.0392426980301748" k="544.7568"/>
+    <Angle class1="c" class2="cx" class3="c" angle="2.0771163427984516" k="520.4896"/>
+    <Angle class1="c3" class2="cy" class3="cv" angle="2.0690878282392777" k="513.7952"/>
+    <Angle class1="c" class2="ce" class3="cv" angle="2.1120229278383382" k="543.9200000000001"/>
+    <Angle class1="c3" class2="cy" class3="ce" angle="2.0786871391252464" k="512.9584"/>
+    <Angle class1="nj" class2="s6" class3="oh" angle="1.6982053621904827" k="587.4336000000001"/>
+    <Angle class1="ce" class2="c2" class3="cy" angle="2.0984093596727824" k="541.4096000000001"/>
+    <Angle class1="c" class2="ni" class3="cx" angle="1.9703021925763986" k="533.8783999999999"/>
+    <Angle class1="cx" class2="cx" class3="ni" angle="1.0506882097005865" k="753.12"/>
+    <Angle class1="cx" class2="cx" class3="nk" angle="1.052957137728179" k="749.7728"/>
+    <Angle class1="cy" class2="nj" class3="cy" angle="1.6502088077606385" k="578.2288"/>
+    <Angle class1="c" class2="cy" class3="n3" angle="2.082875929330033" k="531.368"/>
+    <Angle class1="h1" class2="cy" class3="sq" angle="1.9666370011472105" k="343.9248"/>
+    <Angle class1="ca" class2="ca" class3="nj" angle="2.0954422999443922" k="569.8607999999999"/>
+    <Angle class1="cy" class2="cy" class3="nl" angle="1.569400063393301" k="598.312"/>
+    <Angle class1="c3" class2="cy" class3="ca" angle="1.9821704314899597" k="525.5104"/>
+    <Angle class1="sq" class2="p5" class3="sq" angle="1.6151276897955529" k="323.8416"/>
+    <Angle class1="p5" class2="sq" class3="p5" angle="1.526290430869041" k="853.5360000000001"/>
+    <Angle class1="cy" class2="cy" class3="nh" angle="2.027374459116613" k="538.8992000000001"/>
+    <Angle class1="cx" class2="c3" class3="f" angle="1.9156733869889764" k="555.6352"/>
+    <Angle class1="ca" class2="cx" class3="ca" angle="1.956339558560444" k="538.8992000000001"/>
+    <Angle class1="cy" class2="nl" class3="cy" angle="1.6683602319813795" k="556.472"/>
+    <Angle class1="cv" class2="sq" class3="cy" angle="1.441991027997715" k="562.3296"/>
+    <Angle class1="c3" class2="cx" class3="nm" angle="2.0402898955813713" k="543.0832"/>
+    <Angle class1="cd" class2="cd" class3="cx" angle="2.1146409217163296" k="533.0416"/>
+    <Angle class1="ce" class2="cx" class3="op" angle="2.0457004162625534" k="552.288"/>
+    <Angle class1="cx" class2="cx" class3="oh" angle="2.051285469868936" k="557.3088"/>
+    <Angle class1="cl" class2="cy" class3="sq" angle="1.9765853778835782" k="512.1216000000001"/>
+    <Angle class1="cl" class2="cy" class3="cl" angle="1.898394627394232" k="528.0208"/>
+    <Angle class1="nh" class2="p5" class3="np" angle="1.8017033868337466" k="353.96639999999996"/>
+    <Angle class1="h2" class2="cy" class3="h2" angle="1.9624482109424242" k="323.8416"/>
+    <Angle class1="c" class2="nj" class3="cx" angle="2.2766074763014035" k="509.6112"/>
+    <Angle class1="f" class2="cy" class3="s4" angle="1.9509290378792614" k="497.05920000000003"/>
+    <Angle class1="cy" class2="nl" class3="hn" angle="2.033134045648194" k="369.86560000000003"/>
+    <Angle class1="cy" class2="cv" class3="cy" angle="1.6142550251695553" k="584.0864"/>
+    <Angle class1="c3" class2="nq" class3="p5" angle="2.2694516263682267" k="615.048"/>
+    <Angle class1="c2" class2="cv" class3="cy" angle="2.336995868420407" k="512.9584"/>
+    <Angle class1="cy" class2="nn" class3="cy" angle="1.6285667250359088" k="580.7392000000001"/>
+    <Angle class1="cu" class2="c3" class3="hc" angle="1.907993938280201" k="400.8272"/>
+    <Angle class1="o" class2="p5" class3="oq" angle="1.9484855769264695" k="362.3344"/>
+    <Angle class1="f" class2="cy" class3="p3" angle="1.9805996351631652" k="625.9264"/>
+    <Angle class1="cx" class2="nj" class3="cy" angle="2.0282471237426103" k="526.3472"/>
+    <Angle class1="c" class2="cx" class3="nj" angle="2.111673861987939" k="538.8992000000001"/>
+    <Angle class1="br" class2="cx" class3="br" angle="1.9434241220956858" k="566.5136"/>
+    <Angle class1="c2" class2="c3" class3="nj" angle="1.7809339687350139" k="584.0864"/>
+    <Angle class1="cy" class2="nj" class3="hn" angle="2.276432943376204" k="360.66080000000005"/>
+    <Angle class1="c" class2="nj" class3="hn" angle="2.2809707994313895" k="378.2336"/>
+    <Angle class1="c3" class2="cx" class3="ce" angle="2.0549506612981236" k="520.4896"/>
+    <Angle class1="c3" class2="os" class3="cx" angle="2.005034244691086" k="523.8368"/>
+    <Angle class1="c" class2="os" class3="cx" angle="2.064375439258893" k="529.6944"/>
+    <Angle class1="c" class2="c" class3="cx" angle="1.9528489000564555" k="528.8576"/>
+    <Angle class1="cx" class2="c2" class3="n2" angle="2.11760798144472" k="568.1872000000001"/>
+    <Angle class1="ce" class2="cx" class3="h1" angle="2.012015561699063" k="386.6016"/>
+    <Angle class1="c3" class2="c3" class3="nk" angle="1.966462468222011" k="541.4096000000001"/>
+    <Angle class1="op" class2="cx" class3="os" angle="2.0259781957150174" k="592.4544"/>
+    <Angle class1="c2" class2="cy" class3="oh" angle="1.931381350256925" k="570.6976000000001"/>
+    <Angle class1="ce" class2="cv" class3="sq" angle="2.2629939081358477" k="502.9168"/>
+    <Angle class1="cy" class2="p3" class3="cy" angle="1.464505775348442" k="330.536"/>
+    <Angle class1="p3" class2="cy" class3="p3" angle="1.6407840297998693" k="866.0880000000001"/>
+    <Angle class1="cx" class2="cx" class3="i" angle="2.155481626212997" k="459.4032"/>
+    <Angle class1="ce" class2="c2" class3="nm" angle="2.221280539013183" k="564.0032000000001"/>
+    <Angle class1="c3" class2="c2" class3="nm" angle="2.0847957915072266" k="548.104"/>
+    <Angle class1="c" class2="cy" class3="oq" angle="1.5496778428457652" k="619.232"/>
+    <Angle class1="cx" class2="no" class3="o" angle="2.0378464346285794" k="569.024"/>
+    <Angle class1="cx" class2="cx" class3="h2" angle="2.1423916568230394" k="373.2128"/>
+    <Angle class1="cy" class2="s4" class3="o" angle="1.865582437456739" k="523.8368"/>
+    <Angle class1="sq" class2="cy" class3="sq" angle="1.6524777357882312" k="555.6352"/>
+    <Angle class1="cv" class2="cx" class3="cx" angle="2.296329696848939" k="494.5488"/>
+    <Angle class1="nj" class2="p5" class3="nj" angle="1.913229926036184" k="328.8624"/>
+    <Angle class1="cl" class2="cx" class3="op" angle="2.017949681155844" k="533.0416"/>
+    <Angle class1="h2" class2="cy" class3="na" angle="1.8596483179999581" k="425.9312"/>
+    <Angle class1="na" class2="cy" class3="oq" angle="1.9685568633244044" k="584.0864"/>
+    <Angle class1="h2" class2="cy" class3="oq" angle="1.9458675830484777" k="415.05280000000005"/>
+    <Angle class1="ce" class2="cv" class3="cy" angle="2.3177972466484698" k="511.2848"/>
+    <Angle class1="c1" class2="cy" class3="cy" angle="2.021614872585032" k="523.8368"/>
+    <Angle class1="c" class2="cy" class3="nj" angle="2.0008454544862997" k="538.8992000000001"/>
+    <Angle class1="cu" class2="c2" class3="h4" angle="2.1090558681099476" k="419.2368"/>
+    <Angle class1="c" class2="cy" class3="nq" angle="1.983392161966356" k="540.5728"/>
+    <Angle class1="c3" class2="cy" class3="cl" angle="2.033657644423793" k="505.4272"/>
+    <Angle class1="cc" class2="c2" class3="cx" angle="2.0715312891920696" k="548.9408"/>
+    <Angle class1="c" class2="cd" class3="cx" angle="2.110277598586344" k="527.184"/>
+    <Angle class1="c3" class2="c" class3="nj" angle="2.0505873381681377" k="549.7776"/>
+    <Angle class1="cx" class2="nk" class3="cx" angle="1.0356783781334353" k="719.648"/>
+    <Angle class1="c" class2="nj" class3="ca" angle="2.3326325452904215" k="511.2848"/>
+    <Angle class1="c3" class2="nk" class3="c3" angle="2.0287707225182086" k="510.44800000000004"/>
+    <Angle class1="ni" class2="c" class3="o" angle="2.1774727747881255" k="600.8224"/>
+    <Angle class1="c3" class2="cx" class3="n2" angle="2.0334831114985934" k="544.7568"/>
+    <Angle class1="cx" class2="ni" class3="cx" angle="1.040041701263421" k="722.1584"/>
+    <Angle class1="cx" class2="c2" class3="oh" angle="2.06524810388489" k="569.8607999999999"/>
+    <Angle class1="c" class2="cx" class3="nm" angle="2.0312141834710005" k="548.104"/>
+    <Angle class1="cy" class2="sq" class3="cy" angle="1.3281955607676845" k="572.3712"/>
+    <Angle class1="cx" class2="c2" class3="cx" angle="1.9996237240099033" k="537.2256000000001"/>
+    <Angle class1="c" class2="cy" class3="c" angle="1.9343484099853154" k="523.0"/>
+    <Angle class1="cy" class2="cy" class3="sq" angle="1.5938346729212216" k="558.9824"/>
+    <Angle class1="hx" class2="c3" class3="nl" angle="1.898394627394232" k="406.68480000000005"/>
+    <Angle class1="h2" class2="cx" class3="op" angle="2.029643387144206" k="412.5424"/>
+    <Angle class1="c1" class2="cx" class3="op" angle="2.053903463746927" k="563.1664"/>
+    <Angle class1="cg" class2="c1" class3="cx" angle="3.1196015050146646" k="472.79200000000003"/>
+    <Angle class1="cu" class2="c2" class3="na" angle="2.227738257245562" k="567.3504"/>
+    <Angle class1="cy" class2="cy" class3="n2" angle="2.0549506612981236" k="538.8992000000001"/>
+    <Angle class1="ca" class2="nj" class3="cy" angle="2.26229577643505" k="504.5904"/>
+    <Angle class1="ca" class2="cy" class3="nj" angle="2.0378464346285794" k="541.4096000000001"/>
+    <Angle class1="ca" class2="cy" class3="h1" angle="1.9186404467173663" k="392.4592"/>
+    <Angle class1="np" class2="py" class3="np" angle="1.8238690683340744" k="348.9456"/>
+    <Angle class1="c3" class2="cy" class3="p5" angle="2.0162043519038493" k="621.7424"/>
+    <Angle class1="h1" class2="cy" class3="n2" angle="1.9940386704035216" k="415.88960000000003"/>
+    <Angle class1="sq" class2="p5" class3="ss" angle="1.8956021005910413" k="302.9216"/>
+    <Angle class1="c2" class2="n2" class3="cy" angle="2.0387190992545765" k="564.0032000000001"/>
+    <Angle class1="n3" class2="cy" class3="p3" angle="1.9114845967841896" k="656.0512000000001"/>
+    <Angle class1="c3" class2="cy" class3="p3" angle="2.02213847136063" k="616.7216000000001"/>
+    <Angle class1="cx" class2="c2" class3="nh" angle="2.104518012054762" k="553.9616000000001"/>
+    <Angle class1="op" class2="op" class3="p5" angle="1.052084473102182" k="900.3968"/>
+    <Angle class1="f" class2="cy" class3="s6" angle="1.970127659651199" k="509.6112"/>
+    <Angle class1="o" class2="p5" class3="op" angle="2.1652554700241655" k="353.96639999999996"/>
+    <Angle class1="c" class2="c" class3="nj" angle="2.008699436120274" k="550.6144"/>
+    <Angle class1="no" class2="cy" class3="no" angle="1.8596483179999581" k="571.5344"/>
+    <Angle class1="cv" class2="cy" class3="f" angle="2.0364501712269836" k="538.0624"/>
+    <Angle class1="c" class2="cx" class3="c2" angle="2.0537289308217277" k="527.184"/>
+    <Angle class1="c2" class2="os" class3="cy" angle="1.9207348418197596" k="545.5936"/>
+    <Angle class1="h2" class2="cx" class3="sp" angle="2.017600615305445" k="343.9248"/>
+    <Angle class1="ce" class2="cx" class3="ce" angle="1.9460421159736774" k="538.0624"/>
+    <Angle class1="ca" class2="os" class3="cy" angle="2.07449834892046" k="523.0"/>
+    <Angle class1="h2" class2="cy" class3="s4" angle="1.981646832714362" k="329.6992"/>
+    <Angle class1="ca" class2="c" class3="cy" angle="1.8657569703819383" k="542.2464"/>
+    <Angle class1="n3" class2="p5" class3="sq" angle="1.8315485170428494" k="314.63680000000005"/>
+    <Angle class1="n" class2="c" class3="nj" angle="1.987755485096342" k="604.1696000000001"/>
+    <Angle class1="cf" class2="c3" class3="cx" angle="1.8933331725634486" k="539.736"/>
+    <Angle class1="cx" class2="np" class3="sy" angle="2.015331687277852" k="513.7952"/>
+    <Angle class1="c" class2="nj" class3="cl" angle="2.1916099417292796" k="497.896"/>
+    <Angle class1="c" class2="nj" class3="c" angle="1.8259634634364679" k="578.2288"/>
+    <Angle class1="nj" class2="c" class3="nj" angle="1.6151276897955529" k="665.256"/>
+    <Angle class1="cx" class2="cx" class3="n2" angle="2.0825268634796337" k="540.5728"/>
+    <Angle class1="nq" class2="p5" class3="nq" angle="1.4027211198278426" k="389.9488"/>
+    <Angle class1="p5" class2="nq" class3="p5" angle="1.7388715337619502" k="898.7232000000001"/>
+    <Angle class1="ca" class2="nn" class3="p5" angle="2.2682298958918308" k="643.4992000000001"/>
+    <Angle class1="c3" class2="p5" class3="nj" angle="1.8425440913304136" k="319.65760000000006"/>
+    <Angle class1="c3" class2="nj" class3="p5" angle="2.378534704617872" k="594.128"/>
+    <Angle class1="c" class2="nj" class3="p5" angle="1.6332791140162934" k="722.9952000000001"/>
+    <Angle class1="n4" class2="cy" class3="p3" angle="2.0046851788406865" k="635.9680000000001"/>
+    <Angle class1="hx" class2="cy" class3="p3" angle="1.9898498801987352" k="417.5632"/>
+    <Angle class1="cf" class2="cc" class3="sq" angle="2.2708478897698225" k="497.896"/>
+    <Angle class1="ce" class2="cy" class3="cl" angle="1.9928169399271256" k="512.1216000000001"/>
+    <Angle class1="cl" class2="np" class3="cx" angle="2.0073031727186783" k="499.56960000000004"/>
+    <Angle class1="s6" class2="cy" class3="s6" angle="1.6137314263939568" k="561.4928"/>
+    <Angle class1="c1" class2="c1" class3="cx" angle="3.1346113365818153" k="473.6288"/>
+    <Angle class1="c" class2="cy" class3="c2" angle="2.0053833105414847" k="519.6528000000001"/>
+    <Angle class1="cv" class2="cy" class3="h1" angle="2.0271999261914138" k="380.744"/>
+    <Angle class1="sq" class2="cv" class3="sq" angle="1.7573720238330903" k="565.6768"/>
+    <Angle class1="br" class2="cy" class3="c" angle="1.9860101558443477" k="518.816"/>
+    <Angle class1="c3" class2="nl" class3="cy" angle="1.9971802630571114" k="511.2848"/>
+    <Angle class1="cy" class2="c1" class3="n1" angle="3.1100021941286955" k="487.0176"/>
+    <Angle class1="c" class2="cy" class3="f" angle="1.9544196963832503" k="542.2464"/>
+    <Angle class1="cx" class2="s6" class3="o" angle="1.8828611970514826" k="538.8992000000001"/>
+    <Angle class1="c2" class2="cy" class3="oq" angle="1.9280652246781358" k="563.1664"/>
+    <Angle class1="np" class2="p5" class3="os" angle="1.7516124373015092" k="366.5184"/>
+    <Angle class1="c3" class2="c3" class3="cu" angle="1.971698455977994" k="531.368"/>
+    <Angle class1="c3" class2="cu" class3="cu" angle="2.6586600495629624" k="492.8752"/>
+    <Angle class1="c3" class2="cu" class3="cx" angle="2.497740692529085" k="483.6704"/>
+    <Angle class1="cx" class2="np" class3="p3" angle="2.047445745514548" k="639.3152000000001"/>
+    <Angle class1="ca" class2="p3" class3="cy" angle="1.857553922897565" k="299.57439999999997"/>
+    <Angle class1="cy" class2="py" class3="s" angle="2.006430508092681" k="297.9008"/>
+    <Angle class1="ca" class2="py" class3="cy" angle="1.9090411358313977" k="293.71680000000003"/>
+    <Angle class1="np" class2="s6" class3="o" angle="1.865582437456739" k="568.1872000000001"/>
+    <Angle class1="cu" class2="cx" class3="f" angle="2.148151243354621" k="534.7152"/>
+    <Angle class1="cy" class2="cc" class3="na" angle="2.223549467040776" k="538.0624"/>
+    <Angle class1="c" class2="cy" class3="n2" angle="1.9973547959823106" k="547.2672000000001"/>
+    <Angle class1="nm" class2="cx" class3="os" angle="2.050936404018537" k="581.576"/>
+    <Angle class1="cl" class2="cx" class3="nm" angle="2.0338321773489922" k="526.3472"/>
+    <Angle class1="c3" class2="n" class3="cx" angle="2.0130627592502597" k="533.0416"/>
+    <Angle class1="cx" class2="cx" class3="no" angle="2.03749736877818" k="538.8992000000001"/>
+    <Angle class1="cf" class2="sx" class3="cy" angle="1.528210293046235" k="536.3888"/>
+    <Angle class1="cy" class2="sx" class3="o" angle="1.8626153777283485" k="534.7152"/>
+    <Angle class1="h2" class2="cy" class3="sx" angle="1.8343410438460404" k="353.12960000000004"/>
+    <Angle class1="nj" class2="cy" class3="sx" angle="1.847954612011596" k="536.3888"/>
+    <Angle class1="cy" class2="cy" class3="sx" angle="2.1497220396814156" k="479.4864"/>
+    <Angle class1="ce" class2="cy" class3="s6" angle="2.0598375832037075" k="495.38560000000007"/>
+    <Angle class1="c" class2="cx" class3="ca" angle="2.0113174299982655" k="530.5312"/>
+    <Angle class1="np" class2="sy" class3="o" angle="1.893507705488648" k="576.5552"/>
+    <Angle class1="cy" class2="p5" class3="n3" angle="1.9518017025052585" k="312.1264"/>
+    <Angle class1="cf" class2="c2" class3="cx" angle="2.257583387454665" k="528.0208"/>
+    <Angle class1="c" class2="cx" class3="cv" angle="1.5596262195821329" k="600.8224"/>
+    <Angle class1="cx" class2="cx" class3="s4" angle="2.066120768510887" k="488.6912"/>
+    <Angle class1="ca" class2="ss" class3="cy" angle="1.7329374143051697" k="510.44800000000004"/>
+    <Angle class1="cv" class2="ce" class3="cy" angle="1.6540485321150258" k="605.8432"/>
+    <Angle class1="c" class2="cy" class3="cv" angle="2.016902483604647" k="517.1424"/>
+    <Angle class1="c3" class2="c" class3="cy" angle="2.028072590817411" k="514.6320000000001"/>
+    <Angle class1="cl" class2="cy" class3="f" angle="1.9401079965168966" k="524.6736000000001"/>
+    <Angle class1="c2" class2="nh" class3="cy" angle="2.0809560671528393" k="535.552"/>
+    <Angle class1="c1" class2="ce" class3="cy" angle="2.3743459144130856" k="512.1216000000001"/>
+    <Angle class1="c2" class2="cy" class3="cl" angle="1.881290400724688" k="527.184"/>
+    <Angle class1="c" class2="cx" class3="c1" angle="1.9278906917529361" k="550.6144"/>
+    <Angle class1="c" class2="cy" class3="n4" angle="1.8463838156848014" k="554.7984"/>
+    <Angle class1="cx" class2="n4" class3="hn" angle="1.9448203854972816" k="382.41760000000005"/>
+    <Angle class1="c3" class2="ce" class3="cv" angle="2.186199421048097" k="527.184"/>
+    <Angle class1="cy" class2="nj" class3="os" angle="2.1874211515244935" k="530.5312"/>
+    <Angle class1="c" class2="nj" class3="os" angle="2.1954496660836673" k="543.9200000000001"/>
+    <Angle class1="ce" class2="ce" class3="cy" angle="1.6064010435355809" k="598.312"/>
+    <Angle class1="cx" class2="p5" class3="o" angle="1.880941334874289" k="337.2304"/>
+    <Angle class1="c3" class2="cy" class3="f" angle="2.026501794490616" k="536.3888"/>
+    <Angle class1="cx" class2="p5" class3="oh" angle="1.7386970008367513" k="343.088"/>
+    <Angle class1="cx" class2="cx" class3="p5" angle="2.099456557223979" k="625.0896"/>
+    <Angle class1="c2" class2="cy" class3="c3" angle="1.9015362200478219" k="537.2256000000001"/>
+    <Angle class1="ce" class2="cy" class3="oq" angle="1.8774506763703" k="569.8607999999999"/>
+    <Angle class1="c3" class2="c2" class3="cv" angle="2.2223277365643797" k="528.0208"/>
+    <Angle class1="cv" class2="c2" class3="ha" angle="2.0453513504121545" k="423.42080000000004"/>
+    <Angle class1="c1" class2="c2" class3="cx" angle="2.158797751791786" k="545.5936"/>
+    <Angle class1="c1" class2="cx" class3="c3" angle="1.969953126726" k="541.4096000000001"/>
+    <Angle class1="cy" class2="nh" class3="hn" angle="2.032435913947397" k="389.112"/>
+    <Angle class1="cx" class2="ce" class3="n2" angle="2.2116812281272145" k="550.6144"/>
+    <Angle class1="cx" class2="cx" class3="s6" angle="2.0668189002116852" k="495.38560000000007"/>
+    <Angle class1="ce" class2="n2" class3="cx" angle="1.8725637544647162" k="579.9024"/>
+    <Angle class1="ce" class2="c" class3="cy" angle="1.570621793869697" k="592.4544"/>
+    <Angle class1="cl" class2="c2" class3="cx" angle="2.005906909317083" k="526.3472"/>
+    <Angle class1="c3" class2="c3" class3="cv" angle="1.9062486090282067" k="538.0624"/>
+    <Angle class1="cy" class2="c3" class3="nh" angle="1.9528489000564555" k="551.4512000000001"/>
+    <Angle class1="h1" class2="cx" class3="i" angle="1.8786724068466962" k="314.63680000000005"/>
+    <Angle class1="cy" class2="c3" class3="no" angle="2.0022417178878946" k="532.2048"/>
+    <Angle class1="c" class2="cx" class3="cl" angle="1.9767599108087777" k="516.3056"/>
+    <Angle class1="br" class2="c3" class3="cy" angle="1.9181168479417683" k="523.0"/>
+    <Angle class1="c1" class2="cx" class3="np" angle="2.035752039526186" k="555.6352"/>
+    <Angle class1="cv" class2="cv" class3="nh" angle="2.3017402175301216" k="562.3296"/>
+    <Angle class1="cy" class2="cv" class3="nh" angle="2.3427554549519884" k="519.6528000000001"/>
+    <Angle class1="ca" class2="cx" class3="n2" angle="2.0697859599400754" k="544.7568"/>
+    <Angle class1="o" class2="s6" class3="sp" angle="2.0313887163962" k="507.93760000000003"/>
+    <Angle class1="o" class2="s6" class3="op" angle="1.979377904686769" k="595.8016"/>
+    <Angle class1="c2" class2="c3" class3="nq" angle="1.980250569312766" k="553.9616000000001"/>
+    <Angle class1="n3" class2="c3" class3="np" angle="1.8561576594959692" k="594.128"/>
+    <Angle class1="h2" class2="c3" class3="np" angle="1.8978710286186338" k="417.5632"/>
+    <Angle class1="cy" class2="nq" class3="nq" angle="1.5570082257041413" k="604.1696000000001"/>
+    <Angle class1="c3" class2="s6" class3="cx" angle="1.8067648416645299" k="496.2224"/>
+    <Angle class1="c3" class2="cx" class3="s6" angle="1.9448203854972816" k="509.6112"/>
+    <Angle class1="ca" class2="p3" class3="cx" angle="1.8374826364996302" k="301.248"/>
+    <Angle class1="hc" class2="cx" class3="p3" angle="1.907993938280201" k="425.0944"/>
+    <Angle class1="cx" class2="cx" class3="p3" angle="1.1700687305369988" k="813.3696000000001"/>
+    <Angle class1="c2" class2="cx" class3="p3" angle="2.0238838006126247" k="620.0688"/>
+    <Angle class1="c3" class2="cx" class3="n" angle="2.069262361164477" k="543.0832"/>
+    <Angle class1="ce" class2="nm" class3="cx" angle="2.1406463275710452" k="523.8368"/>
+    <Angle class1="ca" class2="cx" class3="n3" angle="2.013586358025858" k="553.9616000000001"/>
+    <Angle class1="ne" class2="sy" class3="np" angle="1.7914059442469796" k="561.4928"/>
+    <Angle class1="h1" class2="cx" class3="n2" angle="2.008699436120274" k="408.3584"/>
+    <Angle class1="c3" class2="s6" class3="np" angle="1.6819738001469353" k="534.7152"/>
+    <Angle class1="nj" class2="os" class3="s6" angle="1.9586084865880367" k="545.5936"/>
+    <Angle class1="op" class2="np" class3="s6" angle="1.8685494971851293" k="535.552"/>
+    <Angle class1="cx" class2="np" class3="s6" angle="1.9064231419534063" k="515.4688"/>
+    <Angle class1="cx" class2="np" class3="op" angle="1.0053096491487339" k="763.1616"/>
+    <Angle class1="cx" class2="op" class3="np" angle="1.051735407251783" k="720.4848"/>
+    <Angle class1="np" class2="cx" class3="op" angle="1.08646745936647" k="785.7552000000001"/>
+    <Angle class1="ca" class2="cx" class3="np" angle="1.9502309061784637" k="558.1456000000001"/>
+    <Angle class1="ne" class2="cv" class3="sq" angle="2.279050937254196" k="519.6528000000001"/>
+    <Angle class1="cx" class2="c2" class3="n" angle="1.848303677861995" k="588.2704"/>
+    <Angle class1="n" class2="c" class3="ni" angle="1.9017107529730213" k="610.0272000000001"/>
+    <Angle class1="cy" class2="s4" class3="os" angle="1.7434093898171357" k="523.8368"/>
+    <Angle class1="cy" class2="s4" class3="cy" angle="1.3449507215868304" k="549.7776"/>
+    <Angle class1="s4" class2="cy" class3="s6" angle="1.6812756684461374" k="541.4096000000001"/>
+    <Angle class1="cy" class2="c3" class3="cy" angle="1.6760396806901547" k="568.1872000000001"/>
+    <Angle class1="op" class2="p5" class3="op" angle="1.0293951928262555" k="493.71200000000005"/>
+    <Angle class1="nh" class2="p5" class3="op" angle="1.9154988540637765" k="353.96639999999996"/>
+    <Angle class1="hn" class2="nl" class3="hn" angle="1.9940386704035216" k="324.6784"/>
+    <Angle class1="c" class2="cy" class3="nl" angle="1.888271717732665" k="546.4304"/>
+    <Angle class1="c" class2="cy" class3="hx" angle="1.8914133103862552" k="387.4384"/>
+    <Angle class1="cy" class2="cc" class3="nd" angle="2.1629865419965726" k="554.7984"/>
+    <Angle class1="c1" class2="cv" class3="cy" angle="2.352354765837957" k="514.6320000000001"/>
+    <Angle class1="h2" class2="cx" class3="nm" angle="2.0971876291963865" k="399.15360000000004"/>
+    <Angle class1="cl" class2="cx" class3="h2" angle="1.9121827284849875" k="358.98720000000003"/>
+    <Angle class1="c3" class2="cx" class3="sp" angle="2.0586158527273115" k="500.4064"/>
+    <Angle class1="h1" class2="cx" class3="sp" angle="1.987406419245943" k="347.272"/>
+    <Angle class1="cx" class2="cx" class3="sp" angle="1.154535300194249" k="669.44"/>
+    <Angle class1="cy" class2="cy" class3="sy" angle="2.030865117620602" k="495.38560000000007"/>
+    <Angle class1="cy" class2="sy" class3="o" angle="1.9078194053550015" k="534.7152"/>
+    <Angle class1="c3" class2="s4" class3="cy" angle="1.5872024217636433" k="517.1424"/>
+    <Angle class1="nj" class2="cy" class3="s4" angle="1.9086920699809986" k="517.1424"/>
+    <Angle class1="c1" class2="cx" class3="n3" angle="2.038020967553779" k="560.6560000000001"/>
+    <Angle class1="c3" class2="s4" class3="cx" angle="1.6721999563357672" k="507.93760000000003"/>
+    <Angle class1="c" class2="cy" class3="ca" angle="1.9189895125677654" k="530.5312"/>
+    <Angle class1="ce" class2="os" class3="cx" angle="1.8634880423543456" k="555.6352"/>
+    <Angle class1="cx" class2="c" class3="s" angle="2.2038272464932396" k="514.6320000000001"/>
+    <Angle class1="cy" class2="ca" class3="nb" angle="2.075720079396856" k="557.3088"/>
+    <Angle class1="cl" class2="cx" class3="n2" angle="2.0319123151717986" k="527.184"/>
+    <Angle class1="c3" class2="cx" class3="cl" angle="2.0073031727186783" k="510.44800000000004"/>
+    <Angle class1="cl" class2="cy" class3="p3" angle="1.9758872461827806" k="637.6416"/>
+    <Angle class1="cl" class2="cy" class3="p5" angle="1.9989255923091056" k="636.8048"/>
+    <Angle class1="c1" class2="cx" class3="c1" angle="1.9762363120331796" k="555.6352"/>
+    <Angle class1="nn" class2="p5" class3="nn" angle="1.3948671381938682" k="407.52160000000003"/>
+    <Angle class1="p5" class2="nn" class3="p5" angle="1.746725515395925" k="933.032"/>
+    <Angle class1="cp" class2="ca" class3="cx" angle="1.8896679811342605" k="564.84"/>
+    <Angle class1="ce" class2="cv" class3="cx" angle="2.348689574408769" k="511.2848"/>
+    <Angle class1="cc" class2="sq" class3="cc" angle="1.4028956527530418" k="579.9024"/>
+    <Angle class1="sq" class2="cc" class3="sq" angle="1.7386970008367513" k="564.0032000000001"/>
+    <Angle class1="ca" class2="cy" class3="cl" angle="1.9275416259025373" k="520.4896"/>
+    <Angle class1="c3" class2="cy" class3="nl" angle="2.0004963886359004" k="534.7152"/>
+    <Angle class1="sq" class2="cy" class3="ss" angle="1.974840048631584" k="507.93760000000003"/>
+    <Angle class1="cx" class2="c3" class3="py" angle="1.8210765415308834" k="669.44"/>
+    <Angle class1="cy" class2="s4" class3="nq" angle="1.3412855301576423" k="589.1072"/>
+    <Angle class1="nq" class2="s4" class3="o" angle="1.992642407001926" k="558.1456000000001"/>
+    <Angle class1="c3" class2="nq" class3="s4" angle="2.172062254106943" k="497.05920000000003"/>
+    <Angle class1="cy" class2="nq" class3="no" angle="2.150769237232612" k="537.2256000000001"/>
+    <Angle class1="nq" class2="no" class3="o" angle="2.044304152860958" k="624.2528"/>
+    <Angle class1="ce" class2="cu" class3="cx" angle="1.1496483782886648" k="752.2832000000001"/>
+    <Angle class1="cu" class2="ce" class3="cx" angle="1.0922270458980514" k="760.6512000000001"/>
+    <Angle class1="ca" class2="ce" class3="cu" angle="2.7111944600479916" k="488.6912"/>
+    <Angle class1="cv" class2="cy" class3="nj" angle="1.5212289760382576" k="625.0896"/>
+    <Angle class1="ca" class2="ce" class3="cx" angle="2.4804619329343414" k="481.16"/>
+    <Angle class1="ce" class2="cx" class3="cu" angle="0.8997172294030767" k="799.9807999999999"/>
+    <Angle class1="cy" class2="s6" class3="nj" angle="1.3531537690712037" k="599.1487999999999"/>
+    <Angle class1="c3" class2="cy" class3="s6" angle="2.047445745514548" k="495.38560000000007"/>
+    <Angle class1="c2" class2="cy" class3="os" angle="1.8310249182672511" k="584.9232000000001"/>
+    <Angle class1="c3" class2="cy" class3="nn" angle="2.0436060211601603" k="536.3888"/>
+    <Angle class1="h1" class2="cx" class3="oh" angle="1.9401079965168966" k="431.78880000000004"/>
+    <Angle class1="cc" class2="cx" class3="op" angle="2.036624704152183" k="560.6560000000001"/>
+    <Angle class1="c" class2="c3" class3="np" angle="1.9404570623672956" k="555.6352"/>
+    <Angle class1="cx" class2="os" class3="p5" angle="2.120400508247911" k="649.3568"/>
+    <Angle class1="oq" class2="cy" class3="oq" angle="1.583537230334455" k="651.8672"/>
+    <Angle class1="cy" class2="cd" class3="nd" angle="2.0748474147708587" k="555.6352"/>
+    <Angle class1="cx" class2="c" class3="ne" angle="1.9703021925763986" k="567.3504"/>
+    <Angle class1="oq" class2="cy" class3="os" angle="1.9008380883470242" k="602.496"/>
+    <Angle class1="ce" class2="cx" class3="cf" angle="1.8552849948699721" k="551.4512000000001"/>
+    <Angle class1="cf" class2="cx" class3="op" angle="2.102423616952369" k="545.5936"/>
+    <Angle class1="cf" class2="cf" class3="cx" angle="1.8336429121452427" k="563.1664"/>
+    <Angle class1="cv" class2="cu" class3="cx" angle="2.607870968329927" k="499.56960000000004"/>
+    <Angle class1="cx" class2="sp" class3="sp" angle="0.944572191179331" k="680.3184"/>
+    <Angle class1="br" class2="c2" class3="cx" angle="1.9736183181551878" k="538.0624"/>
+    <Angle class1="cy" class2="cy" class3="n1" angle="2.0134118251006585" k="543.9200000000001"/>
+    <Angle class1="c" class2="cx" class3="f" angle="1.9870573533955442" k="548.104"/>
+    <Angle class1="c" class2="cx" class3="cy" angle="1.561197015908928" k="595.8016"/>
+    <Angle class1="c3" class2="cy" class3="cx" angle="1.9643680731196178" k="525.5104"/>
+    <Angle class1="c3" class2="p5" class3="np" angle="1.8235200024836755" k="326.35200000000003"/>
+    <Angle class1="cy" class2="p5" class3="s" angle="2.0355775066009865" k="302.9216"/>
+    <Angle class1="np" class2="p3" class3="ss" angle="1.7240362351199987" k="326.35200000000003"/>
+    <Angle class1="cy" class2="cy" class3="p5" angle="1.5111060663766904" k="715.464"/>
+    <Angle class1="cy" class2="cv" class3="n2" angle="2.3198916417508624" k="534.7152"/>
+    <Angle class1="c1" class2="c3" class3="cy" angle="1.924923632024546" k="541.4096000000001"/>
+    <Angle class1="oq" class2="p5" class3="oq" angle="1.4927801092307502" k="391.62239999999997"/>
+    <Angle class1="p5" class2="oq" class3="p5" angle="1.6484634785086443" k="907.0912000000001"/>
+    <Angle class1="cx" class2="cx" class3="n1" angle="2.1331414117874696" k="543.9200000000001"/>
+    <Angle class1="cd" class2="cx" class3="h1" angle="1.970476725501598" k="395.8064"/>
+    <Angle class1="cd" class2="cx" class3="np" angle="2.1521655006342075" k="533.8783999999999"/>
+    <Angle class1="c2" class2="cx" class3="cd" angle="2.014109956801456" k="536.3888"/>
+    <Angle class1="cx" class2="op" class3="op" angle="0.9796533091444172" k="717.9744000000001"/>
+    <Angle class1="s4" class2="cy" class3="sq" angle="1.6123351629923615" k="552.288"/>
+    <Angle class1="c3" class2="cy" class3="s4" angle="1.7551030958054976" k="522.1632"/>
+    <Angle class1="c3" class2="cy" class3="h2" angle="2.065946235585688" k="374.04960000000005"/>
+    <Angle class1="c3" class2="cy" class3="sq" angle="1.853714198543177" k="521.3264"/>
+    <Angle class1="cx" class2="c2" class3="os" angle="2.030516051770203" k="571.5344"/>
+    <Angle class1="cy" class2="c3" class3="s6" angle="1.853888731468377" k="529.6944"/>
+    <Angle class1="cy" class2="py" class3="cy" angle="1.4578735241908634" k="326.35200000000003"/>
+    <Angle class1="py" class2="cy" class3="py" angle="1.6837191293989295" k="841.8208"/>
+    <Angle class1="cl" class2="cy" class3="cv" angle="1.9814722997891623" k="512.9584"/>
+    <Angle class1="cl" class2="c2" class3="cv" angle="2.1322687471614725" k="524.6736000000001"/>
+    <Angle class1="cx" class2="np" class3="os" angle="1.9256217637253437" k="559.8192"/>
+    <Angle class1="c" class2="cy" class3="oh" angle="1.8235200024836755" k="578.2288"/>
+    <Angle class1="c3" class2="cy" class3="oh" angle="1.9329521465837198" k="565.6768"/>
+    <Angle class1="c3" class2="nh" class3="cy" angle="2.086541120759221" k="521.3264"/>
+    <Angle class1="c3" class2="p5" class3="op" angle="1.88373386167748" k="328.8624"/>
+    <Angle class1="ca" class2="ce" class3="cy" angle="1.924574566174147" k="543.0832"/>
+    <Angle class1="ca" class2="cy" class3="ce" angle="1.7523105690023069" k="562.3296"/>
+    <Angle class1="cx" class2="cu" class3="f" angle="2.5563837553960944" k="496.2224"/>
+    <Angle class1="cu" class2="cu" class3="f" angle="2.621484536495483" k="525.5104"/>
+    <Angle class1="c1" class2="cy" class3="hc" angle="1.8929841067130497" k="407.52160000000003"/>
+    <Angle class1="n3" class2="py" class3="np" angle="1.8746581495671093" k="344.76160000000004"/>
+    <Angle class1="cy" class2="c3" class3="n" angle="1.7257815643719931" k="586.5968"/>
+    <Angle class1="n2" class2="ce" class3="nm" angle="2.17310945165814" k="595.8016"/>
+    <Angle class1="ce" class2="ce" class3="nm" angle="2.0771163427984516" k="561.4928"/>
+    <Angle class1="ca" class2="ne" class3="cv" angle="2.176425577236929" k="553.9616000000001"/>
+    <Angle class1="c2" class2="cx" class3="ni" angle="1.8828611970514826" k="566.5136"/>
+    <Angle class1="c" class2="nj" class3="nq" angle="1.6627751783749978" k="608.3536"/>
+    <Angle class1="ca" class2="nj" class3="nq" angle="2.1893410137016867" k="528.8576"/>
+    <Angle class1="cy" class2="nq" class3="nj" angle="1.5353661429794117" k="615.8847999999999"/>
+    <Angle class1="hn" class2="nq" class3="nj" angle="1.8563321924211689" k="413.3792"/>
+    <Angle class1="c3" class2="cy" class3="no" angle="2.031737782246599" k="531.368"/>
+    <Angle class1="c" class2="cy" class3="sy" angle="1.8872245201814684" k="514.6320000000001"/>
+    <Angle class1="ca" class2="sy" class3="cy" angle="1.8381807682004276" k="493.71200000000005"/>
+    <Angle class1="h2" class2="cx" class3="np" angle="2.0315632493213998" k="401.664"/>
+    <Angle class1="ca" class2="cx" class3="h2" angle="2.030865117620602" k="386.6016"/>
+    <Angle class1="c3" class2="ss" class3="cx" angle="1.8687240301103285" k="485.344"/>
+    <Angle class1="cd" class2="c3" class3="cy" angle="1.9711748572023957" k="529.6944"/>
+    <Angle class1="c1" class2="cx" class3="ss" angle="2.0177751482306445" k="508.7744"/>
+    <Angle class1="c" class2="cx" class3="s4" angle="1.8648843057559408" k="515.4688"/>
+    <Angle class1="cx" class2="c3" class3="s6" angle="1.8216001403064819" k="535.552"/>
+    <Angle class1="c2" class2="c1" class3="cv" angle="3.1293753488258327" k="487.8544"/>
+    <Angle class1="cx" class2="c2" class3="f" angle="1.9647171389700164" k="558.9824"/>
+    <Angle class1="ce" class2="n2" class3="nj" angle="2.012364627549462" k="591.6176"/>
+    <Angle class1="cy" class2="nj" class3="n2" angle="2.3338542757668175" k="513.7952"/>
+    <Angle class1="c" class2="nj" class3="n2" angle="2.2677062971162325" k="536.3888"/>
+    <Angle class1="cx" class2="sp" class3="cx" angle="0.8285077959217081" k="734.7104"/>
+    <Angle class1="op" class2="s6" class3="sp" angle="1.028347995275059" k="703.7488"/>
+    <Angle class1="op" class2="sp" class3="s6" angle="0.8407251006856686" k="748.936"/>
+    <Angle class1="s6" class2="op" class3="sp" angle="1.2725195576290655" k="620.9056"/>
+    <Angle class1="ce" class2="cy" class3="s4" angle="2.0635027746328958" k="482.83360000000005"/>
+    <Angle class1="cx" class2="cy" class3="nj" angle="1.534668011278614" k="620.9056"/>
+    <Angle class1="cx" class2="cy" class3="h2" angle="2.1593213505673843" k="367.3552"/>
+    <Angle class1="cx" class2="cy" class3="s6" angle="2.0355775066009865" k="497.05920000000003"/>
+    <Angle class1="cx" class2="c" class3="nj" angle="1.5735888535980873" k="633.4576000000001"/>
+    <Angle class1="cd" class2="c" class3="cy" angle="2.0493656076917417" k="521.3264"/>
+    <Angle class1="c" class2="nj" class3="c1" angle="2.348864107333969" k="519.6528000000001"/>
+    <Angle class1="c1" class2="nj" class3="cy" angle="2.2968532956245378" k="510.44800000000004"/>
+    <Angle class1="cy" class2="c3" class3="i" angle="2.013237292175459" k="470.2816"/>
+    <Angle class1="cg" class2="c1" class3="nj" angle="3.138974659711802" k="507.10080000000005"/>
+    <Angle class1="br" class2="cy" class3="c3" angle="2.0195204774826387" k="515.4688"/>
+    <Angle class1="cx" class2="c3" class3="cy" angle="1.7030922840960667" k="565.6768"/>
+    <Angle class1="br" class2="cy" class3="cx" angle="2.0600121161289073" k="511.2848"/>
+    <Angle class1="c3" class2="cx" class3="cy" angle="1.7174039839624204" k="564.84"/>
+    <Angle class1="cc" class2="c3" class3="cy" angle="1.9785052400607719" k="528.0208"/>
+    <Angle class1="c1" class2="cy" class3="oh" angle="1.8329447804444448" k="596.6384"/>
+    <Angle class1="c3" class2="nh" class3="cx" angle="2.180614367441715" k="512.1216000000001"/>
+    <Angle class1="cl" class2="c" class3="cx" angle="1.965240737745615" k="514.6320000000001"/>
+    <Angle class1="nj" class2="c3" class3="os" angle="1.8807668019490895" k="602.496"/>
+    <Angle class1="cv" class2="p3" class3="n3" angle="1.8615681801771518" k="323.8416"/>
+    <Angle class1="cy" class2="p3" class3="n3" angle="1.9217820393709562" k="308.7792"/>
+    <Angle class1="cv" class2="p3" class3="cy" angle="1.3833479651307057" k="348.9456"/>
+    <Angle class1="cl" class2="p5" class3="cv" angle="2.122669436275504" k="300.4112"/>
+    <Angle class1="cl" class2="p5" class3="cy" angle="1.9188149796425658" k="303.7584"/>
+    <Angle class1="cv" class2="p5" class3="n3" angle="2.05303079912093" k="325.5152"/>
+    <Angle class1="cv" class2="p5" class3="cy" angle="1.5034266176679154" k="346.4352"/>
+    <Angle class1="cl" class2="cv" class3="p3" angle="2.2113321622768156" k="629.2736000000001"/>
+    <Angle class1="cl" class2="cv" class3="p5" angle="2.258281519155463" k="646.0096000000001"/>
+    <Angle class1="p3" class2="cv" class3="p5" angle="1.8135716257473076" k="897.8864"/>
+    <Angle class1="p3" class2="cy" class3="p5" angle="1.5817919010824608" k="885.3344"/>
+    <Angle class1="h1" class2="cx" class3="p5" angle="1.9977038618327094" k="434.2992"/>
+    <Angle class1="op" class2="cx" class3="p5" angle="1.9933405387027237" k="668.6032000000001"/>
+    <Angle class1="ca" class2="cy" class3="oq" angle="1.974490982781185" k="555.6352"/>
+    <Angle class1="c" class2="cy" class3="ce" angle="1.9830430961159573" k="522.1632"/>
+    <Angle class1="cf" class2="ss" class3="cx" angle="1.7580701555338882" k="508.7744"/>
+    <Angle class1="no" class2="cx" class3="op" angle="2.0207422079590347" k="569.8607999999999"/>
+    <Angle class1="ce" class2="cy" class3="os" angle="1.9751891144819826" k="561.4928"/>
+    <Angle class1="h2" class2="cx" class3="no" angle="1.9343484099853154" k="405.01120000000003"/>
+    <Angle class1="op" class2="cx" class3="s6" angle="1.9409806611428937" k="532.2048"/>
+    <Angle class1="ce" class2="cu" class3="os" angle="2.6588345824881614" k="539.736"/>
+    <Angle class1="cx" class2="cu" class3="os" angle="2.455329191705623" k="526.3472"/>
+    <Angle class1="c3" class2="os" class3="cu" angle="2.017949681155844" k="534.7152"/>
+    <Angle class1="cy" class2="os" class3="p5" angle="2.2490312741198935" k="627.6"/>
+    <Angle class1="sp" class2="cx" class3="sp" angle="1.25262280415633" k="646.8464"/>
+    <Angle class1="ca" class2="sy" class3="np" angle="1.7657496042426633" k="533.8783999999999"/>
+    <Angle class1="ni" class2="c" class3="ni" angle="1.9259708295757425" k="595.8016"/>
+    <Angle class1="c1" class2="c3" class3="nj" angle="1.9294614880797314" k="569.8607999999999"/>
+    <Angle class1="cy" class2="cy" class3="s4" angle="2.1453587165514296" k="470.2816"/>
+    <Angle class1="br" class2="cy" class3="br" angle="1.9507545049540622" k="561.4928"/>
+    <Angle class1="c1" class2="cx" class3="ce" angle="2.1493729738310168" k="521.3264"/>
+    <Angle class1="ce" class2="cx" class3="no" angle="2.042558823608964" k="538.8992000000001"/>
+    <Angle class1="c1" class2="cx" class3="cu" angle="2.163510140772171" k="526.3472"/>
+    <Angle class1="cu" class2="cx" class3="no" angle="2.0497146735421405" k="543.9200000000001"/>
+    <Angle class1="c1" class2="cx" class3="no" angle="1.9462166488988768" k="562.3296"/>
+    <Angle class1="cx" class2="cu" class3="ha" angle="2.477145807355552" k="355.64"/>
+    <Angle class1="ce" class2="cu" class3="ha" angle="2.675415210382108" k="376.56"/>
+    <Angle class1="c" class2="oq" class3="cv" angle="1.584235362035253" k="592.4544"/>
+    <Angle class1="cx" class2="c" class3="oq" angle="1.6236798031303248" k="631.784"/>
+    <Angle class1="cx" class2="cv" class3="oq" angle="1.5884241522400395" k="624.2528"/>
+    <Angle class1="cu" class2="cv" class3="oq" angle="2.205921641595633" k="565.6768"/>
+    <Angle class1="cu" class2="cv" class3="cx" angle="2.488839513343914" k="502.9168"/>
+    <Angle class1="cy" class2="ce" class3="n2" angle="2.266659099565036" k="540.5728"/>
+    <Angle class1="na" class2="cc" class3="nm" angle="2.124240232602298" k="581.576"/>
+    <Angle class1="nd" class2="cc" class3="nm" angle="2.239257430308725" k="578.2288"/>
+    <Angle class1="cx" class2="c" class3="cy" angle="1.587551487614042" k="585.76"/>
+    <Angle class1="cx" class2="cy" class3="cx" angle="2.0085249031950743" k="521.3264"/>
+    <Angle class1="c3" class2="ss" class3="cv" angle="1.76365520914027" k="514.6320000000001"/>
+    <Angle class1="sq" class2="cv" class3="ss" angle="2.2291345206471576" k="507.93760000000003"/>
+    <Angle class1="ce" class2="cy" class3="sq" angle="1.5323990832510213" k="574.8816"/>
+    <Angle class1="cy" class2="p5" class3="cy" angle="1.4021975210522444" k="340.5776"/>
+    <Angle class1="c3" class2="cy" class3="ss" angle="1.8969983639926367" k="514.6320000000001"/>
+    <Angle class1="c" class2="cx" class3="no" angle="1.9465657147492759" k="552.288"/>
+    <Angle class1="cy" class2="c2" class3="o" angle="2.1429152555986377" k="568.1872000000001"/>
+    <Angle class1="ce" class2="c" class3="oq" angle="1.6217599409531311" k="637.6416"/>
+    <Angle class1="s4" class2="cy" class3="s4" angle="1.655619328441821" k="536.3888"/>
+    <Angle class1="s4" class2="nq" class3="s4" angle="1.9078194053550015" k="535.552"/>
+    <Angle class1="br" class2="cy" class3="oq" angle="1.9682077974740053" k="543.0832"/>
+    <Angle class1="br" class2="c3" class3="cx" angle="1.9299850868553294" k="522.1632"/>
+    <Angle class1="cl" class2="cx" class3="f" angle="1.9795524376119686" k="520.4896"/>
+    <Angle class1="cy" class2="os" class3="no" angle="1.9914206765255298" k="537.2256000000001"/>
+    <Angle class1="nj" class2="c" class3="os" angle="1.926494428351341" k="621.7424"/>
+    <Angle class1="f" class2="cx" class3="os" angle="2.0118410287738633" k="584.0864"/>
+    <Angle class1="c2" class2="cy" class3="nq" angle="2.0748474147708587" k="536.3888"/>
+    <Angle class1="cx" class2="c3" class3="p5" angle="1.9711748572023957" k="643.4992000000001"/>
+    <Angle class1="n3" class2="cx" class3="oh" angle="1.9456930501232788" k="600.8224"/>
+    <Angle class1="cx" class2="c3" class3="no" angle="1.7875662198925926" k="565.6768"/>
+    <Angle class1="c3" class2="nl" class3="c3" angle="1.9010126212722238" k="527.184"/>
+    <Angle class1="c3" class2="cy" class3="hx" angle="1.9495327744776663" k="385.76480000000004"/>
+    <Angle class1="c3" class2="c3" class3="nl" angle="1.9884536167971396" k="538.0624"/>
+    <Angle class1="cl" class2="c2" class3="cy" angle="2.157226955464991" k="504.5904"/>
+    <Angle class1="ca" class2="cc" class3="cy" angle="2.2507766033718877" k="509.6112"/>
+    <Angle class1="cf" class2="ce" class3="cx" angle="1.9545942293084493" k="562.3296"/>
+    <Angle class1="cc" class2="n" class3="cy" angle="2.0954422999443922" k="537.2256000000001"/>
+    <Angle class1="ce" class2="cx" class3="n2" angle="0.8639379797371932" k="840.984"/>
+    <Angle class1="c" class2="cx" class3="n2" angle="2.0263272615654166" k="548.9408"/>
+    <Angle class1="nb" class2="ca" class3="nn" angle="2.078861672050446" k="605.0064"/>
+    <Angle class1="cy" class2="n3" class3="s6" angle="2.0497146735421405" k="523.8368"/>
+    <Angle class1="br" class2="cy" class3="h1" angle="1.8505726058895877" k="358.98720000000003"/>
+    <Angle class1="c3" class2="cx" class3="oh" angle="2.0217894055102312" k="558.1456000000001"/>
+    <Angle class1="c3" class2="cx" class3="cc" angle="2.012015561699063" k="531.368"/>
+    <Angle class1="ca" class2="c3" class3="np" angle="1.9348720087609137" k="558.1456000000001"/>
+    <Angle class1="cy" class2="c3" class3="na" angle="2.0107938312226667" k="543.0832"/>
+    <Angle class1="np" class2="c3" class3="np" angle="1.81287349404651" k="601.6592"/>
+    <Angle class1="cl" class2="cv" class3="cv" angle="2.336472269644809" k="498.73280000000005"/>
+    <Angle class1="cl" class2="cv" class3="cy" angle="2.2979004931757343" k="487.0176"/>
+    <Angle class1="cv" class2="cv" class3="os" angle="2.276258410451004" k="569.024"/>
+    <Angle class1="cy" class2="cv" class3="os" angle="2.345198915904781" k="523.0"/>
+    <Angle class1="c2" class2="cy" class3="cv" angle="2.050936404018537" k="519.6528000000001"/>
+    <Angle class1="cv" class2="os" class3="p5" angle="2.2109830964264168" k="640.9888"/>
+    <Angle class1="c3" class2="nq" class3="nq" angle="1.9413297269932928" k="546.4304"/>
+    <Angle class1="c3" class2="nh" class3="cv" angle="2.1752038467605326" k="523.0"/>
+    <Angle class1="hn" class2="nq" class3="nq" angle="1.866455102082736" k="403.33760000000007"/>
+    <Angle class1="cx" class2="c2" class3="ne" angle="2.029817920069405" k="579.0656"/>
+    <Angle class1="cv" class2="nh" class3="hn" angle="1.9999727898603024" k="412.5424"/>
+    <Angle class1="cv" class2="nh" class3="n2" angle="2.0488420089161434" k="576.5552"/>
+    <Angle class1="cc" class2="os" class3="cy" angle="2.110277598586344" k="519.6528000000001"/>
+    <Angle class1="cx" class2="ce" class3="n1" angle="2.130872483759877" k="557.3088"/>
+    <Angle class1="cv" class2="nh" class3="o" angle="2.020044076258237" k="601.6592"/>
+    <Angle class1="cc" class2="cx" class3="h1" angle="2.0416861589829667" k="391.62239999999997"/>
+    <Angle class1="cc" class2="cc" class3="cx" angle="2.0622810441564994" k="542.2464"/>
+    <Angle class1="c2" class2="cy" class3="ce" angle="2.0402898955813713" k="521.3264"/>
+    <Angle class1="ce" class2="cy" class3="oh" angle="1.987406419245943" k="561.4928"/>
+    <Angle class1="cx" class2="p3" class3="cx" angle="0.8005825278897989" k="446.8512"/>
+    <Angle class1="cc" class2="ce" class3="nj" angle="2.0125391604746614" k="565.6768"/>
+    <Angle class1="cy" class2="ce" class3="n1" angle="1.9891517484979375" k="573.208"/>
+    <Angle class1="ce" class2="cy" class3="n1" angle="1.8954275676658416" k="569.024"/>
+    <Angle class1="c1" class2="n1" class3="cy" angle="3.13024801345183" k="469.44480000000004"/>
+    <Angle class1="c" class2="op" class3="cx" angle="1.0088003076527225" k="756.4672"/>
+    <Angle class1="cx" class2="c" class3="op" angle="1.2575097260619144" k="727.1792"/>
+    <Angle class1="o" class2="c" class3="op" angle="2.3996531885670036" k="605.8432"/>
+    <Angle class1="c3" class2="c" class3="ni" angle="1.9898498801987352" k="553.1247999999999"/>
+    <Angle class1="c" class2="ne" class3="cu" angle="2.0706586245660725" k="569.8607999999999"/>
+    <Angle class1="cu" class2="cx" class3="op" angle="0.9066985464110543" k="840.1472000000001"/>
+    <Angle class1="cx" class2="cu" class3="ne" angle="2.7607618108046306" k="502.08000000000004"/>
+    <Angle class1="ne" class2="cu" class3="op" angle="2.3307126831132274" k="601.6592"/>
+    <Angle class1="cx" class2="cu" class3="op" angle="1.1917108132617282" k="758.9776"/>
+    <Angle class1="cy" class2="c" class3="s" angle="2.17293491873294" k="512.1216000000001"/>
+    <Angle class1="cu" class2="op" class3="cx" angle="1.043183293917011" k="744.7520000000001"/>
+    <Angle class1="cd" class2="cx" class3="op" angle="2.0240583335378237" k="559.8192"/>
+    <Angle class1="c" class2="cx" class3="cd" angle="2.0816541988536366" k="523.8368"/>
+    <Angle class1="c3" class2="cv" class3="cy" angle="2.4193754091145396" k="480.3232"/>
+    <Angle class1="c3" class2="cv" class3="ce" angle="2.226865592619565" k="526.3472"/>
+    <Angle class1="os" class2="cy" class3="os" angle="1.8676768325591322" k="616.7216000000001"/>
+    <Angle class1="c3" class2="os" class3="nj" angle="1.9266689612765402" k="548.9408"/>
+    <Angle class1="cy" class2="c3" class3="ss" angle="2.001194520336698" k="503.75360000000006"/>
+    <Angle class1="c" class2="cx" class3="oh" angle="2.238384765682728" k="534.7152"/>
+    <Angle class1="ce" class2="cx" class3="oh" angle="2.1921335405048774" k="539.736"/>
+    <Angle class1="ca" class2="c3" class3="nk" angle="2.0134118251006585" k="538.8992000000001"/>
+    <Angle class1="cy" class2="cx" class3="op" angle="2.0352284407505876" k="548.9408"/>
+    <Angle class1="ch" class2="c" class3="cx" angle="2.0118410287738633" k="538.0624"/>
+    <Angle class1="cy" class2="cx" class3="h1" angle="2.002765316663493" k="381.5808"/>
+    <Angle class1="cx" class2="cy" class3="nq" angle="2.021614872585032" k="539.736"/>
+    <Angle class1="cx" class2="cy" class3="h1" angle="1.9083430041306" k="390.78560000000004"/>
+    <Angle class1="np" class2="p3" class3="np" angle="1.6622515795993993" k="353.96639999999996"/>
+    <Angle class1="h2" class2="cy" class3="nq" angle="2.0214403396598324" k="399.99039999999997"/>
+    <Angle class1="nq" class2="cy" class3="os" angle="2.009223034895872" k="578.2288"/>
+    <Angle class1="cv" class2="n2" class3="os" angle="1.9118336626345886" k="607.5168"/>
+    <Angle class1="c3" class2="s6" class3="nj" angle="1.7456783178447284" k="534.7152"/>
+    <Angle class1="cy" class2="c2" class3="nh" angle="2.0703095587156737" k="552.288"/>
+    <Angle class1="cy" class2="c2" class3="n2" angle="2.1790435711149203" k="553.1247999999999"/>
+    <Angle class1="c2" class2="cy" class3="ca" angle="2.0352284407505876" k="522.1632"/>
+    <Angle class1="c" class2="sq" class3="cy" angle="1.3400637996812461" k="574.0448"/>
+    <Angle class1="cc" class2="n" class3="cx" angle="2.1064378742319563" k="535.552"/>
+    <Angle class1="c3" class2="nj" class3="cx" angle="2.3202407076012617" k="496.2224"/>
+    <Angle class1="nj" class2="c" class3="oq" angle="1.6362461737446838" k="671.1136"/>
+    <Angle class1="nj" class2="cx" class3="op" angle="2.19771859411126" k="557.3088"/>
+    <Angle class1="nj" class2="cx" class3="oq" angle="1.5742869852988852" k="658.5616"/>
+    <Angle class1="cx" class2="cx" class3="oq" angle="2.193355270981274" k="533.0416"/>
+    <Angle class1="op" class2="cx" class3="oq" angle="2.078512606200047" k="578.2288"/>
+    <Angle class1="c" class2="oq" class3="cx" angle="1.5322245503258218" k="605.0064"/>
+    <Angle class1="c3" class2="os" class3="np" angle="1.8840829275278788" k="548.104"/>
+    <Angle class1="n" class2="cx" class3="op" angle="1.977283509584376" k="589.9440000000001"/>
+    <Angle class1="c2" class2="cx" class3="ce" angle="1.8491763424879921" k="555.6352"/>
+    <Angle class1="cu" class2="c2" class3="n" angle="2.2088887013240233" k="570.6976000000001"/>
+    <Angle class1="c" class2="cy" class3="ss" angle="2.066295301436087" k="492.03839999999997"/>
+    <Angle class1="c1" class2="n1" class3="cx" angle="3.0918507699079547" k="481.16"/>
+    <Angle class1="n1" class2="cx" class3="op" angle="2.0484929430657446" k="588.2704"/>
+    <Angle class1="ca" class2="cy" class3="nh" angle="1.9388862660405006" k="559.8192"/>
+    <Angle class1="cy" class2="n3" class3="sy" angle="2.144660584850632" k="507.10080000000005"/>
+    <Angle class1="op" class2="cx" class3="op" angle="1.1623892818282233" k="773.2032"/>
+    <Angle class1="ca" class2="ce" class3="cv" angle="2.396511595913414" k="512.1216000000001"/>
+    <Angle class1="c1" class2="cx" class3="ni" angle="2.0230111359866276" k="553.9616000000001"/>
+    <Angle class1="c2" class2="cy" class3="c2" angle="1.9907225448247323" k="528.8576"/>
+    <Angle class1="c1" class2="c3" class3="nq" angle="1.9556414268596463" k="565.6768"/>
+    <Angle class1="c1" class2="c3" class3="nk" angle="1.9022343517486198" k="563.1664"/>
+    <Angle class1="cy" class2="c" class3="ss" angle="2.016727950679448" k="507.10080000000005"/>
+    <Angle class1="nj" class2="cy" class3="sh" angle="1.9896753472735356" k="523.0"/>
+    <Angle class1="h2" class2="cy" class3="sh" angle="1.9093902016817967" k="351.456"/>
+    <Angle class1="cy" class2="cy" class3="sh" angle="2.0565214576249184" k="494.5488"/>
+    <Angle class1="cy" class2="sh" class3="hs" angle="1.639562299323473" k="378.2336"/>
+    <Angle class1="c1" class2="cy" class3="cl" angle="1.8517943363659837" k="536.3888"/>
+    <Angle class1="c1" class2="cy" class3="cv" angle="2.0549506612981236" k="527.184"/>
+    <Angle class1="n3" class2="cx" class3="p5" angle="2.022487537211029" k="659.3984"/>
+    <Angle class1="o" class2="c" class3="sq" angle="2.3188444441996667" k="501.2432"/>
+    <Angle class1="c" class2="cx" class3="cu" angle="2.0731020855188644" k="527.184"/>
+    <Angle class1="ca" class2="cx" class3="f" angle="1.9540706305328512" k="554.7984"/>
+    <Angle class1="c2" class2="cy" class3="f" angle="1.8928095737878503" k="560.6560000000001"/>
+    <Angle class1="cy" class2="c2" class3="f" angle="2.0453513504121545" k="541.4096000000001"/>
+    <Angle class1="c2" class2="cx" class3="nm" angle="1.9991001252343052" k="555.6352"/>
+    <Angle class1="cy" class2="c" class3="sq" angle="1.642878424902262" k="556.472"/>
+    <Angle class1="c1" class2="cy" class3="oq" angle="1.9141025906621811" k="574.8816"/>
+    <Angle class1="c1" class2="cy" class3="c3" angle="1.9237019015481498" k="542.2464"/>
+    <Angle class1="op" class2="cx" class3="s4" angle="1.9484855769264695" k="523.8368"/>
+    <Angle class1="c3" class2="cx" class3="s4" angle="2.0231856689118266" k="492.8752"/>
+    <Angle class1="ca" class2="os" class3="cx" angle="1.866106036232337" k="554.7984"/>
+  </HarmonicAngleForce>
+  <PeriodicTorsionForce>
+    <Proper class1="" class2="c" class3="c" class4="" periodicity1="2" k1="1.2552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="c1" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="cg" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="ch" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="c2" class4="" periodicity1="2" k1="9.1002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="cu" class4="" periodicity1="2" k1="9.1002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="cv" class4="" periodicity1="2" k1="9.1002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="ce" class4="" periodicity1="2" k1="9.1002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="cf" class4="" periodicity1="2" k1="9.1002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="c3" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="cx" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="cy" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="ca" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="cc" class4="" periodicity1="2" k1="12.029" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="cd" class4="" periodicity1="2" k1="12.029" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="n" class4="" periodicity1="2" k1="10.46" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="n2" class4="" periodicity1="2" k1="17.3636" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="nc" class4="" periodicity1="2" k1="16.736" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="nd" class4="" periodicity1="2" k1="16.736" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="ne" class4="" periodicity1="2" k1="0.8368000000000001" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="nf" class4="" periodicity1="2" k1="0.8368000000000001" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="na" class4="" periodicity1="2" k1="6.0668" phase1="3.141592653589793" periodicity2="4" k2="1.4644" phase2="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="no" class4="" periodicity1="2" k1="1.8828" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="oh" class4="" periodicity1="2" k1="9.623199999999999" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="os" class4="" periodicity1="2" k1="11.296800000000001" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="p2" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="pc" class4="" periodicity1="2" k1="8.368" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="pd" class4="" periodicity1="2" k1="8.368" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="pe" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="pf" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="p3" class4="" periodicity1="2" k1="6.485200000000001" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="p4" class4="" periodicity1="2" k1="5.6484000000000005" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="px" class4="" periodicity1="2" k1="5.6484000000000005" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="p5" class4="" periodicity1="2" k1="4.184" phase1="0.0"/>
+    <Proper class1="" class2="c" class3="py" class4="" periodicity1="2" k1="4.184" phase1="0.0"/>
+    <Proper class1="" class2="c" class3="sh" class4="" periodicity1="2" k1="9.414" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="ss" class4="" periodicity1="2" k1="12.970400000000001" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="s4" class4="" periodicity1="2" k1="0.8368000000000001" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="sx" class4="" periodicity1="2" k1="0.8368000000000001" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c" class3="s6" class4="" periodicity1="2" k1="2.092" phase1="0.0"/>
+    <Proper class1="" class2="c" class3="sy" class4="" periodicity1="2" k1="2.092" phase1="0.0"/>
+    <Proper class1="" class2="c1" class3="c1" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="cg" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="ch" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cg" class3="cg" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ch" class3="ch" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cg" class3="ch" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="c2" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="c3" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="ca" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="cc" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="cd" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="ce" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="cf" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="cu" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="cv" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="cx" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="cy" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="n" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="n2" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="n3" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="n4" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="na" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="nb" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="nc" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="nd" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="ne" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="nf" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="nh" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="no" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="oh" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="os" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="p2" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="pb" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="pc" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="pd" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="pe" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="pf" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="p3" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="p4" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="px" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="p5" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="py" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="s2" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="sh" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="ss" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="s4" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="sx" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="s6" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c1" class3="sy" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="c2" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="ce" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="cf" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="cf" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="ce" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cf" class3="cf" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cc" class3="cd" class4="" periodicity1="2" k1="16.736" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cc" class3="cc" class4="" periodicity1="2" k1="16.736" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cd" class3="cd" class4="" periodicity1="2" k1="16.736" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="c3" class4="" periodicity1="2" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="c2" class3="ca" class4="" periodicity1="2" k1="2.9288" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="n" class4="" periodicity1="2" k1="2.7196000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="n2" class4="" periodicity1="2" k1="17.3636" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="ne" class4="" periodicity1="2" k1="17.3636" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="nf" class4="" periodicity1="2" k1="17.3636" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="ne" class4="" periodicity1="2" k1="3.3472000000000004" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cf" class3="nf" class4="" periodicity1="2" k1="3.3472000000000004" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="nc" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="nd" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cc" class3="nd" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cd" class3="nc" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cc" class3="nc" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cd" class3="nd" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="n3" class4="" periodicity1="2" k1="1.2552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="n4" class4="" periodicity1="3" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="na" class4="" periodicity1="2" k1="2.615" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cc" class3="na" class4="" periodicity1="2" k1="7.1128" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cd" class3="na" class4="" periodicity1="2" k1="7.1128" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="nh" class4="" periodicity1="2" k1="2.8242000000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="no" class4="" periodicity1="2" k1="3.138" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="oh" class4="" periodicity1="2" k1="4.3932" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="os" class4="" periodicity1="2" k1="4.3932" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="p2" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="pe" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="pf" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="pf" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="pe" class4="" periodicity1="2" k1="3.9748" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cf" class3="pf" class4="" periodicity1="2" k1="3.9748" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="pc" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="pd" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cc" class3="pc" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cc" class3="pd" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cd" class3="pc" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cd" class3="pd" class4="" periodicity1="2" k1="19.874000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="p3" class4="" periodicity1="2" k1="1.8828" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="p4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="p4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cf" class3="p4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="px" class4="" periodicity1="2" k1="1.3598000000000001" phase1="0.0"/>
+    <Proper class1="" class2="ce" class3="px" class4="" periodicity1="2" k1="1.3598000000000001" phase1="0.0"/>
+    <Proper class1="" class2="cf" class3="px" class4="" periodicity1="2" k1="1.3598000000000001" phase1="0.0"/>
+    <Proper class1="" class2="c2" class3="p5" class4="" periodicity1="2" k1="27.8236" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="p5" class4="" periodicity1="2" k1="27.8236" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cf" class3="p5" class4="" periodicity1="2" k1="27.8236" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="py" class4="" periodicity1="2" k1="5.997066666666666" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="py" class4="" periodicity1="2" k1="5.997066666666666" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cf" class3="py" class4="" periodicity1="2" k1="5.997066666666666" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="sh" class4="" periodicity1="2" k1="2.092" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="ss" class4="" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="s4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="s4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cf" class3="s4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="sx" class4="" periodicity1="2" k1="2.5104" phase1="0.0"/>
+    <Proper class1="" class2="ce" class3="sx" class4="" periodicity1="2" k1="2.5104" phase1="0.0"/>
+    <Proper class1="" class2="cf" class3="sx" class4="" periodicity1="2" k1="2.5104" phase1="0.0"/>
+    <Proper class1="" class2="c2" class3="s6" class4="" periodicity1="2" k1="27.8236" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="s6" class4="" periodicity1="2" k1="27.8236" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cf" class3="s6" class4="" periodicity1="2" k1="27.8236" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c2" class3="sy" class4="" periodicity1="2" k1="5.299733333333333" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ce" class3="sy" class4="" periodicity1="2" k1="5.299733333333333" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cf" class3="sy" class4="" periodicity1="2" k1="5.299733333333333" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c3" class3="c3" class4="" periodicity1="3" k1="0.6508444444444444" phase1="0.0"/>
+    <Proper class1="" class2="cx" class3="cx" class4="" periodicity1="3" k1="0.6508444444444444" phase1="0.0"/>
+    <Proper class1="" class2="cy" class3="cy" class4="" periodicity1="3" k1="0.6508444444444444" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="ca" class4="" periodicity1="2" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="n" class4="" periodicity1="2" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="cx" class3="n" class4="" periodicity1="2" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="cy" class3="n" class4="" periodicity1="2" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="n2" class4="" periodicity1="3" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="ne" class4="" periodicity1="3" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="nf" class4="" periodicity1="3" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="n3" class4="" periodicity1="3" k1="1.2552" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="n4" class4="" periodicity1="3" k1="0.6508444444444444" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="na" class4="" periodicity1="2" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="nh" class4="" periodicity1="2" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="no" class4="" periodicity1="2" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="oh" class4="" periodicity1="3" k1="0.6973333333333334" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="os" class4="" periodicity1="3" k1="1.6038666666666666" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="p2" class4="" periodicity1="2" k1="1.1157333333333335" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c3" class3="pe" class4="" periodicity1="2" k1="1.1157333333333335" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c3" class3="pf" class4="" periodicity1="2" k1="1.1157333333333335" phase1="3.141592653589793"/>
+    <Proper class1="" class2="c3" class3="p3" class4="" periodicity1="3" k1="0.5578666666666667" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="p4" class4="" periodicity1="3" k1="0.5578666666666667" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="px" class4="" periodicity1="3" k1="0.5578666666666667" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="p5" class4="" periodicity1="3" k1="0.09297777777777778" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="py" class4="" periodicity1="3" k1="0.09297777777777778" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="sh" class4="" periodicity1="3" k1="1.046" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="ss" class4="" periodicity1="3" k1="1.3946666666666667" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="s4" class4="" periodicity1="3" k1="0.8368000000000001" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="sx" class4="" periodicity1="3" k1="0.8368000000000001" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="s6" class4="" periodicity1="3" k1="0.6043555555555556" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="sy" class4="" periodicity1="3" k1="0.6043555555555556" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="cc" class4="" periodicity1="3" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="c3" class3="cd" class4="" periodicity1="3" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="ca" class3="ca" class4="" periodicity1="2" k1="15.167" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="cp" class4="" periodicity1="2" k1="15.167" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="cq" class4="" periodicity1="2" k1="15.167" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cp" class3="cp" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cq" class3="cq" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="n" class4="" periodicity1="2" k1="1.8828" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="n2" class4="" periodicity1="3" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="ne" class4="" periodicity1="3" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="nf" class4="" periodicity1="3" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="n4" class4="" periodicity1="2" k1="7.322" phase1="0.0"/>
+    <Proper class1="" class2="ca" class3="na" class4="" periodicity1="2" k1="1.2552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="nb" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="nc" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="nd" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="nh" class4="" periodicity1="2" k1="4.3932" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cc" class3="nh" class4="" periodicity1="2" k1="4.3932" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cd" class3="nh" class4="" periodicity1="2" k1="4.3932" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="no" class4="" periodicity1="2" k1="2.5104" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="oh" class4="" periodicity1="2" k1="3.7656" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="os" class4="" periodicity1="2" k1="3.7656" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="p2" class4="" periodicity1="2" k1="2.5104" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="pe" class4="" periodicity1="2" k1="2.5104" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="pf" class4="" periodicity1="2" k1="2.5104" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="pc" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="pd" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="p3" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="p4" class4="" periodicity1="2" k1="2.1966" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="px" class4="" periodicity1="2" k1="2.1966" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="p5" class4="" periodicity1="2" k1="6.136533333333333" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="py" class4="" periodicity1="2" k1="6.136533333333333" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="sh" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="ss" class4="" periodicity1="2" k1="1.6736000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="s4" class4="" periodicity1="2" k1="1.2552" phase1="0.0"/>
+    <Proper class1="" class2="ca" class3="sx" class4="" periodicity1="2" k1="1.2552" phase1="0.0"/>
+    <Proper class1="" class2="ca" class3="s6" class4="" periodicity1="2" k1="5.4392" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ca" class3="sy" class4="" periodicity1="2" k1="5.4392" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="cc" class4="" periodicity1="2" k1="6.9036" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="cd" class4="" periodicity1="2" k1="6.9036" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="n" class4="" periodicity1="2" k1="4.811599999999999" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="n2" class4="" periodicity1="2" k1="1.6736000000000002" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="ne" class4="" periodicity1="2" k1="1.6736000000000002" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="nf" class4="" periodicity1="2" k1="1.6736000000000002" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="n3" class4="" periodicity1="2" k1="4.4978" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="n4" class4="" periodicity1="2" k1="3.9748" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="na" class4="" periodicity1="2" k1="2.9288" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="nc" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="nd" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="nh" class4="" periodicity1="2" k1="4.6024" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="no" class4="" periodicity1="2" k1="5.753" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="oh" class4="" periodicity1="2" k1="6.276" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="os" class4="" periodicity1="2" k1="4.6024" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="p2" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="pe" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="pf" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="pc" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="pd" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="p3" class4="" periodicity1="2" k1="9.414" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="p4" class4="" periodicity1="2" k1="1.3598000000000001" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="px" class4="" periodicity1="2" k1="1.3598000000000001" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="p5" class4="" periodicity1="2" k1="9.2048" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="py" class4="" periodicity1="2" k1="9.2048" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="sh" class4="" periodicity1="2" k1="4.6024" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="ss" class4="" periodicity1="2" k1="6.276" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="s4" class4="" periodicity1="3" k1="6.276" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="sx" class4="" periodicity1="3" k1="6.276" phase1="0.0"/>
+    <Proper class1="" class2="n" class3="s6" class4="" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n" class3="sy" class4="" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="c2" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="c3" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="ca" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="cc" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="cd" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="ce" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="cf" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="cu" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="cv" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="cx" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="cy" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="n" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="n1" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="n2" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="n3" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="n4" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="na" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="nb" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="nc" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="nd" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="ne" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="nf" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="nh" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="no" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="oh" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="os" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="p2" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="pb" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="pc" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="pd" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="pe" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="pf" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="p3" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="p4" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="px" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="p5" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="py" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="s2" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="sh" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="ss" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="s4" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="sx" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="s6" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n1" class3="sy" class4="" periodicity1="2" k1="0.0" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="n2" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793" periodicity2="1" k2="11.7152" phase2="0.0"/>
+    <Proper class1="" class2="n2" class3="ne" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793" periodicity2="1" k2="11.7152" phase2="0.0"/>
+    <Proper class1="" class2="n2" class3="nf" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793" periodicity2="1" k2="11.7152" phase2="0.0"/>
+    <Proper class1="" class2="ne" class3="nf" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793" periodicity2="1" k2="11.7152" phase2="0.0"/>
+    <Proper class1="" class2="ne" class3="ne" class4="" periodicity1="2" k1="5.0208" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="nf" class4="" periodicity1="2" k1="5.0208" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nc" class3="nc" class4="" periodicity1="2" k1="16.736" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nd" class3="nd" class4="" periodicity1="2" k1="16.736" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nc" class3="nd" class4="" periodicity1="2" k1="16.736" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="nc" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793" periodicity2="1" k2="11.7152" phase2="0.0"/>
+    <Proper class1="" class2="n2" class3="nd" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793" periodicity2="1" k2="11.7152" phase2="0.0"/>
+    <Proper class1="" class2="n2" class3="n3" class4="" periodicity1="2" k1="25.5224" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="n3" class4="" periodicity1="2" k1="25.5224" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="n3" class4="" periodicity1="2" k1="25.5224" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="n4" class4="" periodicity1="2" k1="33.472" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="n4" class4="" periodicity1="2" k1="33.472" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="n4" class4="" periodicity1="2" k1="33.472" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="na" class4="" periodicity1="2" k1="7.1128" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="na" class4="" periodicity1="2" k1="7.1128" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="na" class4="" periodicity1="2" k1="7.1128" phase1="3.141592653589793"/>
+    <Proper class1="" class2="na" class3="nc" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="na" class3="nd" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="nh" class4="" periodicity1="2" k1="11.7152" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="nh" class4="" periodicity1="2" k1="11.7152" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="nh" class4="" periodicity1="2" k1="11.7152" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="no" class4="" periodicity1="2" k1="3.138" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="no" class4="" periodicity1="2" k1="3.138" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="no" class4="" periodicity1="2" k1="3.138" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="oh" class4="" periodicity1="2" k1="13.388800000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="oh" class4="" periodicity1="2" k1="13.388800000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="oh" class4="" periodicity1="2" k1="13.388800000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="os" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="os" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="os" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nc" class3="os" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nc" class3="ss" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="p2" class4="" periodicity1="2" k1="22.593600000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="pe" class4="" periodicity1="2" k1="22.593600000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="pf" class4="" periodicity1="2" k1="22.593600000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="pf" class4="" periodicity1="2" k1="22.593600000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="pc" class4="" periodicity1="2" k1="22.593600000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="pd" class4="" periodicity1="2" k1="22.593600000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nc" class3="p2" class4="" periodicity1="2" k1="22.593600000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nd" class3="p2" class4="" periodicity1="2" k1="22.593600000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nc" class3="pc" class4="" periodicity1="2" k1="27.6144" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nd" class3="pd" class4="" periodicity1="2" k1="27.6144" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nd" class3="pc" class4="" periodicity1="2" k1="27.6144" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nc" class3="pd" class4="" periodicity1="2" k1="27.6144" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="pe" class4="" periodicity1="1" k1="2.5104" phase1="0.0"/>
+    <Proper class1="" class2="nf" class3="pf" class4="" periodicity1="1" k1="2.5104" phase1="0.0"/>
+    <Proper class1="" class2="n2" class3="p3" class4="" periodicity1="2" k1="8.7864" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="p4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="p4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="p4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="p5" class4="" periodicity1="2" k1="27.893333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="p5" class4="" periodicity1="3" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="p5" class4="" periodicity1="3" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="px" class4="" periodicity1="3" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="px" class4="" periodicity1="3" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="sh" class4="" periodicity1="2" k1="8.7864" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="sh" class4="" periodicity1="2" k1="8.7864" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="sh" class4="" periodicity1="2" k1="8.7864" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="ss" class4="" periodicity1="2" k1="11.7152" phase1="3.141592653589793" periodicity2="1" k2="5.4392000000000005" phase2="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="ss" class4="" periodicity1="2" k1="11.7152" phase1="3.141592653589793" periodicity2="1" k2="5.4392000000000005" phase2="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="ss" class4="" periodicity1="2" k1="11.7152" phase1="3.141592653589793" periodicity2="1" k2="5.4392000000000005" phase2="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="s4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="sx" class4="" periodicity1="3" k1="6.276" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="sx" class4="" periodicity1="3" k1="6.276" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n2" class3="s6" class4="" periodicity1="2" k1="27.893333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ne" class3="sy" class4="" periodicity1="3" k1="2.092" phase1="3.141592653589793" periodicity2="1" k2="28.4512" phase2="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="sy" class4="" periodicity1="3" k1="2.092" phase1="3.141592653589793" periodicity2="1" k2="28.4512" phase2="3.141592653589793"/>
+    <Proper class1="" class2="n3" class3="n3" class4="" periodicity1="2" k1="9.414" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="n4" class4="" periodicity1="3" k1="1.046" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="na" class4="" periodicity1="2" k1="6.694400000000001" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="nh" class4="" periodicity1="2" k1="7.9496" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="no" class4="" periodicity1="2" k1="16.736" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n3" class3="oh" class4="" periodicity1="2" k1="9.2048" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="os" class4="" periodicity1="2" k1="7.5312" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="p2" class4="" periodicity1="2" k1="13.388800000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n3" class3="pe" class4="" periodicity1="2" k1="13.388800000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n3" class3="pf" class4="" periodicity1="2" k1="13.388800000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n3" class3="p3" class4="" periodicity1="2" k1="9.832400000000002" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="p4" class4="" periodicity1="2" k1="8.7864" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n3" class3="px" class4="" periodicity1="2" k1="8.7864" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n3" class3="p5" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n3" class3="py" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n3" class3="sh" class4="" periodicity1="2" k1="12.970400000000001" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="ss" class4="" periodicity1="2" k1="10.878400000000001" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="s4" class4="" periodicity1="2" k1="15.690000000000001" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="sx" class4="" periodicity1="2" k1="15.690000000000001" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="s6" class4="" periodicity1="2" k1="13.109866666666669" phase1="0.0"/>
+    <Proper class1="" class2="n3" class3="sy" class4="" periodicity1="2" k1="13.109866666666669" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="n4" class4="" periodicity1="3" k1="0.7903111111111111" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="na" class4="" periodicity1="3" k1="0.9762666666666666" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="nh" class4="" periodicity1="3" k1="0.7670666666666667" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="no" class4="" periodicity1="3" k1="0.3486666666666667" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n4" class3="oh" class4="" periodicity1="3" k1="1.3946666666666667" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="os" class4="" periodicity1="3" k1="2.3709333333333333" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="p2" class4="" periodicity1="3" k1="0.6973333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n4" class3="pe" class4="" periodicity1="3" k1="0.6973333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n4" class3="pf" class4="" periodicity1="3" k1="0.6973333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="n4" class3="p3" class4="" periodicity1="3" k1="0.6276" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="p4" class4="" periodicity1="3" k1="0.20920000000000002" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="px" class4="" periodicity1="3" k1="0.20920000000000002" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="p5" class4="" periodicity1="3" k1="0.37191111111111114" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="py" class4="" periodicity1="3" k1="0.37191111111111114" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="sh" class4="" periodicity1="3" k1="2.7893333333333334" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="ss" class4="" periodicity1="3" k1="1.3946666666666667" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="s4" class4="" periodicity1="3" k1="1.1854666666666667" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="sx" class4="" periodicity1="3" k1="1.1854666666666667" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="s6" class4="" periodicity1="3" k1="0.5578666666666667" phase1="0.0"/>
+    <Proper class1="" class2="n4" class3="sy" class4="" periodicity1="3" k1="0.5578666666666667" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="na" class4="" periodicity1="2" k1="3.7656" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="nh" class4="" periodicity1="2" k1="5.0208" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="no" class4="" periodicity1="2" k1="25.104" phase1="3.141592653589793"/>
+    <Proper class1="" class2="na" class3="oh" class4="" periodicity1="2" k1="4.184" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="os" class4="" periodicity1="2" k1="2.7196000000000002" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="p2" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="na" class3="pe" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="na" class3="pf" class4="" periodicity1="2" k1="4.184" phase1="3.141592653589793"/>
+    <Proper class1="" class2="na" class3="p3" class4="" periodicity1="2" k1="6.0668" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="p4" class4="" periodicity1="3" k1="4.6024" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="px" class4="" periodicity1="3" k1="4.6024" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="p5" class4="" periodicity1="2" k1="3.486666666666667" phase1="3.141592653589793"/>
+    <Proper class1="" class2="na" class3="py" class4="" periodicity1="2" k1="3.486666666666667" phase1="3.141592653589793"/>
+    <Proper class1="" class2="na" class3="sh" class4="" periodicity1="2" k1="7.5312" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="ss" class4="" periodicity1="2" k1="32.6352" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="s4" class4="" periodicity1="2" k1="4.3932" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="sx" class4="" periodicity1="2" k1="4.3932" phase1="0.0"/>
+    <Proper class1="" class2="na" class3="s6" class4="" periodicity1="2" k1="15.341333333333333" phase1="3.141592653589793"/>
+    <Proper class1="" class2="na" class3="sy" class4="" periodicity1="2" k1="15.341333333333333" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nh" class3="nh" class4="" periodicity1="3" k1="7.5312" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nh" class3="no" class4="" periodicity1="2" k1="10.6692" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nh" class3="oh" class4="" periodicity1="2" k1="6.276" phase1="0.0"/>
+    <Proper class1="" class2="nh" class3="os" class4="" periodicity1="1" k1="6.276" phase1="0.0"/>
+    <Proper class1="" class2="nh" class3="p2" class4="" periodicity1="2" k1="5.8576" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nh" class3="pe" class4="" periodicity1="2" k1="5.8576" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nh" class3="pf" class4="" periodicity1="2" k1="5.8576" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nh" class3="p3" class4="" periodicity1="2" k1="9.832400000000002" phase1="0.0"/>
+    <Proper class1="" class2="nh" class3="p4" class4="" periodicity1="3" k1="4.916200000000001" phase1="0.0"/>
+    <Proper class1="" class2="nh" class3="px" class4="" periodicity1="3" k1="4.916200000000001" phase1="0.0"/>
+    <Proper class1="" class2="nh" class3="p5" class4="" periodicity1="2" k1="3.3472000000000004" phase1="0.0"/>
+    <Proper class1="" class2="nh" class3="py" class4="" periodicity1="2" k1="3.3472000000000004" phase1="0.0"/>
+    <Proper class1="" class2="nh" class3="sh" class4="" periodicity1="2" k1="6.694400000000001" phase1="0.0"/>
+    <Proper class1="" class2="nh" class3="ss" class4="" periodicity1="2" k1="8.7864" phase1="0.0"/>
+    <Proper class1="" class2="nh" class3="s4" class4="" periodicity1="2" k1="3.138" phase1="0.0" periodicity2="3" k2="0.41840000000000005" phase2="3.141592653589793"/>
+    <Proper class1="" class2="nh" class3="sx" class4="" periodicity1="2" k1="3.138" phase1="0.0" periodicity2="3" k2="0.41840000000000005" phase2="3.141592653589793"/>
+    <Proper class1="" class2="nh" class3="s6" class4="" periodicity1="2" k1="0.41840000000000005" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nh" class3="sy" class4="" periodicity1="2" k1="0.41840000000000005" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="no" class4="" periodicity1="4" k1="1.6736000000000002" phase1="3.141592653589793" periodicity2="2" k2="7.5312" phase2="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="oh" class4="" periodicity1="2" k1="16.3176" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="os" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="p2" class4="" periodicity1="2" k1="1.2552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="pe" class4="" periodicity1="2" k1="1.2552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="pf" class4="" periodicity1="2" k1="1.2552" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="p3" class4="" periodicity1="2" k1="7.9496" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="p4" class4="" periodicity1="2" k1="2.4057999999999997" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="px" class4="" periodicity1="2" k1="2.4057999999999997" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="p5" class4="" periodicity1="2" k1="10.0416" phase1="0.0" periodicity2="3" k2="1.6736000000000002" phase2="0.0"/>
+    <Proper class1="" class2="no" class3="py" class4="" periodicity1="2" k1="10.0416" phase1="0.0" periodicity2="3" k2="1.6736000000000002" phase2="0.0"/>
+    <Proper class1="" class2="no" class3="sh" class4="" periodicity1="2" k1="9.623199999999999" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="ss" class4="" periodicity1="2" k1="11.296800000000001" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="s4" class4="" periodicity1="2" k1="10.878400000000001" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="sx" class4="" periodicity1="2" k1="10.878400000000001" phase1="3.141592653589793"/>
+    <Proper class1="" class2="no" class3="s6" class4="" periodicity1="2" k1="1.3946666666666667" phase1="0.0"/>
+    <Proper class1="" class2="no" class3="sy" class4="" periodicity1="2" k1="1.3946666666666667" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="oh" class4="" periodicity1="2" k1="6.694400000000001" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="os" class4="" periodicity1="2" k1="6.694400000000001" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="p2" class4="" periodicity1="2" k1="6.276" phase1="3.141592653589793"/>
+    <Proper class1="" class2="oh" class3="pe" class4="" periodicity1="2" k1="6.276" phase1="3.141592653589793"/>
+    <Proper class1="" class2="oh" class3="pf" class4="" periodicity1="2" k1="6.276" phase1="3.141592653589793"/>
+    <Proper class1="" class2="oh" class3="p3" class4="" periodicity1="3" k1="1.6736000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="oh" class3="p4" class4="" periodicity1="1" k1="2.9288" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="px" class4="" periodicity1="1" k1="2.9288" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="p5" class4="" periodicity1="3" k1="2.231466666666667" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="py" class4="" periodicity1="3" k1="2.231466666666667" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="sh" class4="" periodicity1="2" k1="10.0416" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="ss" class4="" periodicity1="2" k1="10.0416" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="s4" class4="" periodicity1="1" k1="20.92" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="sx" class4="" periodicity1="1" k1="20.92" phase1="0.0"/>
+    <Proper class1="" class2="oh" class3="s6" class4="" periodicity1="1" k1="39.748" phase1="3.141592653589793"/>
+    <Proper class1="" class2="oh" class3="sy" class4="" periodicity1="1" k1="39.748" phase1="3.141592653589793"/>
+    <Proper class1="" class2="os" class3="os" class4="" periodicity1="1" k1="4.184" phase1="0.0"/>
+    <Proper class1="" class2="os" class3="ss" class4="" periodicity1="2" k1="9.2048" phase1="0.0"/>
+    <Proper class1="" class2="os" class3="sh" class4="" periodicity1="2" k1="7.5312" phase1="0.0"/>
+    <Proper class1="" class2="os" class3="s4" class4="" periodicity1="3" k1="6.9036" phase1="0.0"/>
+    <Proper class1="" class2="os" class3="sx" class4="" periodicity1="3" k1="6.9036" phase1="0.0"/>
+    <Proper class1="" class2="os" class3="s6" class4="" periodicity1="2" k1="5.0208" phase1="3.141592653589793"/>
+    <Proper class1="" class2="os" class3="sy" class4="" periodicity1="2" k1="5.0208" phase1="3.141592653589793"/>
+    <Proper class1="" class2="os" class3="p2" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793" periodicity2="1" k2="8.368" phase2="3.141592653589793"/>
+    <Proper class1="" class2="os" class3="pe" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793" periodicity2="1" k2="8.368" phase2="3.141592653589793"/>
+    <Proper class1="" class2="os" class3="pf" class4="" periodicity1="2" k1="12.552" phase1="3.141592653589793" periodicity2="1" k2="8.368" phase2="3.141592653589793"/>
+    <Proper class1="" class2="os" class3="p3" class4="" periodicity1="2" k1="9.2048" phase1="0.0"/>
+    <Proper class1="" class2="os" class3="p4" class4="" periodicity1="2" k1="4.3932" phase1="3.141592653589793"/>
+    <Proper class1="" class2="os" class3="px" class4="" periodicity1="2" k1="4.3932" phase1="3.141592653589793"/>
+    <Proper class1="" class2="os" class3="p5" class4="" periodicity1="2" k1="3.3472000000000004" phase1="0.0"/>
+    <Proper class1="" class2="os" class3="py" class4="" periodicity1="2" k1="3.3472000000000004" phase1="0.0"/>
+    <Proper class1="" class2="p2" class3="p2" class4="" periodicity1="2" k1="27.6144" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p2" class3="pe" class4="" periodicity1="2" k1="27.6144" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p2" class3="pf" class4="" periodicity1="2" k1="27.6144" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p2" class3="pc" class4="" periodicity1="2" k1="27.6144" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p2" class3="pd" class4="" periodicity1="2" k1="27.6144" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pe" class3="pe" class4="" periodicity1="2" k1="5.0208" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pf" class3="pf" class4="" periodicity1="2" k1="5.0208" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pc" class3="pc" class4="" periodicity1="2" k1="30.1248" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pd" class3="pd" class4="" periodicity1="2" k1="30.1248" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pc" class3="pd" class4="" periodicity1="2" k1="30.1248" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p2" class3="p3" class4="" periodicity1="1" k1="5.0208" phase1="0.0"/>
+    <Proper class1="" class2="pe" class3="p3" class4="" periodicity1="1" k1="5.0208" phase1="0.0"/>
+    <Proper class1="" class2="pf" class3="p3" class4="" periodicity1="1" k1="5.0208" phase1="0.0"/>
+    <Proper class1="" class2="p2" class3="p4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pe" class3="px" class4="" periodicity1="2" k1="10.250800000000002" phase1="0.0"/>
+    <Proper class1="" class2="pf" class3="px" class4="" periodicity1="2" k1="10.250800000000002" phase1="0.0"/>
+    <Proper class1="" class2="p2" class3="p5" class4="" periodicity1="2" k1="27.893333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pe" class3="py" class4="" periodicity1="1" k1="7.9496" phase1="0.0"/>
+    <Proper class1="" class2="pf" class3="py" class4="" periodicity1="1" k1="7.9496" phase1="0.0"/>
+    <Proper class1="" class2="p2" class3="sh" class4="" periodicity1="2" k1="5.8576" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pe" class3="sh" class4="" periodicity1="2" k1="5.8576" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pf" class3="sh" class4="" periodicity1="2" k1="5.8576" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p2" class3="ss" class4="" periodicity1="2" k1="5.8576" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pe" class3="ss" class4="" periodicity1="2" k1="5.8576" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pf" class3="ss" class4="" periodicity1="2" k1="5.8576" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p2" class3="s4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pe" class3="sx" class4="" periodicity1="2" k1="6.276" phase1="0.0"/>
+    <Proper class1="" class2="pf" class3="sx" class4="" periodicity1="2" k1="6.276" phase1="0.0"/>
+    <Proper class1="" class2="p2" class3="s6" class4="" periodicity1="2" k1="27.893333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pe" class3="sy" class4="" periodicity1="3" k1="1.6736000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="pf" class3="sy" class4="" periodicity1="3" k1="1.6736000000000002" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p3" class3="p3" class4="" periodicity1="3" k1="2.092" phase1="0.0"/>
+    <Proper class1="" class2="p3" class3="p4" class4="" periodicity1="1" k1="3.7656" phase1="0.0"/>
+    <Proper class1="" class2="p3" class3="px" class4="" periodicity1="1" k1="3.7656" phase1="0.0"/>
+    <Proper class1="" class2="p3" class3="p5" class4="" periodicity1="2" k1="7.6706666666666665" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p3" class3="py" class4="" periodicity1="2" k1="7.6706666666666665" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p3" class3="sh" class4="" periodicity1="2" k1="19.246399999999998" phase1="0.0"/>
+    <Proper class1="" class2="p3" class3="ss" class4="" periodicity1="3" k1="4.811599999999999" phase1="0.0"/>
+    <Proper class1="" class2="p3" class3="s4" class4="" periodicity1="2" k1="16.1084" phase1="0.0"/>
+    <Proper class1="" class2="p3" class3="sx" class4="" periodicity1="2" k1="16.1084" phase1="0.0"/>
+    <Proper class1="" class2="p3" class3="s6" class4="" periodicity1="3" k1="1.1157333333333335" phase1="0.0"/>
+    <Proper class1="" class2="p3" class3="sy" class4="" periodicity1="3" k1="1.1157333333333335" phase1="0.0"/>
+    <Proper class1="" class2="p4" class3="p4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="px" class3="px" class4="" periodicity1="2" k1="6.0668" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p4" class3="p5" class4="" periodicity1="2" k1="27.8236" phase1="3.141592653589793"/>
+    <Proper class1="" class2="px" class3="py" class4="" periodicity1="2" k1="1.3249333333333333" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p4" class3="s4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="px" class3="sx" class4="" periodicity1="1" k1="3.5564" phase1="0.0"/>
+    <Proper class1="" class2="p4" class3="s6" class4="" periodicity1="2" k1="27.8236" phase1="3.141592653589793"/>
+    <Proper class1="" class2="px" class3="sy" class4="" periodicity1="3" k1="0.4881333333333333" phase1="0.0"/>
+    <Proper class1="" class2="p4" class3="sh" class4="" periodicity1="1" k1="1.046" phase1="3.141592653589793"/>
+    <Proper class1="" class2="px" class3="sh" class4="" periodicity1="1" k1="1.046" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p4" class3="ss" class4="" periodicity1="2" k1="2.5104" phase1="3.141592653589793"/>
+    <Proper class1="" class2="px" class3="ss" class4="" periodicity1="2" k1="2.5104" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p5" class3="p5" class4="" periodicity1="2" k1="27.893333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="py" class3="py" class4="" periodicity1="2" k1="2.5104" phase1="0.0"/>
+    <Proper class1="" class2="p5" class3="sh" class4="" periodicity1="3" k1="1.2552" phase1="0.0"/>
+    <Proper class1="" class2="py" class3="sh" class4="" periodicity1="3" k1="1.2552" phase1="0.0"/>
+    <Proper class1="" class2="p5" class3="ss" class4="" periodicity1="2" k1="15.8992" phase1="3.141592653589793"/>
+    <Proper class1="" class2="py" class3="ss" class4="" periodicity1="2" k1="15.8992" phase1="3.141592653589793"/>
+    <Proper class1="" class2="p5" class3="s4" class4="" periodicity1="2" k1="27.893333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="py" class3="sx" class4="" periodicity1="3" k1="1.1157333333333335" phase1="0.0"/>
+    <Proper class1="" class2="p5" class3="s6" class4="" periodicity1="2" k1="27.893333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="py" class3="sy" class4="" periodicity1="3" k1="1.1622222222222223" phase1="0.0"/>
+    <Proper class1="" class2="sh" class3="sh" class4="" periodicity1="3" k1="23.4304" phase1="0.0"/>
+    <Proper class1="" class2="sh" class3="ss" class4="" periodicity1="3" k1="22.1752" phase1="0.0"/>
+    <Proper class1="" class2="sh" class3="s4" class4="" periodicity1="3" k1="2.9288" phase1="0.0"/>
+    <Proper class1="" class2="sh" class3="sx" class4="" periodicity1="3" k1="2.9288" phase1="0.0"/>
+    <Proper class1="" class2="sh" class3="s6" class4="" periodicity1="2" k1="19.525333333333332" phase1="3.141592653589793"/>
+    <Proper class1="" class2="sh" class3="sy" class4="" periodicity1="2" k1="19.525333333333332" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ss" class3="ss" class4="" periodicity1="3" k1="0.0" phase1="0.0"/>
+    <Proper class1="" class2="ss" class3="s4" class4="" periodicity1="3" k1="1.2552" phase1="0.0"/>
+    <Proper class1="" class2="ss" class3="sx" class4="" periodicity1="3" k1="1.2552" phase1="0.0"/>
+    <Proper class1="" class2="ss" class3="s6" class4="" periodicity1="2" k1="12.830933333333332" phase1="3.141592653589793"/>
+    <Proper class1="" class2="ss" class3="sy" class4="" periodicity1="2" k1="12.830933333333332" phase1="3.141592653589793"/>
+    <Proper class1="" class2="s4" class3="s4" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="sx" class3="sx" class4="" periodicity1="3" k1="2.615" phase1="0.0"/>
+    <Proper class1="" class2="s4" class3="s6" class4="" periodicity1="2" k1="27.893333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="sx" class3="sy" class4="" periodicity1="2" k1="18.130666666666666" phase1="3.141592653589793"/>
+    <Proper class1="" class2="s6" class3="s6" class4="" periodicity1="2" k1="27.893333333333334" phase1="3.141592653589793"/>
+    <Proper class1="" class2="sy" class3="sy" class4="" periodicity1="2" k1="0.6508444444444444" phase1="3.141592653589793"/>
+    <Proper class1="" class2="cf" class3="pe" class4="" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nd" class3="os" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nd" class3="ss" class4="" periodicity1="2" k1="20.0832" phase1="3.141592653589793"/>
+    <Proper class1="" class2="nf" class3="pe" class4="" periodicity1="2" k1="22.593600000000002" phase1="3.141592653589793"/>
+    <Proper class1="c3" class2="c" class3="sh" class4="hs" periodicity1="2" k1="9.414" phase1="3.141592653589793" periodicity2="1" k2="5.4392000000000005" phase2="3.141592653589793"/>
+    <Proper class1="c2" class2="c2" class3="ss" class4="c3" periodicity1="2" k1="4.6024" phase1="3.141592653589793" periodicity2="3" k2="2.9288" phase2="3.141592653589793"/>
+    <Proper class1="c2" class2="c2" class3="n" class4="c" periodicity1="2" k1="2.7196000000000002" phase1="3.141592653589793" periodicity2="1" k2="5.0208" phase2="3.141592653589793"/>
+    <Proper class1="c" class2="n" class3="p2" class4="c2" periodicity1="2" k1="4.184" phase1="3.141592653589793" periodicity2="1" k2="7.9496" phase2="3.141592653589793"/>
+    <Proper class1="n" class2="c3" class3="c" class4="n" periodicity1="1" k1="7.1128" phase1="3.141592653589793" periodicity2="2" k2="8.368" phase2="3.141592653589793"/>
+    <Proper class1="c" class2="n" class3="c3" class4="c" periodicity1="2" k1="3.5564" phase1="3.141592653589793" periodicity2="1" k2="3.3472000000000004" phase2="0.0"/>
+    <Proper class1="c3" class2="c3" class3="n" class4="c" periodicity1="4" k1="2.092" phase1="3.141592653589793" periodicity2="3" k2="0.6276" phase2="3.141592653589793" periodicity3="2" k3="0.0" phase3="0.0" periodicity4="1" k4="2.2175200000000004" phase4="0.0"/>
+    <Proper class1="c3" class2="c3" class3="c" class4="n" periodicity1="4" k1="0.41840000000000005" phase1="0.0" periodicity2="2" k2="0.29288000000000003" phase2="0.0"/>
+    <Proper class1="c2" class2="ne" class3="p5" class4="o" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="9.623199999999999" phase2="0.0"/>
+    <Proper class1="c2" class2="nf" class3="p5" class4="o" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="9.623199999999999" phase2="0.0"/>
+    <Proper class1="ce" class2="ne" class3="p5" class4="o" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="9.623199999999999" phase2="0.0"/>
+    <Proper class1="ce" class2="nf" class3="p5" class4="o" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="9.623199999999999" phase2="0.0"/>
+    <Proper class1="cf" class2="ne" class3="p5" class4="o" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="9.623199999999999" phase2="0.0"/>
+    <Proper class1="cf" class2="nf" class3="p5" class4="o" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="9.623199999999999" phase2="0.0"/>
+    <Proper class1="hn" class2="n" class3="c" class4="o" periodicity1="2" k1="10.46" phase1="3.141592653589793" periodicity2="1" k2="8.368" phase2="0.0"/>
+    <Proper class1="c3" class2="ss" class3="ss" class4="c3" periodicity1="2" k1="14.644" phase1="0.0" periodicity2="3" k2="2.5104" phase2="0.0"/>
+    <Proper class1="c3" class2="n3" class3="nh" class4="ca" periodicity1="2" k1="7.9496" phase1="0.0" periodicity2="3" k2="7.9496" phase2="0.0"/>
+    <Proper class1="c3" class2="n3" class3="p5" class4="o" periodicity1="2" k1="12.552" phase1="3.141592653589793" periodicity2="3" k2="9.623199999999999" phase2="0.0"/>
+    <Proper class1="ca" class2="nh" class3="oh" class4="ho" periodicity1="1" k1="5.0208" phase1="0.0" periodicity2="2" k2="6.276" phase2="0.0"/>
+    <Proper class1="oh" class2="p5" class3="os" class4="c3" periodicity1="3" k1="1.046" phase1="0.0" periodicity2="2" k2="5.0208" phase2="0.0"/>
+    <Proper class1="os" class2="p5" class3="os" class4="c3" periodicity1="3" k1="1.046" phase1="0.0" periodicity2="2" k2="5.0208" phase2="0.0"/>
+    <Proper class1="h1" class2="c3" class3="c" class4="o" periodicity1="1" k1="3.3472000000000004" phase1="0.0" periodicity2="2" k2="0.0" phase2="0.0" periodicity3="3" k3="0.33472" phase3="3.141592653589793"/>
+    <Proper class1="hc" class2="c3" class3="c" class4="o" periodicity1="1" k1="3.3472000000000004" phase1="0.0" periodicity2="2" k2="0.0" phase2="0.0" periodicity3="3" k3="0.33472" phase3="3.141592653589793"/>
+    <Proper class1="hc" class2="c3" class3="c3" class4="hc" periodicity1="3" k1="0.6276" phase1="0.0"/>
+    <Proper class1="hc" class2="c3" class3="c3" class4="c3" periodicity1="3" k1="0.66944" phase1="0.0"/>
+    <Proper class1="hc" class2="c3" class3="c2" class4="c2" periodicity1="3" k1="1.58992" phase1="3.141592653589793" periodicity2="2" k2="0.0" phase2="0.0" periodicity3="1" k3="4.811599999999999" phase3="0.0"/>
+    <Proper class1="ho" class2="oh" class3="c3" class4="c3" periodicity1="3" k1="0.66944" phase1="0.0" periodicity2="1" k2="1.046" phase2="0.0"/>
+    <Proper class1="ho" class2="oh" class3="c" class4="o" periodicity1="2" k1="9.623199999999999" phase1="3.141592653589793" periodicity2="1" k2="7.9496" phase2="0.0"/>
+    <Proper class1="c2" class2="c2" class3="c" class4="o" periodicity1="2" k1="9.1002" phase1="3.141592653589793" periodicity2="3" k2="1.2552" phase2="0.0"/>
+    <Proper class1="c3" class2="c2" class3="c2" class4="c3" periodicity1="2" k1="27.823600000000003" phase1="3.141592653589793" periodicity2="1" k2="7.9496" phase2="3.141592653589793"/>
+    <Proper class1="c3" class2="c3" class3="c3" class4="c3" periodicity1="3" k1="0.75312" phase1="0.0" periodicity2="2" k2="1.046" phase2="3.141592653589793" periodicity3="1" k3="0.8368000000000001" phase3="3.141592653589793"/>
+    <Proper class1="c3" class2="c3" class3="n3" class4="c3" periodicity1="3" k1="1.2552" phase1="0.0" periodicity2="2" k2="2.00832" phase2="3.141592653589793"/>
+    <Proper class1="c3" class2="c3" class3="os" class4="c3" periodicity1="3" k1="1.6024720000000001" phase1="0.0" periodicity2="2" k2="0.41840000000000005" phase2="3.141592653589793"/>
+    <Proper class1="c3" class2="c3" class3="os" class4="c" periodicity1="3" k1="1.6024720000000001" phase1="0.0" periodicity2="1" k2="3.3472000000000004" phase2="3.141592653589793"/>
+    <Proper class1="c3" class2="os" class3="c3" class4="os" periodicity1="3" k1="0.41840000000000005" phase1="0.0" periodicity2="2" k2="3.5564" phase2="3.141592653589793" periodicity3="1" k3="5.6484000000000005" phase3="3.141592653589793"/>
+    <Proper class1="c3" class2="os" class3="c3" class4="na" periodicity1="3" k1="1.6024720000000001" phase1="0.0" periodicity2="2" k2="2.7196000000000002" phase2="0.0"/>
+    <Proper class1="o" class2="c" class3="os" class4="c3" periodicity1="2" k1="11.296800000000001" phase1="3.141592653589793" periodicity2="1" k2="5.8576" phase2="3.141592653589793"/>
+    <Proper class1="os" class2="c3" class3="na" class4="c2" periodicity1="2" k1="0.0" phase1="0.0" periodicity2="1" k2="10.46" phase2="0.0"/>
+    <Proper class1="os" class2="c3" class3="c3" class4="os" periodicity1="3" k1="0.602496" phase1="0.0" periodicity2="2" k2="4.916200000000001" phase2="0.0"/>
+    <Proper class1="os" class2="c3" class3="c3" class4="oh" periodicity1="3" k1="0.602496" phase1="0.0" periodicity2="2" k2="4.916200000000001" phase2="0.0"/>
+    <Proper class1="oh" class2="c3" class3="c3" class4="oh" periodicity1="3" k1="0.602496" phase1="0.0" periodicity2="2" k2="4.916200000000001" phase2="0.0"/>
+    <Proper class1="f" class2="c3" class3="c3" class4="f" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="5.0208" phase2="3.141592653589793"/>
+    <Proper class1="cl" class2="c3" class3="c3" class4="cl" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="1.8828" phase2="3.141592653589793"/>
+    <Proper class1="br" class2="c3" class3="c3" class4="br" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="0.0" phase2="3.141592653589793"/>
+    <Proper class1="h1" class2="c3" class3="c3" class4="os" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="1.046" phase2="0.0"/>
+    <Proper class1="h1" class2="c3" class3="c3" class4="oh" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="1.046" phase2="0.0"/>
+    <Proper class1="h1" class2="c3" class3="c3" class4="f" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="0.79496" phase2="0.0"/>
+    <Proper class1="h1" class2="c3" class3="c3" class4="cl" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="1.046" phase2="0.0"/>
+    <Proper class1="h1" class2="c3" class3="c3" class4="br" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="2.3012" phase2="0.0"/>
+    <Proper class1="hc" class2="c3" class3="c3" class4="os" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="1.046" phase2="0.0"/>
+    <Proper class1="hc" class2="c3" class3="c3" class4="oh" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="1.046" phase2="0.0"/>
+    <Proper class1="hc" class2="c3" class3="c3" class4="f" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="0.79496" phase2="0.0"/>
+    <Proper class1="hc" class2="c3" class3="c3" class4="cl" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="1.046" phase2="0.0"/>
+    <Proper class1="hc" class2="c3" class3="c3" class4="br" periodicity1="3" k1="0.0" phase1="0.0" periodicity2="1" k2="2.3012" phase2="0.0"/>
+    <Proper class1="c3" class2="c" class3="n" class4="c3" periodicity1="2" k1="0.0" phase1="0.0" periodicity2="1" k2="6.276" phase2="3.141592653589793"/>
+    <Proper class1="c3" class2="ss" class3="sh" class4="hs" periodicity1="3" k1="7.391733333333334" phase1="0.0" periodicity2="2" k2="11.296800000000001" phase2="0.0"/>
+    <Proper class1="c3" class2="n4" class3="c3" class4="ca" periodicity1="3" k1="0.6508444444444444" phase1="0.0" periodicity2="2" k2="2.9288" phase2="0.0"/>
+    <Proper class1="oh" class2="c3" class3="c3" class4="n4" periodicity1="3" k1="0.602496" phase1="0.0" periodicity2="2" k2="5.4392000000000005" phase2="0.0"/>
+    <Proper class1="c3" class2="c3" class3="n4" class4="c3" periodicity1="3" k1="0.6508444444444444" phase1="0.0"/>
+    <Proper class1="c3" class2="c" class3="os" class4="c3" periodicity1="2" k1="11.296800000000001" phase1="3.141592653589793" periodicity2="1" k2="0.0" phase2="0.0" periodicity3="3" k3="4.811599999999999" phase3="0.0"/>
+    <Proper class1="c3" class2="c" class3="os" class4="p5" periodicity1="2" k1="11.296800000000001" phase1="3.141592653589793" periodicity2="1" k2="8.368" phase2="3.141592653589793"/>
+    <Proper class1="c" class2="os" class3="p5" class4="o" periodicity1="2" k1="3.3472000000000004" phase1="0.0" periodicity2="1" k2="4.6024" phase2="0.0" periodicity3="3" k3="2.092" phase3="3.141592653589793"/>
+    <Proper class1="c3" class2="c3" class3="os" class4="p5" periodicity1="3" k1="1.6038666666666666" phase1="0.0" periodicity2="1" k2="16.5268" phase2="3.141592653589793"/>
+    <Proper class1="c3" class2="os" class3="p5" class4="o" periodicity1="2" k1="3.3472000000000004" phase1="0.0" periodicity2="3" k2="2.3012" phase2="0.0"/>
+    <Proper class1="ca" class2="ca" class3="os" class4="p5" periodicity1="2" k1="7.322" phase1="3.141592653589793"/>
+    <Proper class1="ca" class2="os" class3="p5" class4="o" periodicity1="2" k1="3.3472000000000004" phase1="3.141592653589793" periodicity2="3" k2="0.41840000000000005" phase2="0.0"/>
+    <Improper class1="c" class2="" class3="o" class4="o" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c" class2="" class3="" class4="o" periodicity1="2" k1="43.932" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="" class3="" class4="ha" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="n" class2="" class3="" class4="hn" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="n2" class2="" class3="" class4="hn" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="na" class2="" class3="" class4="hn" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="n" class2="" class3="c3" class4="c3" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="" class3="n2" class4="n2" periodicity1="2" k1="43.932" phase1="3.141592653589793"/>
+    <Improper class1="c2" class2="c" class3="c2" class4="c3" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="c" class3="ca" class4="c3" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="n" class2="c" class3="c3" class4="hn" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="n" class2="c" class3="c3" class4="o" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="na" class2="c2" class3="c2" class4="c3" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c2" class2="c2" class3="c" class4="c3" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c2" class2="c2" class3="c3" class4="hc" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="c2" class3="c3" class4="hc" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c" class2="c2" class3="hc" class4="o" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c" class2="c3" class3="o" class4="oh" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c2" class2="c3" class3="c2" class4="n2" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c2" class2="c3" class3="c2" class4="na" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="c3" class3="ca" class4="n2" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="c3" class3="ca" class4="na" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="ca" class3="ca" class4="c2" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="ca" class3="ca" class4="c3" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="ca" class3="ca" class4="f" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="ca" class3="ca" class4="cl" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="ca" class3="ca" class4="br" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="ca" class3="ca" class4="i" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c" class2="ca" class3="ca" class4="oh" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="na" class2="ca" class3="ca" class4="c3" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="ca" class3="c" class4="c3" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c" class2="ca" class3="hc" class4="o" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="ca" class3="n2" class4="n2" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c" class2="hc" class3="o" class4="oh" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="c" class2="hc" class3="o" class4="os" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="n2" class3="c2" class4="n2" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="n2" class3="ca" class4="n2" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+    <Improper class1="ca" class2="na" class3="n2" class4="n2" periodicity1="2" k1="4.6024" phase1="3.141592653589793"/>
+  </PeriodicTorsionForce>
+</ForceField>

--- a/src/library/forcefields/pps_opls.xml
+++ b/src/library/forcefields/pps_opls.xml
@@ -1,0 +1,48 @@
+<ForceField name="OPLS-AA" version="0.0.3" combining_rule="geometric">
+	<AtomTypes>
+		<Type name="hs" class="HS" element="H" mass="1.008" def="[H;X1]([S;%sh])" desc="H in any Thiol (opls_204)" overrides=""/>
+		<Type name="ca" class="CA" element="C" mass="12.011" def="[C;X3;r6]1[C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6]1" desc="Aromatic C (opls_145)" overrides=""/>
+		<Type name="s" class="S" element="S" mass="32.06" def="[S;X2]" desc="S in any sulfide (opls_202)" overrides=""/>
+		<Type name="ha" class="HA" element="H" mass="1.008" def="[H][C;%ca]" desc="benzene H (opls_146)" overrides=""/>
+		<Type name="sh" class="SH" element="S" mass="32.06" def="[S;X2]H" desc="S in any Thiol (opls_200)" overrides="s"/>
+	</AtomTypes>
+	<HarmonicBondForce>
+		<Bond class1="S" class2="CA" length="0.176" k="209200.0"/>
+		<Bond class1="HS" class2="SH" length="0.1336" k="229283.2"/>
+		<Bond class1="CA" class2="S" length="0.176" k="209200.0"/>
+		<Bond class1="CA" class2="CA" length="0.14" k="392459.2"/>
+		<Bond class1="HA" class2="CA" length="0.108" k="307105.6"/>
+		<Bond class1="SH" class2="CA" length="0.174" k="209200.0"/>
+	</HarmonicBondForce>
+	<HarmonicAngleForce>
+		<Angle class1="CA" class2="S" class3="CA" angle="1.805" k="627.6"/>
+		<Angle class1="CA" class2="SH" class3="HS" angle="1.67551608191" k="418.4"/>
+		<Angle class1="CA" class2="CA" class3="S" angle="2.08392312688" k="711.28"/>
+		<Angle class1="CA" class2="CA" class3="CA" angle="2.09439510239" k="527.184"/>
+		<Angle class1="CA" class2="CA" class3="SH" angle="2.09439510239" k="585.76"/>
+		<Angle class1="SH" class2="CA" class3="CA" angle="2.09439510239" k="585.76"/>
+		<Angle class1="CA" class2="CA" class3="HA" angle="2.09439510239" k="292.88"/>
+		<Angle class1="S" class2="CA" class3="CA" angle="2.08392312688" k="711.28"/>
+	</HarmonicAngleForce>
+	<RBTorsionForce>
+		<Proper class1="CA" class2="CA" class3="S" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="S" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="S" class2="CA" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="S" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="SH" class2="CA" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="HA" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="SH" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="SH" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="S" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="SH" class4="HS" c0="4.6024" c1="0.0" c2="-4.6024" c3="0.0" c4="0.0" c5="0.0"/>
+	</RBTorsionForce>
+	<NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+		<Atom type="hs" charge="0.1" sigma="0.0" epsilon="0.0"/>
+		<Atom type="ca" charge="-0.1" sigma="0.355" epsilon="0.29288"/>
+		<Atom type="s" charge="0.0" sigma="0.36" epsilon="1.48532"/>
+		<Atom type="ha" charge="0.0" sigma="0.242" epsilon="0.12552"/>
+		<Atom type="sh" charge="0.0" sigma="0.36" epsilon="1.7782"/>
+	</NonbondedForce>
+</ForceField>


### PR DESCRIPTION
This PR achieves 2 things:

1. Makes it a little easier to use difference force fields with the addition of `forcefield.py`.  This essentially creates classes of different force fields that can be imported and passed into `System.apply_forcefield` rather than using foyer directly.  The primary motivation for this was to add the opls force field that is slightly modified to work for PPS. I also included GAFF.

2. I added a `united_atom` parameter that can be `True` or `False` when initializing the `System` class.  If `True`, the hydrogen atoms will be removed, and the mass and charges of the heavy atoms they were bonded to will be be adjust to account for the lost hydrogens.  This is all done in the `apply_forcefield` method.  I think most of our simulations for this project can be UA, which will bump up our TPS performance. 


To do:
Importing from the forcefield library in `project.py` doesn't seem to be working yet. 
